### PR TITLE
Reworked the style of TXT devices

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -1971,6 +1971,68 @@ body table[id^="itemtable"] tr td.options {
     }
 
 
+/* ── 6m. Text device cards (.dz-text-device) ──────────────────── */
+/*    "General, Text" devices contain long messages that don't fit   */
+/*    the hero-value style. The JS moves the full text into #status  */
+/*    as a .dz-text-msg div. The bigtext shows a short preview.     */
+
+.dz-text-device table[id^="itemtable"] tr td#bigtext {
+    font-size: 0.85rem !important;
+    font-weight: 600 !important;
+    color: var(--dz-text-soft) !important;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-height: 0 !important;
+    line-height: 1.3;
+    display: none !important;
+}
+
+.dz-text-device table[id^="itemtable"] tr td#status {
+    padding-left: 0 !important;
+    margin-top: 4px !important;
+}
+
+.dz-text-msg {
+    font-family: 'Courier New', 'Consolas', ui-monospace, monospace;
+    font-size: 0.75rem;
+    line-height: 1.55;
+    color: var(--dz-text-soft);
+    background: var(--dz-bg-alt);
+    border: 1px solid rgba(var(--dz-overlay-rgb), 0.04);
+    border-radius: 8px;
+    padding: 8px 10px;
+    max-height: 80px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    white-space: pre-wrap;
+    word-break: break-word;
+    -webkit-user-select: text;
+    user-select: text;
+    scrollbar-width: thin;
+    scrollbar-color: var(--dz-border) transparent;
+}
+
+    .dz-text-msg::-webkit-scrollbar {
+        width: 4px;
+    }
+
+    .dz-text-msg::-webkit-scrollbar-track {
+        background: transparent;
+    }
+
+    .dz-text-msg::-webkit-scrollbar-thumb {
+        background: var(--dz-border);
+        border-radius: 2px;
+    }
+
+/* Hover: expand slightly + accent border */
+.dz-text-device:hover .dz-text-msg {
+    border-color: rgba(var(--dz-accent-rgb), 0.15);
+    max-height: 120px;
+}
+
+
 /* ══════════════════════════════════════════════════════════════════
    7.  BUTTONS  (flat dark style)
    ══════════════════════════════════════════════════════════════════ */

--- a/custom.css
+++ b/custom.css
@@ -1989,7 +1989,6 @@ body table[id^="itemtable"] tr td.options {
 }
 
 .dz-text-device table[id^="itemtable"] tr td#status {
-    padding-left: 0 !important;
     margin-top: 4px !important;
 }
 

--- a/custom.js
+++ b/custom.js
@@ -1197,6 +1197,86 @@ if (document.readyState === 'loading') {
 })();
 
 
+/* -- Text device card enhancement --------------------------------- */
+/*    For "General, Text" devices the bigtext contains long messages  */
+/*    that don't fit the hero-value style. Move the full text into    */
+/*    the status area as a scrollable message block and show a        */
+/*    truncated preview in bigtext.                                   */
+
+(function () {
+    'use strict';
+
+    var maxPreviewLen = 60;
+
+    function processTextDevices() {
+        var cards = document.querySelectorAll(
+            'table[id^="itemtable"] tbody tr'
+        );
+        for (var i = 0; i < cards.length; i++) {
+            var tr = cards[i];
+            if (tr.getAttribute('data-dz-text-done')) continue;
+
+            var typeTd  = tr.querySelector('td#type');
+            if (!typeTd) continue;
+            var typeText = (typeTd.textContent || '').trim();
+            if (!/\bText\b/i.test(typeText)) continue;
+
+            var bigtext = tr.querySelector('td#bigtext');
+            var status  = tr.querySelector('td#status');
+            if (!bigtext || !status) continue;
+
+            var fullText = (bigtext.textContent || '').trim();
+            if (!fullText) continue;
+
+            tr.setAttribute('data-dz-text-done', '1');
+
+            var itemBlock = tr.closest('.itemBlock');
+            if (itemBlock) itemBlock.classList.add('dz-text-device');
+
+            status.textContent = '';
+            var msgDiv = document.createElement('div');
+            msgDiv.className = 'dz-text-msg';
+            msgDiv.textContent = fullText;
+            status.appendChild(msgDiv);
+
+            if (fullText.length > maxPreviewLen) {
+                bigtext.textContent = fullText.substring(0, maxPreviewLen) + '…';
+            }
+        }
+    }
+
+    window._dzExtraProcessors = window._dzExtraProcessors || [];
+    window._dzExtraProcessors.push(processTextDevices);
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', processTextDevices);
+    } else {
+        processTextDevices();
+    }
+
+    var _timer = null;
+    var observer = new MutationObserver(function () {
+        clearTimeout(_timer);
+        _timer = setTimeout(processTextDevices, 250);
+    });
+
+    function startObserver() {
+        var target = document.getElementById('dashcontent') ||
+                     document.getElementById('main-content') ||
+                     document.body;
+        if (target) {
+            observer.observe(target, { childList: true, subtree: true });
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', startObserver);
+    } else {
+        startObserver();
+    }
+})();
+
+
 /* -- Format last-update timestamps + strip "Type:" prefix --------- */
 /*    Runs after Angular renders each digest cycle.                   */
 

--- a/demo/utility.html
+++ b/demo/utility.html
@@ -224,8 +224,50 @@
             </tr></table></section>
           </div>
 
-        </div><!-- /.row -->
-      </div><!-- /.devicesList -->
+                  <!-- 10. Text Device (short) -->
+                  <div class="item span4 itemBlock statusNormal dz-text-device" id="d10">
+                    <section><table id="itemtable" border="0" cellpadding="0" cellspacing="0"><tr>
+                      <td id="name">Door Status</td>
+                      <td id="bigtext" style="display:none!important;"></td>
+                      <td id="img">
+                        <i class="dz-fa-device fa-solid fa-font" style="color:#b0b3c6;"></i>
+                      </td>
+                      <td id="status"><div class="dz-text-msg">Front door closed</div></td>
+                      <td id="lastupdate"><span style="font-style:italic">Last Seen</span>: Today 10:22:01</td>
+                      <td id="type">General, Text</td>
+                      <td class="options">
+                        <span><i class="fa-regular fa-star dz-fa-fav dz-fav-off lcursor"></i></span>
+                        <a class="btnsmall" href="#">Log</a>
+                        <a class="btnsmall" href="#">Edit</a>
+                      </td>
+                    </tr></table></section>
+                  <div class="dz-card-footer"><span class="dz-time">today 10:22 am</span></div></div>
+
+                  <!-- 11. Text Device (long) -->
+                  <div class="item span4 itemBlock statusNormal dz-text-device" id="d11">
+                    <section><table id="itemtable" border="0" cellpadding="0" cellspacing="0"><tr>
+                      <td id="name">MeshCore - Mesh Inbox</td>
+                      <td id="bigtext" style="display:none!important;"></td>
+                      <td id="img">
+                        <i class="dz-fa-device fa-solid fa-font" style="color:#b0b3c6;"></i>
+                      </td>
+                      <td id="status"><div class="dz-text-msg">[#mc-radar|pd1sco] Test @[PA3SSB] :)
+        [#mc-radar|pd2xyz] Network check — all nodes responding OK
+        [#mc-radar|pe4abc] Sensor batch upload: temp=22.3°C, hum=61%, pres=1013hPa
+        [#mc-radar|pa0def] Firmware v2.4.1 deployed to 12 nodes — no errors
+        [#mc-radar|pd1sco] Mesh latency report: avg 42ms, max 180ms, 0 drops</div></td>
+                      <td id="lastupdate"><span style="font-style:italic">Last Seen</span>: Today 10:19:58</td>
+                      <td id="type">General, Text</td>
+                      <td class="options">
+                        <span><i class="fa-regular fa-star dz-fa-fav dz-fav-off lcursor"></i></span>
+                        <a class="btnsmall" href="#">Log</a>
+                        <a class="btnsmall" href="#">Edit</a>
+                      </td>
+                    </tr></table></section>
+                  <div class="dz-card-footer"><span class="dz-time">today 10:19 am</span></div></div>
+
+                </div><!-- /.row -->
+              </div><!-- /.devicesList -->
 
       <div class="page-bottom"></div>
 


### PR DESCRIPTION
## Summary by Sourcery

Improve the dashboard presentation of "General, Text" devices by moving long messages into a styled, scrollable status block and updating the demo to showcase the new layout.

New Features:
- Automatically transform "General, Text" device cards so long messages are rendered as scrollable content in the status area with a truncated preview.
- Add dedicated styling for text-device message blocks to improve readability and interaction, including hover expansion.
- Extend the utility demo page with short and long text device examples using the new message block layout.