### PR TITLE
Remove padding from copyright footer in custom.css

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -4980,7 +4980,6 @@ div.item.itemBlock:hover .dz-sparkline-wrap,
 /* Copyright footer (on the update page) */
 #copyright {
     text-align: center;
-    padding: 20px 0 16px;
     color: var(--dz-text-faint);
     font-size: 0.78rem;
 }


### PR DESCRIPTION
The padding property was removed from the #copyright CSS rule, eliminating the extra space above and below the copyright footer.

## Summary by Sourcery

Enhancements:
- Simplify the copyright footer styling to rely on default spacing instead of custom padding.