### PR TITLE
Trend indicator icons, tooltips, and staleness logic

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -531,11 +531,18 @@ i.dz-fa-trend {
         color: var(--dz-danger);
     }
 
-    i.dz-fa-trend.fa-minus {
+    i.dz-fa-trend.fa-right-long {
         color: var(--dz-text-muted);
+        opacity: 0.5;
     }
 
-    i.dz-fa-trend.fa-question {
+    /* Unknown trend — no useful info, hide completely */
+    i.dz-fa-trend.dz-trend-unk {
+        display: none;
+    }
+
+    /* Report trend equal icons (equal.png / gequal.png) still use fa-minus */
+    i.dz-fa-trend.fa-minus {
         color: var(--dz-text-muted);
     }
 

--- a/custom.js
+++ b/custom.js
@@ -1555,7 +1555,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     /* ── Staleness Indicator (Feature 9) ─────────────────────────── */
-    var STALE_MS = 60 * 60 * 1000; // 1 hour
+    var STALE_MS = 24 * 60 * 60 * 1000; // 1 day
 
     function parseFooterDate(text) {
         var now = new Date();

--- a/custom.js
+++ b/custom.js
@@ -329,8 +329,8 @@ if (document.readyState === 'loading') {
         /* Trend arrows (inline in bigtext / status) */
         'images/arrow_up.png':     'fa-solid fa-arrow-trend-up',
         'images/arrow_down.png':   'fa-solid fa-arrow-trend-down',
-        'images/arrow_stable.png': 'fa-solid fa-minus',
-        'images/arrow_unk.png':    'fa-solid fa-question',
+        'images/arrow_stable.png': 'fa-solid fa-right-long',
+        'images/arrow_unk.png':    'fa-solid fa-question dz-trend-unk',
 
         /* Blinds stop (no 48 in filename) */
         'images/blindsstop.png':   'fa-solid fa-stop',
@@ -774,6 +774,14 @@ if (document.readyState === 'loading') {
         }
 
         copyAttrs(img, icon);
+
+        /* Trend indicator tooltips — explain the arrow meaning on hover */
+        if (icon.classList.contains('dz-fa-trend') && !icon.getAttribute('title')) {
+            if (icon.classList.contains('fa-arrow-trend-up'))   icon.title = 'Rising';
+            else if (icon.classList.contains('fa-arrow-trend-down')) icon.title = 'Falling';
+            else if (icon.classList.contains('fa-right-long'))  icon.title = 'Stable';
+        }
+
         img.setAttribute('data-dz-src', src);
         img.classList.add('dz-icon-replaced');
         iconMap.set(img, icon);

--- a/demo/temperature.html
+++ b/demo/temperature.html
@@ -59,7 +59,7 @@
                                 <table id="itemtable" border="0" cellpadding="0" cellspacing="0">
                                     <tr>
                                         <td id="name">Living Room</td>
-                                        <td id="bigtext">21.4 °C <i class="dz-fa-trend fa-solid fa-arrow-trend-up"></i></td>
+                                        <td id="bigtext">21.4 °C <i class="dz-fa-trend fa-solid fa-arrow-trend-up" title="Rising"></i></td>
                                         <td id="img">
                                             <i class="dz-fa-device fa-solid fa-temperature-half" style="color:#e05555;"></i>
                                         </td>
@@ -82,7 +82,7 @@
                                 <table id="itemtable" border="0" cellpadding="0" cellspacing="0">
                                     <tr>
                                         <td id="name">Kitchen</td>
-                                        <td id="bigtext">22.1 °C <i class="dz-fa-trend fa-solid fa-arrow-trend-up"></i></td>
+                                        <td id="bigtext">22.1 °C <i class="dz-fa-trend fa-solid fa-arrow-trend-up" title="Rising"></i></td>
                                         <td id="img">
                                             <i class="dz-fa-device fa-solid fa-temperature-half" style="color:#e05555;"></i>
                                         </td>
@@ -105,7 +105,7 @@
                                 <table id="itemtable" border="0" cellpadding="0" cellspacing="0">
                                     <tr>
                                         <td id="name">Bedroom</td>
-                                        <td id="bigtext">19.8 °C <i class="dz-fa-trend fa-solid fa-minus"></i></td>
+                                        <td id="bigtext">19.8 °C <i class="dz-fa-trend fa-solid fa-right-long" title="Stable"></i></td>
                                         <td id="img">
                                             <i class="dz-fa-device fa-solid fa-temperature-half" style="color:#4e9af1;"></i>
                                         </td>
@@ -128,7 +128,7 @@
                                 <table id="itemtable" border="0" cellpadding="0" cellspacing="0">
                                     <tr>
                                         <td id="name">Outdoor</td>
-                                        <td id="bigtext">8.2 °C <i class="dz-fa-trend fa-solid fa-minus"></i></td>
+                                        <td id="bigtext">8.2 °C <i class="dz-fa-trend fa-solid fa-right-long" title="Stable"></i></td>
                                         <td id="img">
                                             <i class="dz-fa-device fa-solid fa-temperature-half" style="color:#29b6f6;"></i>
                                         </td>
@@ -151,7 +151,7 @@
                                 <table id="itemtable" border="0" cellpadding="0" cellspacing="0">
                                     <tr>
                                         <td id="name">Attic</td>
-                                        <td id="bigtext">14.5 °C <i class="dz-fa-trend fa-solid fa-arrow-trend-down"></i></td>
+                                        <td id="bigtext">14.5 °C <i class="dz-fa-trend fa-solid fa-arrow-trend-down" title="Falling"></i></td>
                                         <td id="img">
                                             <i class="dz-fa-device fa-solid fa-temperature-half" style="color:#29b6f6;"></i>
                                         </td>
@@ -174,7 +174,7 @@
                                 <table id="itemtable" border="0" cellpadding="0" cellspacing="0">
                                     <tr>
                                         <td id="name">Garage</td>
-                                        <td id="bigtext">11.0 °C <i class="dz-fa-trend fa-solid fa-arrow-trend-down"></i></td>
+                                        <td id="bigtext">11.0 °C <i class="dz-fa-trend fa-solid fa-arrow-trend-down" title="Falling"></i></td>
                                         <td id="img">
                                             <i class="dz-fa-device fa-solid fa-temperature-half" style="color:#29b6f6;"></i>
                                         </td>
@@ -244,7 +244,7 @@
                                 <table id="itemtable" border="0" cellpadding="0" cellspacing="0">
                                     <tr>
                                         <td id="name">Garden Sensor</td>
-                                        <td id="bigtext">7.8 °C <i class="dz-fa-trend fa-solid fa-arrow-trend-down"></i></td>
+                                        <td id="bigtext">7.8 °C <i class="dz-fa-trend fa-solid fa-arrow-trend-down" title="Falling"></i></td>
                                         <td id="img">
                                             <i class="dz-fa-device fa-solid fa-temperature-half" style="color:#29b6f6;"></i>
                                         </td>


### PR DESCRIPTION
This pull request updates the trend indicator icons, tooltips, and staleness logic to improve clarity and accessibility in the temperature dashboard. The most important changes are:

**Trend Indicator Icon and Tooltip Improvements:**

* The "stable" trend icon is now represented by `fa-right-long` instead of `fa-minus`, and the "unknown" trend icon is hidden completely using the new `dz-trend-unk` class. [[1]](diffhunk://#diff-3d5c50bd13c7954f907b7a887b7f3b9ea15f9239850fad87a599855a2a50f6e2L534-R545) [[2]](diffhunk://#diff-ad14b11d3e2b19151c144abb4e072c7f2a8fa1864c01e7f0ca77763d64eef952L332-R333)
* Tooltips are added to trend icons, displaying "Rising", "Falling", or "Stable" on hover for better accessibility and user understanding. [[1]](diffhunk://#diff-955751662715bb9644dedc9531f23924d41e291bfcba88a4b96f3d16413b4573L62-R62) [[2]](diffhunk://#diff-955751662715bb9644dedc9531f23924d41e291bfcba88a4b96f3d16413b4573L85-R85) [[3]](diffhunk://#diff-955751662715bb9644dedc9531f23924d41e291bfcba88a4b96f3d16413b4573L108-R108) [[4]](diffhunk://#diff-955751662715bb9644dedc9531f23924d41e291bfcba88a4b96f3d16413b4573L131-R131) [[5]](diffhunk://#diff-955751662715bb9644dedc9531f23924d41e291bfcba88a4b96f3d16413b4573L154-R154) [[6]](diffhunk://#diff-955751662715bb9644dedc9531f23924d41e291bfcba88a4b96f3d16413b4573L177-R177) [[7]](diffhunk://#diff-955751662715bb9644dedc9531f23924d41e291bfcba88a4b96f3d16413b4573L247-R247) [[8]](diffhunk://#diff-ad14b11d3e2b19151c144abb4e072c7f2a8fa1864c01e7f0ca77763d64eef952R777-R784)

**Logic and Behavior Updates:**

* The staleness threshold for data is increased from 1 hour to 24 hours, making the staleness indicator less sensitive to short outages.

## Summary by Sourcery

Update temperature dashboard trend indicators and staleness behaviour for clearer, more informative status display.

New Features:
- Add hover tooltips to trend icons indicating Rising, Falling, or Stable states.

Bug Fixes:
- Relax the data staleness threshold from 1 hour to 24 hours to reduce false-positive stale warnings.

Enhancements:
- Change the stable trend icon to a right-pointing arrow and adjust its styling for better visual clarity.
- Hide unknown trend icons entirely via a dedicated CSS class to avoid displaying non-informative indicators.
- Demonstrate explicit trend tooltips in the temperature demo markup for sample locations.