### PR TITLE
Feature: Rework on icons and a way to override icons per device

### DIFF
--- a/demo/settings.html
+++ b/demo/settings.html
@@ -34,8 +34,8 @@
           <li id="demo-tab-location"><a href="javascript:void(0)">Location</a></li>
         </ul>
 
-        <!-- Demo system settings (placeholder content shown by default) -->
-        <div id="demo-settings-system" class="demo-settings-pane" style="padding: 24px 0;">
+        <!-- Demo system settings (shown when System tab is active) -->
+        <div id="demo-settings-system" class="demo-settings-pane" style="padding: 24px 0; display:none;">
           <table style="width:100%; border-collapse:separate; border-spacing:0 8px;">
             <tr>
               <td style="width:220px; padding:8px 12px; color:var(--dz-text-soft); font-size:0.88rem; font-weight:500;">Language</td>
@@ -85,11 +85,112 @@
 
       </div><!-- /settingscontent -->
 
+      <!-- ═══ Icon Override Feature Demo ═══ -->
+      <div style="margin-top: 40px;">
+        <div class="page-header" style="margin-bottom: 20px;">
+          <i class="fa-solid fa-icons"></i>
+          Device Icon Override — Feature Demo
+        </div>
+        <p style="color:var(--dz-text-soft); font-size:0.9rem; margin-bottom: 20px; max-width:700px;">
+          The <strong>Device Icon Overrides</strong> feature (in the Nightglass settings tab above) lets you assign
+          any Font Awesome icon — with custom on/off colors — to individual devices by their IDX.
+          Below are example device cards showing the effect of various overrides.
+        </p>
+        <div style="display:flex; flex-wrap:wrap; gap:16px; margin-bottom: 32px;">
+
+          <!-- Demo card: WiFi Router (override: fa-wifi, green on) -->
+          <div style="background:var(--dz-surface-2); border:1px solid var(--dz-border); border-radius:12px; padding:20px 24px; min-width:140px; text-align:center; position:relative;">
+            <div style="position:absolute; top:8px; right:10px; font-size:0.65rem; color:var(--dz-accent); font-weight:600; text-transform:uppercase; letter-spacing:.05em; opacity:.7;">Override</div>
+            <i class="fa-solid fa-wifi" style="font-size:2.2rem; color:#4caf7d; margin-bottom:10px; display:block;"></i>
+            <div style="font-size:0.7rem; font-weight:700; text-transform:uppercase; letter-spacing:.08em; color:var(--dz-text); margin-bottom:4px;">WiFi Router</div>
+            <div style="font-size:0.72rem; color:var(--dz-success, #4caf7d);">On</div>
+          </div>
+
+          <!-- Demo card: EV Charger (override: fa-charging-station, blue on) -->
+          <div style="background:var(--dz-surface-2); border:1px solid var(--dz-border); border-radius:12px; padding:20px 24px; min-width:140px; text-align:center; position:relative;">
+            <div style="position:absolute; top:8px; right:10px; font-size:0.65rem; color:var(--dz-accent); font-weight:600; text-transform:uppercase; letter-spacing:.05em; opacity:.7;">Override</div>
+            <i class="fa-solid fa-charging-station" style="font-size:2.2rem; color:#4e9af1; margin-bottom:10px; display:block;"></i>
+            <div style="font-size:0.7rem; font-weight:700; text-transform:uppercase; letter-spacing:.08em; color:var(--dz-text); margin-bottom:4px;">EV Charger</div>
+            <div style="font-size:0.72rem; color:#4e9af1;">Charging</div>
+          </div>
+
+          <!-- Demo card: Boiler (override: fa-fire-flame-curved, orange) -->
+          <div style="background:var(--dz-surface-2); border:1px solid var(--dz-border); border-radius:12px; padding:20px 24px; min-width:140px; text-align:center; position:relative;">
+            <div style="position:absolute; top:8px; right:10px; font-size:0.65rem; color:var(--dz-accent); font-weight:600; text-transform:uppercase; letter-spacing:.05em; opacity:.7;">Override</div>
+            <i class="fa-solid fa-fire-flame-curved" style="font-size:2.2rem; color:#ff7043; margin-bottom:10px; display:block;"></i>
+            <div style="font-size:0.7rem; font-weight:700; text-transform:uppercase; letter-spacing:.08em; color:var(--dz-text); margin-bottom:4px;">Boiler</div>
+            <div style="font-size:0.72rem; color:#ff7043;">Heating</div>
+          </div>
+
+          <!-- Demo card: Solar Panel (override: fa-solar-panel, amber on) -->
+          <div style="background:var(--dz-surface-2); border:1px solid var(--dz-border); border-radius:12px; padding:20px 24px; min-width:140px; text-align:center; position:relative;">
+            <div style="position:absolute; top:8px; right:10px; font-size:0.65rem; color:var(--dz-accent); font-weight:600; text-transform:uppercase; letter-spacing:.05em; opacity:.7;">Override</div>
+            <i class="fa-solid fa-solar-panel" style="font-size:2.2rem; color:#f0a832; margin-bottom:10px; display:block;"></i>
+            <div style="font-size:0.7rem; font-weight:700; text-transform:uppercase; letter-spacing:.08em; color:var(--dz-text); margin-bottom:4px;">Solar Panels</div>
+            <div style="font-size:0.72rem; color:#f0a832;">Generating</div>
+          </div>
+
+          <!-- Demo card: Washing Machine (override: fa-shirt) — OFF state -->
+          <div style="background:var(--dz-surface-2); border:1px solid var(--dz-border); border-radius:12px; padding:20px 24px; min-width:140px; text-align:center; position:relative;">
+            <div style="position:absolute; top:8px; right:10px; font-size:0.65rem; color:var(--dz-accent); font-weight:600; text-transform:uppercase; letter-spacing:.05em; opacity:.7;">Override</div>
+            <i class="fa-solid fa-shirt" style="font-size:2.2rem; color:#555770; margin-bottom:10px; display:block;"></i>
+            <div style="font-size:0.7rem; font-weight:700; text-transform:uppercase; letter-spacing:.08em; color:var(--dz-text); margin-bottom:4px;">Washing Machine</div>
+            <div style="font-size:0.72rem; color:var(--dz-text-muted);">Off</div>
+          </div>
+
+          <!-- Demo card: NAS (override: fa-hard-drive) -->
+          <div style="background:var(--dz-surface-2); border:1px solid var(--dz-border); border-radius:12px; padding:20px 24px; min-width:140px; text-align:center; position:relative;">
+            <div style="position:absolute; top:8px; right:10px; font-size:0.65rem; color:var(--dz-accent); font-weight:600; text-transform:uppercase; letter-spacing:.05em; opacity:.7;">Override</div>
+            <i class="fa-solid fa-hard-drive" style="font-size:2.2rem; color:#4e9af1; margin-bottom:10px; display:block;"></i>
+            <div style="font-size:0.7rem; font-weight:700; text-transform:uppercase; letter-spacing:.08em; color:var(--dz-text); margin-bottom:4px;">NAS Storage</div>
+            <div style="font-size:0.72rem; color:#4e9af1;">Online</div>
+          </div>
+
+        </div>
+
+        <!-- How it works explainer -->
+        <div style="background:var(--dz-surface-2); border:1px solid var(--dz-border); border-radius:12px; padding:20px 24px; max-width:680px;">
+          <h4 style="margin:0 0 12px; font-size:0.95rem; color:var(--dz-text); display:flex; align-items:center; gap:8px;">
+            <i class="fa-solid fa-circle-info" style="color:var(--dz-accent);"></i>
+            How it works
+          </h4>
+          <ol style="margin:0; padding-left:20px; color:var(--dz-text-soft); font-size:0.85rem; line-height:1.8;">
+            <li>Go to <strong>Settings → Nightglass</strong> tab in Domoticz</li>
+            <li>Find the <strong>Device Icon Overrides</strong> section and click <strong>Manage</strong></li>
+            <li>Search for a device in the list (or use a <em>Quick Preset</em> chip)</li>
+            <li>Click <strong>+</strong> next to any device, then pick an icon from the searchable grid</li>
+            <li>Set custom <strong>On</strong> and <strong>Off</strong> colors with the color pickers</li>
+            <li>Click <strong>Save Overrides</strong> — overrides persist across browsers via Domoticz user variables</li>
+          </ol>
+        </div>
+      </div>
+
     </div>
   </div>
 </div>
 
 <div class="page-bottom"></div>
+
+<script>
+// Demo device list — used as fallback by openDeviceIconOverrideDialog when API is unavailable
+window.__ngDemoDevices = [
+    { idx: 1,  Name: 'Living Room Light',   Type: 'Light/Switch',    HardwareName: 'Philips Hue' },
+    { idx: 2,  Name: 'Garden Socket',       Type: 'Light/Switch',    HardwareName: 'Z-Wave' },
+    { idx: 3,  Name: 'TV',                  Type: 'Light/Switch',    HardwareName: 'Harmony Hub' },
+    { idx: 4,  Name: 'WiFi Router',         Type: 'Light/Switch',    HardwareName: 'Network' },
+    { idx: 5,  Name: 'Thermostat',          Type: 'Thermostat',      HardwareName: 'Nest' },
+    { idx: 6,  Name: 'Kitchen Sensor',      Type: 'Temp + Humidity', HardwareName: 'Z-Wave' },
+    { idx: 7,  Name: 'Solar Panels',        Type: 'General',         HardwareName: 'SolarEdge' },
+    { idx: 8,  Name: 'Electricity Meter',   Type: 'P1 Smart Meter',  HardwareName: 'DSMR' },
+    { idx: 9,  Name: 'Rain Gauge',          Type: 'Rain',            HardwareName: 'Weather Station' },
+    { idx: 10, Name: 'EV Charger',          Type: 'Light/Switch',    HardwareName: 'EVSE' },
+    { idx: 11, Name: 'NAS Storage',         Type: 'Light/Switch',    HardwareName: 'Synology' },
+    { idx: 12, Name: 'Front Doorbell',      Type: 'Light/Switch',    HardwareName: 'Ring' },
+    { idx: 13, Name: 'Washing Machine',     Type: 'Light/Switch',    HardwareName: 'Smart Plug' },
+    { idx: 14, Name: 'Central Heating',     Type: 'Light/Switch',    HardwareName: 'OpenTherm' },
+    { idx: 15, Name: 'Air Quality',         Type: 'Air Quality',     HardwareName: 'CO\u2082 Sensor' }
+];
+</script>
 
 <script>
 // Demo: wire up the placeholder tabs to show/hide content
@@ -118,8 +219,17 @@
     });
   });
 
-  // Default: activate System tab
-  document.getElementById('demo-tab-system').classList.add('active');
+  // Default: open the Nightglass tab so visitors immediately see the settings panel
+  setTimeout(function() {
+    var ngTab = document.getElementById('ng-settings-tab');
+    if (ngTab) {
+      ngTab.querySelector('a').click();
+    } else {
+      // Fallback to System tab if Nightglass tab not yet injected
+      document.getElementById('demo-tab-system').classList.add('active');
+      if (systemPane) systemPane.style.display = '';
+    }
+  }, 600);
 })();
 </script>
 

--- a/docs/icon-replacement-system.md
+++ b/docs/icon-replacement-system.md
@@ -1,0 +1,370 @@
+# Icon Replacement System — Documentation
+
+## Overview
+
+`src/js/icons.js` replaces every `<img>` Domoticz renders with a Font Awesome `<i>` element.
+The original `<img>` is hidden (kept in place for event delegation and state tracking).
+Replacement runs in multiple passes: on load, after Angular route changes, and via `MutationObserver` on img `src` attribute changes.
+
+---
+
+## 1. What is replaced
+
+Replacement happens for three categories of image:
+
+### 1a. Navbar / UI icons — `ICON_MAP`
+
+Key is a substring matched against `img.src`. These are static, stateless icons.
+
+| PNG src substring | FA class |
+|---|---|
+| `images/desktop.png` | `fa-solid fa-gauge` |
+| `images/house.png` | `fa-solid fa-house` |
+| `images/lightbulb.png` | `fa-solid fa-lightbulb` |
+| `images/lightbulboff.png` | `fa-regular fa-lightbulb` |
+| `images/scenes.png` | `fa-solid fa-layer-group` |
+| `images/temperature.png` | `fa-solid fa-temperature-half` |
+| `images/rain.png` | `fa-solid fa-cloud-rain` |
+| `images/utility.png` | `fa-solid fa-bolt` |
+| `images/setup.png` | `fa-solid fa-gear` |
+| `images/hardware.png` | `fa-solid fa-microchip` |
+| `images/devices.png` | `fa-solid fa-sliders` |
+| `images/energy.png` | `fa-solid fa-charging-station` |
+| `images/users.png` | `fa-solid fa-users` |
+| `images/update.png` | `fa-solid fa-download` |
+| `images/log.png` | `fa-solid fa-terminal` |
+| `images/about.png` | `fa-solid fa-circle-info` |
+| `images/logout.png` | `fa-solid fa-right-from-bracket` |
+| `images/restart.png` | `fa-solid fa-rotate-right` |
+| `images/shutdown.png` | `fa-solid fa-power-off` |
+| `images/events.png` | `fa-solid fa-code` |
+| `images/customicons.png` | `fa-solid fa-icons` |
+| `images/variables.png` | `fa-solid fa-list` |
+| `images/contact.png` | `fa-solid fa-share-nodes` |
+| `images/camera-web.png` | `fa-solid fa-video` |
+| `images/security.png` | `fa-solid fa-shield-halved` |
+| `images/notification.png` | `fa-solid fa-bell` |
+| `images/floorplans.png` | `fa-solid fa-map` |
+| `images/report.png` | `fa-solid fa-chart-bar` |
+| `images/delete.png` | `fa-solid fa-trash-can` |
+| `images/rename.png` | `fa-solid fa-pen-to-square` |
+| `images/add.png` | `fa-solid fa-plus` |
+| `images/webcam.png` | `fa-solid fa-video` |
+| `images/override.png` | `fa-solid fa-sliders` |
+| `images/next.png` | `fa-solid fa-chevron-right` |
+| `images/capture.png` | `fa-solid fa-camera` |
+| `images/location.png` | `fa-solid fa-location-dot` |
+| `images/arrow_up.png` | `fa-solid fa-arrow-trend-up` |
+| `images/arrow_down.png` | `fa-solid fa-arrow-trend-down` |
+| `images/arrow_stable.png` | `fa-solid fa-right-long` |
+| `images/arrow_unk.png` | `fa-solid fa-question dz-trend-unk` |
+| `images/blindsstop.png` | `fa-solid fa-stop` |
+| `images/up.png` | `fa-solid fa-arrow-up` |
+| `images/down.png` | `fa-solid fa-arrow-down` |
+| `images/remove.png` | `fa-solid fa-circle-minus` |
+| `images/ok.png` | `fa-solid fa-circle-check` |
+| `images/failed.png` | `fa-solid fa-circle-xmark` |
+| `images/unknown.png` | `fa-solid fa-circle-question` |
+| `images/sleep.png` | `fa-solid fa-moon` |
+| `images/heal.png` | `fa-solid fa-heart-pulse` |
+| `images/battery-ok.png` | `fa-solid fa-battery-full dz-batt-ok` |
+| `images/battery-low.png` | `fa-solid fa-battery-quarter dz-batt-low` |
+| `images/battery.png` | `fa-solid fa-battery-half dz-batt-mid` |
+| `images/air_signal.png` | `fa-solid fa-signal` |
+| `images/equal.png` | `fa-solid fa-minus` |
+| `images/gup.png` | `fa-solid fa-arrow-trend-up` |
+| `images/gdown.png` | `fa-solid fa-arrow-trend-down` |
+| `images/gequal.png` | `fa-solid fa-minus` |
+
+**Priority note:** ICON_MAP is checked *before* the device parser. This prevents e.g. `rain.png` from matching the `rain` device entry.
+
+### 1b. Favorite star icons — `FAV_MAP`
+
+| PNG src substring | FA class |
+|---|---|
+| `images/nofavorite.png` | `fa-regular fa-star dz-fa-fav dz-fav-off` |
+| `images/favorite.png` | `fa-solid fa-star dz-fa-fav dz-fav-on` |
+
+### 1c. Device / widget icons — `DEVICE_MAP`
+
+Matched by parsing the filename: `images/Light48_On.png` → base=`light`, state=`on`.
+The regex is: `/images\/([A-Za-z]+)(?:48)?(?:[_-]?(On|Off|on|off|sel))?\.png/`
+
+These are state-aware: `colorOn` is used when state=`on` (or no state), `colorOff` when state=`off`.
+
+| DEVICE_MAP key (base name) | FA class | colorOn | colorOff |
+|---|---|---|---|
+| `light` | `fa-solid fa-lightbulb` | `#f0a832` | `#555770` |
+| `dimmer` | `fa-solid fa-circle-half-stroke` | `#f0a832` | `#555770` |
+| `glight` | `fa-solid fa-lightbulb` | `#4caf7d` | `#555770` |
+| `strip` | `fa-solid fa-grip-lines` | `#c8a0ff` | `#555770` |
+| `rgb` | `fa-solid fa-palette` | `#c8a0ff` | `#555770` |
+| `generic` | `fa-solid fa-toggle-on` | `#4caf7d` | `#555770` |
+| `push` | `fa-solid fa-circle-dot` | `#4e9af1` | `#555770` |
+| `onoff` | `fa-solid fa-power-off` | null | null |
+| `pushon` | `fa-solid fa-circle-dot` | `#4e9af1` | null |
+| `contact` | `fa-solid fa-door-closed` | `#e05555` | `#4caf7d` |
+| `door` | `fa-solid fa-door-open` | `#e05555` | `#4caf7d` |
+| `window` | `fa-solid fa-window-maximize` | `#e05555` | `#4caf7d` |
+| `blinds` | `fa-solid fa-chevron-down` | `#4e9af1` | `#555770` |
+| `blindsopen` | `fa-solid fa-chevron-up` | `#4e9af1` | `#555770` |
+| `heating` | `fa-solid fa-fire` | `#e05555` | `#555770` |
+| `cooling` | `fa-solid fa-snowflake` | `#29b6f6` | `#555770` |
+| `radiator` | `fa-solid fa-fire-flame-curved` | `#e05555` | `#555770` |
+| `fireplace` | `fa-solid fa-fire` | `#ff7043` | `#555770` |
+| `fan` | `fa-solid fa-fan` | `#4e9af1` | `#555770` |
+| `ac` | `fa-solid fa-snowflake` | `#29b6f6` | `#555770` |
+| `ehome` | `fa-solid fa-house-chimney` | `#4caf7d` | `#555770` |
+| `water` | `fa-solid fa-droplet` | `#29b6f6` | `#555770` |
+| `tap` | `fa-solid fa-faucet` | `#29b6f6` | `#555770` |
+| `irrigation` | `fa-solid fa-hand-holding-droplet` | `#4caf7d` | `#555770` |
+| `pool` | `fa-solid fa-water-ladder` | `#29b6f6` | `#555770` |
+| `pump` | `fa-solid fa-pump-soap` | `#4e9af1` | `#555770` |
+| `solar` | `fa-solid fa-solar-panel` | `#f0a832` | `#555770` |
+| `pv` | `fa-solid fa-solar-panel` | `#f0a832` | null |
+| `inverter` | `fa-solid fa-bolt` | `#f0a832` | `#555770` |
+| `charger` | `fa-solid fa-charging-station` | `#4caf7d` | `#555770` |
+| `laadpaal` | `fa-solid fa-charging-station` | `#4caf7d` | `#555770` |
+| `wallsocket` | `fa-solid fa-plug` | `#4caf7d` | `#555770` |
+| `current` | `fa-solid fa-bolt` | `#f0a832` | null |
+| `tv` | `fa-solid fa-tv` | `#4e9af1` | `#555770` |
+| `media` | `fa-solid fa-play` | `#4e9af1` | `#555770` |
+| `speaker` | `fa-solid fa-volume-high` | `#4e9af1` | `#555770` |
+| `amplifier` | `fa-solid fa-volume-high` | `#c8a0ff` | `#555770` |
+| `logitechmediaserver` | `fa-solid fa-music` | `#4caf7d` | `#555770` |
+| `remote` | `fa-solid fa-gamepad` | null | null |
+| `computer` | `fa-solid fa-display` | `#4e9af1` | `#555770` |
+| `computerpc` | `fa-solid fa-computer` | `#4e9af1` | `#555770` |
+| `harddisk` | `fa-solid fa-hard-drive` | `#4e9af1` | `#555770` |
+| `phone` | `fa-solid fa-phone` | `#4caf7d` | `#555770` |
+| `printer` | `fa-solid fa-print` | `#4e9af1` | `#555770` |
+| `alarm` | `fa-solid fa-bell` | `#e05555` | `#555770` |
+| `smoke` | `fa-solid fa-triangle-exclamation` | `#e05555` | `#555770` |
+| `motion` | `fa-solid fa-person-running` | `#e05555` | `#555770` |
+| `security` | `fa-solid fa-shield-halved` | null | null |
+| `coffee` | `fa-solid fa-mug-hot` | `#ff7043` | `#555770` |
+| `washingmachine` | `fa-solid fa-shirt` | `#4e9af1` | `#555770` |
+| `christmastree` | `fa-solid fa-tree` | `#4caf7d` | `#555770` |
+| `temp` | `fa-solid fa-temperature-half` | `#e05555` | null |
+| `humidity` | `fa-solid fa-droplet` | `#29b6f6` | `#555770` |
+| `baro` | `fa-solid fa-gauge` | `#4e9af1` | null |
+| `rain` | `fa-solid fa-cloud-showers-heavy` | `#29b6f6` | `#555770` |
+| `wind` | `fa-solid fa-wind` | `#b0b3c6` | null |
+| `uv` | `fa-solid fa-sun` | `#f0a832` | null |
+| `lux` | `fa-solid fa-sun` | `#f0a832` | null |
+| `visibility` | `fa-solid fa-eye` | `#b0b3c6` | null |
+| `radiation` | `fa-solid fa-radiation` | `#e05555` | null |
+| `gauge` | `fa-solid fa-gauge` | `#4e9af1` | null |
+| `counter` | `fa-solid fa-hashtag` | `#4e9af1` | null |
+| `percentage` | `fa-solid fa-percent` | `#4e9af1` | null |
+| `scale` | `fa-solid fa-scale-balanced` | `#b0b3c6` | null |
+| `gas` | `fa-solid fa-gas-pump` | `#f0a832` | null |
+| `leaf` | `fa-solid fa-leaf` | `#4caf7d` | null |
+| `moisture` | `fa-solid fa-hand-holding-droplet` | `#29b6f6` | null |
+| `soil` | `fa-solid fa-seedling` | `#4caf7d` | `#555770` |
+| `air` | `fa-solid fa-wind` | `#b0b3c6` | null |
+| `airmeasure` | `fa-solid fa-lungs` | `#4e9af1` | `#555770` |
+| `sun` | `fa-solid fa-sun` | `#f0a832` | `#555770` |
+| `victron` | `fa-solid fa-car-battery` | `#4caf7d` | `#555770` |
+| `doorlock` | `fa-solid fa-lock` | `#4caf7d` | `#e05555` |
+| `doorlockcontact` | `fa-solid fa-lock` | `#4caf7d` | `#e05555` |
+| `smartmeter` | `fa-solid fa-bolt` | `#f0a832` | null |
+| `p1smartmeter` | `fa-solid fa-bolt` | `#f0a832` | null |
+| `electricityusage` | `fa-solid fa-bolt` | `#f0a832` | null |
+| `airquality` | `fa-solid fa-smog` | `#f0a832` | null |
+| `pm25` | `fa-solid fa-smog` | `#f0a832` | null |
+| `co2` | `fa-solid fa-cloud` | `#f0a832` | null |
+| `co` | `fa-solid fa-cloud` | `#e05555` | null |
+| `leaksensor` | `fa-solid fa-droplet` | `#e05555` | `#4caf7d` |
+| `flood` | `fa-solid fa-droplet` | `#e05555` | `#4caf7d` |
+| `curtain` | `fa-solid fa-table-columns` | `#4e9af1` | `#555770` |
+| `presence` | `fa-solid fa-circle-dot` | `#e05555` | `#555770` |
+| `pir` | `fa-solid fa-person-running` | `#e05555` | `#555770` |
+| `text` | `fa-solid fa-align-left` | `#b0b3c6` | null |
+| `alert` | `fa-solid fa-circle-exclamation` | `#e05555` | null |
+| `clock` | `fa-solid fa-clock` | `#4e9af1` | `#555770` |
+| `mode` | `fa-solid fa-sliders` | `#4e9af1` | null |
+| `doorbell` | `fa-solid fa-bell` | `#f0a832` | null |
+| `adjust` | `fa-solid fa-sliders` | `#4e9af1` | null |
+| `custom` | `fa-solid fa-gear` | `#b0b3c6` | `#555770` |
+| `scene` | `fa-solid fa-layer-group` | `#4caf7d` | `#555770` |
+| `group` | `fa-solid fa-layer-group` | `#4caf7d` | `#555770` |
+
+### 1d. Temperature range icons — `TEMP_COLORS`
+
+These are filename-matched (no regex parsing needed), always device-size.
+
+| PNG filename | FA class | Color |
+|---|---|---|
+| `ice.png` | `fa-solid fa-snowflake` | `#29b6f6` |
+| `temp-0-5.png` | `fa-solid fa-temperature-empty` | `#29b6f6` |
+| `temp-5-10.png` | `fa-solid fa-temperature-quarter` | `#4caf7d` |
+| `temp-10-15.png` | `fa-solid fa-temperature-low` | `#4caf7d` |
+| `temp-15-20.png` | `fa-solid fa-temperature-half` | `#f0a832` |
+| `temp-20-25.png` | `fa-solid fa-temperature-three-quarters` | `#ff7043` |
+| `temp-25-30.png` | `fa-solid fa-temperature-high` | `#e05555` |
+| `temp-gt-30.png` | `fa-solid fa-temperature-full` | `#e05555` |
+
+### 1e. Alert level icons
+
+Matched by regex `/images\/Alert48_(\d)\.png/i`.
+
+| Level | Color |
+|---|---|
+| 0 | `#8a8a8a` |
+| 1 | `#4caf7d` |
+| 2 | `#f0a832` |
+| 3 | `#ff7043` |
+| 4 | `#e05555` |
+
+Always uses `fa-solid fa-circle-exclamation`.
+
+### 1f. Wind direction icons
+
+Matched by regex `/images\/Wind([A-Z]{1,3})\.png/`. Icon is `fa-solid fa-arrow-up` rotated via CSS `transform: rotate(Ndeg)`.
+
+`Wind0.png` and `wind48.png` (calm) → `fa-solid fa-wind`, color `#b0b3c6`.
+
+---
+
+## 2. What is NOT replaced — `shouldSkip()`
+
+These image src patterns are skipped and the original PNG is kept:
+
+| Pattern | Reason |
+|---|---|
+| `images/evohome/` | Evohome zone icons (complex, zone-specific) |
+| `Coltemp48` | Color temperature picker (visual slider) |
+| `White48` | White-balance control image |
+| `Customw48` / `Customww48` | Custom white channel images |
+| `RGB48_Sel` / `RGB48.png` | RGB color wheel (visual, not replaceable) |
+| `Up48` / `Down48` / `Stop48` | Blinds directional arrows (Domoticz built-in, use separate blinds logic) |
+| `uvdark` / `uvsunny` | Dusk sensor day/night images |
+| `siren-` | X10 Siren on/off images |
+| `camera_default` | Default camera placeholder |
+| `empty16` | Empty/spacer images |
+| Angular template bindings (`{{`) | Not yet resolved by Angular |
+| Inside `.dd-options`, `.dd-select`, `.iconlist` | Icon-picker dropdowns in the Edit Device dialog |
+
+---
+
+## 3. How `resolveIcon(src)` works — resolution order
+
+1. Check `FAV_MAP` — favorite star images
+2. Check `ICON_MAP` — explicit navbar/action/status images (has priority over device parser)
+3. Run `parseDeviceSrc(src)` — extract base name and on/off state from filename, look up in `DEVICE_MAP`
+4. Check `ALERT_RE` — `Alert48_N.png` alert level icons
+5. Check wind direction regex — `WindN.png` compass icons
+6. Check `Wind0.png` / `wind48.png` — calm wind
+7. Check `TEMP_KEYS` — temperature range icons
+8. Return `null` — image is skipped
+
+---
+
+## 4. How the dialog shows "default" icons — `_dzIconForDevice(device)`
+
+`window._dzIconForDevice` is exposed by `icons.js` (line 1304) for the icon override dialog to call. It takes a Domoticz device API object and tries to predict which FA icon the replacement system will render, so the dialog can preview the "current default" next to each device.
+
+It does this by **constructing a synthetic `src` string** from device properties, then running `resolveIcon()` on it, mirroring `dzLightWidget.js::getDeviceIcon()`.
+
+### Special-case handling in `_dzIconForDevice`
+
+| Condition | Synthetic src used |
+|---|---|
+| `SwitchType == 'Doorbell'` | `images/doorbell48.png` |
+| Any Blinds switch type | `images/{TypeImg}open48sel.png` |
+| `SwitchType == 'Smoke Detector'` | `images/smoke48on.png` |
+| `SwitchType == 'Motion Sensor'` | `images/motion48-on.png` |
+| `SwitchType == 'Dusk Sensor'` | Returns `lux` spec directly (uvdark/uvsunny are skipped) |
+| `SubType == 'Security Panel'` | `images/security48.png` |
+| `SwitchType == 'X10 Siren'` | Returns `alarm` spec directly (siren-on/off are skipped) |
+| `SwitchType == 'TPI'` | `images/Fireplace48_On.png` |
+| Fan subtypes (Itho, Orcon, Lucci, Falmec, Westinghouse) | `images/Fan48_On.png` |
+| `Type == 'Security'` | `images/security48.png` |
+| Door Lock / Door Lock Inverted | `images/{Image}48_On.png` |
+| Contact / Door Contact | `images/{Image}48_On.png` |
+| `Type == 'Scene'` | Returns `scene` spec directly |
+| `Type == 'Group'` | Returns `group` spec directly |
+| No SwitchType (sensors/meters) | Looks up `TypeImg` in DEVICE_MAP with alias normalisation, or `images/{TypeImg}48.png` |
+| Standard switches | `images/{Image}48_On.png` (capitalised when `CustomImage==0`) |
+
+---
+
+## 5. Known mismatches between dialog defaults and actual Domoticz rendering
+
+The dialog uses `_dzIconForDevice()` which mirrors `dzLightWidget.getDeviceIcon()`. However, **utility/sensor devices use `dzUtilityWidget.getDeviceIcon()` in Domoticz**, which has its own filename logic that `_dzIconForDevice` only partially replicates via the TypeImg fallback. This causes several mismatches:
+
+### Humidity devices — FIXED
+- **Was:** `fa-solid fa-droplet` (via DEVICE_MAP alias `hum` → `humidity`)
+- **Now / Domoticz renders:** `fa-solid fa-gauge` (`dzUtilityWidget` returns `gauge48.png` for `device.Type === 'Humidity'`)
+- **Fix:** Added explicit `type === 'Humidity'` branch before the TypeImg lookup.
+
+### Blinds devices with non-standard TypeImg — FIXED
+- **Was:** `fa-circle-question` fallback (constructed `images/{TypeImg}open48sel.png` where TypeImg is not `blinds`)
+- **Now / Domoticz renders:** `fa-solid fa-chevron-up` (`dzLightWidget` always uses `blindsopen48sel.png` regardless of TypeImg)
+- **Fix:** Hardcoded `images/blindsopen48sel.png` instead of using TypeImg.
+
+### Utility sensors looked up via TypeImg
+- `_dzIconForDevice` constructs `images/{TypeImg}48.png` and runs `resolveIcon()`
+- `dzUtilityWidget.getDeviceIcon()` uses specific `SwitchTypeVal`, `SubType`, and `Type` checks to pick filenames
+- Filenames like `Gas48.png`, `Water48_On.png`, `Counter48.png`, `PV48.png`, `current48.png`, `air48.png`, `Percentage48.png` etc. are all hardcoded by Domoticz based on counters/SubType — not derived from TypeImg
+- If `TypeImg` matches one of those names (e.g. `TypeImg = 'counter'`), it works. If it doesn't match (e.g. TypeImg is `'elec'` but SwitchTypeVal selects `current48.png`), the dialog shows the wrong default.
+
+### What the actual replacement sees
+The MutationObserver and initial scan processes the **actual `img.src`** that Domoticz's Angular app sets in the DOM — which comes from `dzLightWidget.getDeviceIcon()` or `dzUtilityWidget.getDeviceIcon()`. This is always correct. The only thing that can be wrong is the **dialog preview** of the default icon.
+
+---
+
+## 6. `resolveIcon()` resolution for key Domoticz filenames
+
+This table maps the actual filenames Domoticz puts in the DOM to what the replacement system produces:
+
+| Actual img.src (from Domoticz) | Parsed base | FA result |
+|---|---|---|
+| `images/Light48_On.png` | `light` | `fa-solid fa-lightbulb` (amber) |
+| `images/Light48_Off.png` | `light` | `fa-solid fa-lightbulb` (grey) |
+| `images/Fan48_On.png` | `fan` | `fa-solid fa-fan` (blue) |
+| `images/doorbell48.png` | `doorbell` | `fa-solid fa-bell` (amber) |
+| `images/blindsopen48sel.png` | `blindsopen`, state=`on` | `fa-solid fa-chevron-up` (blue) |
+| `images/blinds48sel.png` | `blinds`, state=`on` | `fa-solid fa-chevron-down` (blue) |
+| `images/smoke48on.png` | `smoke`, state=`on` | `fa-solid fa-triangle-exclamation` (red) |
+| `images/motion48-on.png` | `motion`, state=`on` | `fa-solid fa-person-running` (red) |
+| `images/security48.png` | `security` | `fa-solid fa-shield-halved` |
+| `images/Fireplace48_On.png` | `fireplace`, state=`on` | `fa-solid fa-fire` (orange) |
+| `images/gas48.png` | `gas` | `fa-solid fa-gas-pump` (amber) |
+| `images/Water48_On.png` | `water`, state=`on` | `fa-solid fa-droplet` (blue) |
+| `images/Counter48.png` | `counter` | `fa-solid fa-hashtag` (blue) |
+| `images/PV48.png` | `pv` | `fa-solid fa-solar-panel` (amber) |
+| `images/current48.png` | `current` | `fa-solid fa-bolt` (amber) |
+| `images/air48.png` | `air` | `fa-solid fa-wind` (grey-blue) |
+| `images/Percentage48.png` | `percentage` | `fa-solid fa-percent` (blue) |
+| `images/leaf48.png` | `leaf` | `fa-solid fa-leaf` (green) |
+| `images/visibility48.png` | `visibility` | `fa-solid fa-eye` (grey-blue) |
+| `images/text48.png` | `text` | `fa-solid fa-align-left` (grey) |
+| `images/Alert48_0.png` – `Alert48_4.png` | alert regex | `fa-solid fa-circle-exclamation` (level color) |
+| `images/gauge48.png` | `gauge` | `fa-solid fa-gauge` (blue) |
+| `images/lux48.png` | `lux` | `fa-solid fa-sun` (amber) |
+| `images/scale48.png` | `scale` | `fa-solid fa-scale-balanced` (grey-blue) |
+| `images/clock48.png` | `clock` | `fa-solid fa-clock` (blue) |
+| `images/mode48.png` | `mode` | `fa-solid fa-sliders` (blue) |
+| `images/Speaker48_On.png` | `speaker`, state=`on` | `fa-solid fa-volume-high` (blue) |
+| `images/moisture48.png` | `moisture` | `fa-solid fa-hand-holding-droplet` (blue) |
+| `images/radiation48.png` | `radiation` | `fa-solid fa-radiation` (red) |
+| `images/Rain48_On.png` | `rain`, state=`on` | `fa-solid fa-cloud-showers-heavy` (blue) |
+| `images/uv48.png` | `uv` | `fa-solid fa-sun` (amber) |
+| `images/WindN.png` / `WindS.png` etc. | wind direction regex | `fa-solid fa-arrow-up` rotated |
+| `images/wind48.png` | special case | `fa-solid fa-wind` (grey-blue) |
+| `images/temp-0-5.png` etc. | TEMP_KEYS match | temperature-range icon |
+| `images/ice.png` | TEMP_KEYS match | `fa-solid fa-snowflake` (blue) |
+| `images/RGB48_On.png` / `RGB48_Off.png` | **SKIPPED** | original PNG kept |
+| `images/uvdark.png` / `images/uvsunny.png` | **SKIPPED** | original PNG kept |
+| `images/siren-on.png` / `images/siren-off.png` | **SKIPPED** | original PNG kept |
+| `images/Up48.png` / `images/Down48.png` / `images/Stop48.png` | **SKIPPED** | original PNG kept |
+
+---
+
+## 7. Adding coverage
+
+- **New device icon:** Add entry to `DEVICE_MAP` in `src/js/icons.js`. Key must be the lowercase base name extracted from the PNG filename by the regex (strip `48`, `_On`, `_Off`, etc.).
+- **New static UI icon:** Add entry to `ICON_MAP`.
+- **Fix a dialog default mismatch:** Update `_dzIconForDevice()` in `icons.js` to add the missing case, mirroring the relevant `dzUtilityWidget.getDeviceIcon()` or `dzLightWidget.getDeviceIcon()` branch.

--- a/src/css/settings-panel.css
+++ b/src/css/settings-panel.css
@@ -1858,6 +1858,53 @@
     background: rgba(var(--dz-accent-rgb), 0.1);
 }
 
+/* Per-device preset confirmation bar */
+.ng-ov-confirm-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    background: rgba(var(--dz-accent-rgb), 0.07);
+    border-top: 1px solid rgba(var(--dz-accent-rgb), 0.18);
+    font-size: 0.82rem;
+    color: var(--dz-text-muted);
+}
+
+.ng-ov-confirm-text {
+    flex: 1;
+    min-width: 0;
+}
+
+.ng-ov-confirm-apply {
+    padding: 3px 10px;
+    border-radius: 4px;
+    border: none;
+    background: var(--dz-accent);
+    color: #fff;
+    font-size: 0.78rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 0.15s;
+}
+
+.ng-ov-confirm-apply:hover { opacity: 0.88; }
+
+.ng-ov-confirm-skip {
+    padding: 3px 8px;
+    border-radius: 4px;
+    border: 1px solid var(--dz-border);
+    background: transparent;
+    color: var(--dz-text-muted);
+    font-size: 0.78rem;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+}
+
+.ng-ov-confirm-skip:hover {
+    background: var(--dz-surface-3);
+    color: var(--dz-text);
+}
+
 /* In select mode the edit button becomes the "apply" indicator */
 .ng-ov-list--select-mode .ng-ov-edit-btn {
     pointer-events: none;

--- a/src/css/settings-panel.css
+++ b/src/css/settings-panel.css
@@ -1284,6 +1284,597 @@
 /* ── Override Domoticz Bootstrap .alerts so intercepted ones are invisible ── */
 .alerts { display: none !important; }
 
+/* ══════════════════════════════════════════════════════════════════
+   DEVICE ICON OVERRIDE DIALOG
+   ══════════════════════════════════════════════════════════════════ */
+
+/* Wider dialog to accommodate sidebar */
+.ng-ov-dialog {
+    max-width: 900px;
+    width: calc(100vw - 32px);
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Body: main column + sidebar side-by-side */
+.ng-ov-body {
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+    min-height: 0;
+}
+
+.ng-ov-main {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border-right: 1px solid var(--dz-border);
+}
+
+/* ── Active Overrides sidebar ─────────────────────────────── */
+
+.ng-ov-sidebar {
+    width: 220px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    background: var(--dz-surface-2);
+}
+
+.ng-ov-sidebar-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 11px 14px;
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: var(--dz-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--dz-border);
+    flex-shrink: 0;
+}
+
+    .ng-ov-sidebar-header i {
+        color: var(--dz-accent);
+        opacity: 0.75;
+    }
+
+.ng-ov-sidebar-count {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    height: 18px;
+    padding: 0 5px;
+    background: rgba(var(--dz-accent-rgb), 0.18);
+    color: var(--dz-accent);
+    font-size: 0.72rem;
+    font-weight: 700;
+    border-radius: 9px;
+}
+
+.ng-ov-sidebar-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 4px 0;
+}
+
+.ng-ov-sidebar-empty {
+    padding: 20px 14px;
+    font-size: 0.8rem;
+    color: var(--dz-text-faint);
+    text-align: center;
+    font-style: italic;
+}
+
+/* Sidebar override item */
+.ng-ov-si {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 7px 10px 7px 14px;
+    cursor: pointer;
+    transition: background 0.12s;
+}
+
+    .ng-ov-si:hover {
+        background: rgba(var(--dz-accent-rgb), 0.07);
+    }
+
+.ng-ov-si-icon {
+    font-size: 1.05rem;
+    flex-shrink: 0;
+    width: 20px;
+    text-align: center;
+    transition: color 0.2s;
+}
+
+.ng-ov-si-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.ng-ov-si-name {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--dz-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.ng-ov-si-dots {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+}
+
+.ng-ov-si-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.ng-ov-si-remove {
+    flex-shrink: 0;
+    padding: 3px 6px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 5px;
+    color: var(--dz-text-faint);
+    cursor: pointer;
+    font-size: 0.78rem;
+    opacity: 0;
+    transition: opacity 0.15s, background 0.15s, color 0.15s;
+}
+
+    .ng-ov-si:hover .ng-ov-si-remove {
+        opacity: 1;
+    }
+
+    .ng-ov-si-remove:hover {
+        background: rgba(224, 85, 85, 0.15);
+        border-color: rgba(224, 85, 85, 0.3);
+        color: var(--dz-danger, #e05555);
+    }
+
+/* Flash highlight when jumping from sidebar to list row */
+.ng-ov-row--flash {
+    animation: ngRowFlash 0.9s ease;
+}
+
+@keyframes ngRowFlash {
+    0%   { background: rgba(var(--dz-accent-rgb), 0.22); }
+    100% { background: transparent; }
+}
+
+/* Collapse sidebar to icon-only on narrow screens */
+@media (max-width: 600px) {
+    .ng-ov-sidebar {
+        width: 48px;
+    }
+    .ng-ov-sidebar-header span:not(.ng-ov-sidebar-count),
+    .ng-ov-si-info,
+    .ng-ov-si-remove {
+        display: none;
+    }
+    .ng-ov-si {
+        justify-content: center;
+        padding: 8px 0;
+    }
+    .ng-ov-si-icon {
+        font-size: 1.15rem;
+    }
+}
+
+/* Badge showing override count in the settings panel row */
+.ng-override-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    height: 20px;
+    padding: 0 6px;
+    background: var(--dz-accent);
+    color: #fff;
+    font-size: 0.72rem;
+    font-weight: 700;
+    border-radius: 10px;
+    margin-left: 6px;
+    vertical-align: middle;
+}
+
+/* Popular presets strip */
+.ng-ov-popular {
+    padding: 12px 16px 4px;
+    border-bottom: 1px solid var(--dz-border);
+}
+
+.ng-ov-popular-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--dz-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 8px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+    .ng-ov-popular-label i {
+        color: var(--dz-accent);
+        opacity: 0.8;
+    }
+
+.ng-ov-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding-bottom: 10px;
+    max-height: 80px;
+    overflow-y: auto;
+}
+
+.ng-ov-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 4px 10px;
+    font-size: 0.78rem;
+    font-weight: 500;
+    background: var(--dz-surface-3);
+    border: 1px solid var(--dz-border);
+    border-radius: 14px;
+    color: var(--dz-text-soft);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.2s, border-color 0.2s, color 0.2s;
+}
+
+    .ng-ov-chip:hover {
+        background: rgba(var(--dz-accent-rgb), 0.15);
+        border-color: var(--dz-accent);
+        color: var(--dz-text);
+    }
+
+    .ng-ov-chip i {
+        font-size: 0.85em;
+        color: var(--dz-accent);
+    }
+
+/* Override list */
+.ng-ov-list {
+    overflow-y: auto;
+    flex: 1;
+}
+
+/* Individual device row */
+.ng-ov-row {
+    border-bottom: 1px solid var(--dz-border);
+    transition: background 0.15s;
+}
+
+.ng-ov-row--active {
+    background: rgba(var(--dz-accent-rgb), 0.06);
+}
+
+.ng-ov-row-summary {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    cursor: default;
+}
+
+.ng-ov-row-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    flex-shrink: 0;
+}
+
+    .ng-ov-row-fa {
+        font-size: 1.1rem;
+        transition: color 0.2s;
+    }
+
+.ng-ov-edit-btn {
+    margin-left: auto;
+    flex-shrink: 0;
+    padding: 5px 10px;
+    font-size: 0.78rem;
+    background: var(--dz-surface-3);
+    border: 1px solid var(--dz-border);
+    border-radius: 8px;
+    color: var(--dz-text-muted);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+    .ng-ov-edit-btn:hover {
+        background: rgba(var(--dz-accent-rgb), 0.18);
+        border-color: var(--dz-accent);
+        color: var(--dz-text);
+    }
+
+    .ng-ov-row--active .ng-ov-edit-btn {
+        border-color: rgba(var(--dz-accent-rgb), 0.4);
+        color: var(--dz-accent);
+    }
+
+/* Inline editor panel */
+.ng-ov-editor {
+    padding: 12px 16px 16px;
+    border-top: 1px solid var(--dz-border);
+    background: var(--dz-surface-2);
+}
+
+/* Preview strip */
+.ng-ov-preview {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    background: var(--dz-surface);
+    border: 1px solid var(--dz-border);
+    border-radius: 10px;
+    margin-bottom: 12px;
+}
+
+.ng-ov-preview-icon {
+    font-size: 1.8rem;
+    transition: color 0.2s;
+    min-width: 32px;
+    text-align: center;
+}
+
+.ng-ov-preview-name {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--dz-text);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+/* Icon picker */
+.ng-ov-picker {
+    margin-bottom: 12px;
+}
+
+.ng-ov-picker-search {
+    width: 100%;
+    padding: 7px 12px;
+    font-size: 0.83rem;
+    background: var(--dz-surface);
+    border: 1px solid var(--dz-border);
+    border-radius: 8px;
+    color: var(--dz-text);
+    margin-bottom: 8px;
+    box-sizing: border-box;
+}
+
+    .ng-ov-picker-search:focus {
+        outline: none;
+        border-color: var(--dz-accent);
+    }
+
+.ng-ov-icon-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(36px, 1fr));
+    gap: 4px;
+    max-height: 160px;
+    overflow-y: auto;
+    padding: 4px;
+    background: var(--dz-surface);
+    border: 1px solid var(--dz-border);
+    border-radius: 8px;
+}
+
+.ng-ov-icon-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--dz-text-soft);
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+
+    .ng-ov-icon-btn:hover {
+        background: rgba(var(--dz-accent-rgb), 0.12);
+        color: var(--dz-text);
+        border-color: rgba(var(--dz-accent-rgb), 0.25);
+    }
+
+    .ng-ov-icon-btn--active {
+        background: rgba(var(--dz-accent-rgb), 0.2) !important;
+        color: var(--dz-accent) !important;
+        border-color: var(--dz-accent) !important;
+    }
+
+/* Color row */
+.ng-ov-color-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.ng-ov-color-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.8rem;
+    color: var(--dz-text-soft);
+    flex-shrink: 0;
+}
+
+    .ng-ov-color-label span {
+        white-space: nowrap;
+    }
+
+/* Scoped tweak: HSV picker inside the override color row */
+.ng-ov-color-label .ng-color-wrap {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+    .ng-ov-color-label .ng-cp-swatch {
+        width: 22px;
+        height: 22px;
+        min-width: 22px;
+        border-radius: 5px;
+    }
+
+    .ng-ov-color-label .ng-cp-hex {
+        width: 72px;
+        font-size: 0.78rem;
+    }
+
+.ng-ov-remove-btn {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 4px 10px;
+    font-size: 0.78rem;
+    background: rgba(var(--dz-danger, 224, 85, 85), 0.08);
+    border: 1px solid rgba(224, 85, 85, 0.25);
+    border-radius: 7px;
+    color: var(--dz-danger, #e05555);
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+    .ng-ov-remove-btn:hover {
+        background: rgba(224, 85, 85, 0.18);
+    }
+
+/* ── Demo mode notice ───────────────────────────────────────── */
+
+.ng-ov-demo-notice {
+    margin: 0 0 10px;
+    padding: 8px 12px;
+    background: rgba(240, 168, 50, 0.10);
+    border: 1px solid rgba(240, 168, 50, 0.28);
+    border-radius: 8px;
+    font-size: 0.78rem;
+    color: var(--dz-text-soft);
+}
+
+    .ng-ov-demo-notice .fa-circle-info {
+        color: #f0a832;
+        margin-right: 5px;
+    }
+
+/* ── Preset selection mode ──────────────────────────────────── */
+
+/* Active chip (preset pending) */
+.ng-ov-chip--active {
+    background: rgba(var(--dz-accent-rgb), 0.22) !important;
+    border-color: var(--dz-accent) !important;
+    color: var(--dz-text) !important;
+}
+
+/* Instruction banner shown above the list */
+.ng-ov-select-banner {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    background: rgba(var(--dz-accent-rgb), 0.1);
+    border-top: 1px solid rgba(var(--dz-accent-rgb), 0.25);
+    border-bottom: 1px solid rgba(var(--dz-accent-rgb), 0.25);
+    font-size: 0.84rem;
+    color: var(--dz-text-soft);
+    animation: ngBannerIn 0.18s ease;
+}
+
+@keyframes ngBannerIn {
+    from { opacity: 0; transform: translateY(-4px); }
+    to   { opacity: 1; transform: translateY(0);    }
+}
+
+.ng-ov-banner-icon {
+    font-size: 1.1rem;
+    flex-shrink: 0;
+}
+
+.ng-ov-banner-text {
+    flex: 1;
+    min-width: 0;
+}
+
+    .ng-ov-banner-text strong {
+        color: var(--dz-text);
+    }
+
+.ng-ov-banner-cancel {
+    margin-left: auto;
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 4px 10px;
+    font-size: 0.78rem;
+    background: transparent;
+    border: 1px solid var(--dz-border);
+    border-radius: 7px;
+    color: var(--dz-text-muted);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+}
+
+    .ng-ov-banner-cancel:hover {
+        background: var(--dz-surface-3);
+        color: var(--dz-text);
+    }
+
+/* Select-mode: make every row look clickable */
+.ng-ov-list--select-mode .ng-ov-row-summary {
+    cursor: pointer;
+}
+
+.ng-ov-list--select-mode .ng-ov-row-summary:hover {
+    background: rgba(var(--dz-accent-rgb), 0.1);
+}
+
+/* In select mode the edit button becomes the "apply" indicator */
+.ng-ov-list--select-mode .ng-ov-edit-btn {
+    pointer-events: none;
+    background: rgba(var(--dz-accent-rgb), 0.1);
+    border-color: rgba(var(--dz-accent-rgb), 0.3);
+    color: var(--dz-accent);
+}
+
+/* Light mode adjustments */
+body.dz-light .ng-ov-icon-btn {
+    color: var(--dz-text-muted);
+}
+
+body.dz-light .ng-ov-dialog {
+    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.18);
+}
+
 /* Light mode adjustments */
 body.dz-light .ng-toast {
     box-shadow: 0 6px 24px rgba(0, 0, 0, 0.14), 0 1px 4px rgba(0, 0, 0, 0.08);

--- a/src/css/settings-panel.css
+++ b/src/css/settings-panel.css
@@ -1867,6 +1867,104 @@
 }
 
 /* Light mode adjustments */
+/* Multi-slot preview strip (blinds open/close, lock unlocked/locked) */
+.ng-ov-preview--multi {
+    gap: 28px;
+}
+
+.ng-ov-preview-slot {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 5px;
+    min-width: 44px;
+}
+
+.ng-ov-preview-label {
+    font-size: 0.67rem;
+    font-weight: 700;
+    color: var(--dz-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+/* Labeled icon-picker section */
+.ng-ov-picker-section {
+    margin-bottom: 4px;
+}
+
+.ng-ov-picker-label {
+    font-size: 0.76rem;
+    font-weight: 700;
+    color: var(--dz-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 4px;
+    padding-left: 2px;
+}
+
+.ng-ov-picker-note {
+    font-size: 0.73rem;
+    color: var(--dz-text-muted);
+    margin-bottom: 5px;
+    padding-left: 2px;
+    font-style: italic;
+    opacity: 0.75;
+}
+
+/* Sensor "keep dynamic color" checkbox row */
+.ng-ov-keepcolor-wrap {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 2px 10px;
+}
+
+.ng-ov-keepcolor-wrap input[type="checkbox"] {
+    width: 14px;
+    height: 14px;
+    accent-color: var(--dz-accent);
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.ng-ov-keepcolor-wrap label {
+    font-size: 0.8rem;
+    color: var(--dz-text-muted);
+    cursor: pointer;
+}
+
+/* Device-model badge shown in the row type line */
+.ng-ov-model-badge {
+    display: inline-block;
+    padding: 1px 5px;
+    margin-left: 5px;
+    font-size: 0.64rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    background: rgba(var(--dz-accent-rgb), 0.14);
+    color: var(--dz-accent);
+    border-radius: 4px;
+    vertical-align: middle;
+}
+
+.ng-ov-model-badge--sensor {
+    background: rgba(76, 175, 125, 0.15);
+    color: #4caf7d;
+}
+
+/* Multi-icon summary slot (blinds: two icons side by side) */
+.ng-ov-row-icon--multi {
+    width: auto;
+    min-width: 44px;
+    gap: 4px;
+}
+
+.ng-ov-row-icon--multi .ng-ov-row-fa {
+    font-size: 0.95rem;
+}
+
 body.dz-light .ng-ov-icon-btn {
     color: var(--dz-text-muted);
 }

--- a/src/css/settings-panel.css
+++ b/src/css/settings-panel.css
@@ -1981,6 +1981,27 @@
     cursor: pointer;
 }
 
+/* Device group tag (Temperature, Weather, Utility, etc.) */
+.ng-ov-group-tag {
+    display: inline-block;
+    padding: 1px 5px;
+    margin-left: 4px;
+    font-size: 0.62rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    background: rgba(176, 179, 198, 0.1);
+    color: var(--dz-text-muted);
+    border-radius: 4px;
+    vertical-align: middle;
+}
+
+.ng-ov-group-tag--temp     { background: rgba(224, 85, 85, 0.1);   color: #e05555; }
+.ng-ov-group-tag--weather  { background: rgba(41, 182, 246, 0.12); color: #29b6f6; }
+.ng-ov-group-tag--security { background: rgba(224, 85, 85, 0.1);   color: #e05555; }
+.ng-ov-group-tag--utility  { background: rgba(200, 160, 255, 0.1); color: #c8a0ff; }
+.ng-ov-group-tag--scene    { background: rgba(76, 175, 125, 0.12); color: #4caf7d; }
+
 /* Device-model badge shown in the row type line */
 .ng-ov-model-badge {
     display: inline-block;

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -642,6 +642,39 @@
     /* WeakMap so entries are GC'd automatically when the img is gone */
     var iconMap = new WeakMap();
 
+    /* ── Per-device icon overrides ─────────────────────────────────
+       Keyed by device IDX string → { icon, on, off }.
+       Populated by the settings module via window._dzSetDeviceIconOverrides. */
+    var DEVICE_ICON_OVERRIDES = {};
+
+    /* Returns an overridden resolved spec for a given device IDX + src,
+       or null when no override is configured for that device.             */
+    function applyDeviceOverride(devIdx, src, fallbackResolved) {
+        if (!devIdx || !DEVICE_ICON_OVERRIDES[devIdx]) return null;
+        var ov = DEVICE_ICON_OVERRIDES[devIdx];
+        if (!ov.icon) return null;
+        var parsedSrc = parseDeviceSrc(src);
+        var isOn  = !parsedSrc || parsedSrc.state !== 'off';
+        var fbOn  = (fallbackResolved && fallbackResolved.colorOn)  || '#4e9af1';
+        var fbOff = (fallbackResolved && fallbackResolved.colorOff) || '#555770';
+        var ovOn  = ov.on  || fbOn;
+        var ovOff = ov.off || fbOff;
+        return {
+            type:     'device',
+            cls:      ov.icon + ' dz-fa-device',
+            color:    isOn ? ovOn : ovOff,
+            colorOn:  ovOn,
+            colorOff: ovOff
+        };
+    }
+
+    /* Called by the settings module when the override map changes.
+       Schedules a replacement burst so already-rendered icons update. */
+    window._dzSetDeviceIconOverrides = function (overrides) {
+        DEVICE_ICON_OVERRIDES = overrides || {};
+        if (typeof window._dzScheduleBurst === 'function') window._dzScheduleBurst();
+    };
+
     /* -- Process a single <img> into an FA <i> -------------------- */
     /* Returns true if the image was processed, false if skipped.      */
 
@@ -670,6 +703,19 @@
         if (!resolved) {
             img.classList.add('dz-icon-skipped');
             return false;
+        }
+
+        /* Per-device icon override — only for 48px device state icons */
+        if (resolved.type === 'device') {
+            var angDev = getDeviceFromIcon(img);
+            if (angDev) {
+                var devIdx = String(angDev.idx || angDev.IDX || '');
+                var ovSpec = devIdx ? applyDeviceOverride(devIdx, src, resolved) : null;
+                if (ovSpec) {
+                    resolved = ovSpec;
+                    img.setAttribute('data-dz-dev-idx', devIdx);
+                }
+            }
         }
 
         var icon = document.createElement('i');
@@ -790,7 +836,24 @@
         if (!curSrc || curSrc === prevSrc || curSrc.indexOf('{{') !== -1) return;
         if (shouldSkip(curSrc)) return;
 
+        /* Resolve icon first so colors are available as fallback for overrides */
         var resolved = resolveIcon(curSrc);
+
+        /* Per-device icon override — check stored IDX on the img element */
+        var devIdx = img.getAttribute('data-dz-dev-idx');
+        if (devIdx) {
+            var ovSpec = applyDeviceOverride(devIdx, curSrc, resolved);
+            if (ovSpec) {
+                icon.className = ovSpec.cls;
+                icon.style.color = ovSpec.color || '';
+                icon.setAttribute('data-dz-color-on',  ovSpec.colorOn);
+                icon.setAttribute('data-dz-color-off', ovSpec.colorOff);
+                icon.setAttribute('data-dz-state', ovSpec.color === ovSpec.colorOn ? 'on' : 'off');
+                img.setAttribute('data-dz-src', curSrc);
+                return;
+            }
+        }
+
         if (!resolved) return;
 
         if (resolved.type === 'fav') {
@@ -903,11 +966,15 @@
                 var rot = WIND_ROTATION[newResolved.dir];
                 prevIcon.style.transform = rot !== null ? 'rotate(' + rot + 'deg)' : '';
             } else if (newResolved.type === 'device') {
-                prevIcon.className = newResolved.cls;
-                prevIcon.style.color = newResolved.color || '';
-                if (newResolved.colorOn)  prevIcon.setAttribute('data-dz-color-on',  newResolved.colorOn);
-                if (newResolved.colorOff) prevIcon.setAttribute('data-dz-color-off', newResolved.colorOff);
-                prevIcon.setAttribute('data-dz-state', newResolved.color === newResolved.colorOn ? 'on' : 'off');
+                /* Prefer per-device override if one is configured */
+                var p2DevIdx = rImg.getAttribute('data-dz-dev-idx');
+                var p2Spec   = p2DevIdx ? applyDeviceOverride(p2DevIdx, curSrc, newResolved) : null;
+                var p2Final  = p2Spec || newResolved;
+                prevIcon.className = p2Final.cls;
+                prevIcon.style.color = p2Final.color || '';
+                if (p2Final.colorOn)  prevIcon.setAttribute('data-dz-color-on',  p2Final.colorOn);
+                if (p2Final.colorOff) prevIcon.setAttribute('data-dz-color-off', p2Final.colorOff);
+                prevIcon.setAttribute('data-dz-state', p2Final.color === p2Final.colorOn ? 'on' : 'off');
             }
 
             rImg.setAttribute('data-dz-src', curSrc);

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -1293,24 +1293,82 @@
        observers in the processCards block) can trigger a replacement pass. */
     window._dzScheduleBurst = scheduleBurst;
 
-    /* Expose a device-icon lookup for other modules (e.g. command palette).
-       Given a Domoticz device object with TypeImg + Status fields, returns
-       { icon: 'fa-solid fa-...', color: '#rrggbb' } or null.               */
+    /* Expose a device-icon lookup for other modules (e.g. settings dialog).
+       Given a Domoticz device object, returns { icon, color } replicating
+       the logic of dzLightWidget.js::getDeviceIcon() so the dialog shows
+       the same icon that Domoticz actually renders.                        */
     window._dzIconForDevice = function (device) {
-        var typeImg = device.TypeImg || '';
-        // Build a synthetic image path that parseDeviceSrc / resolveIcon can parse
-        var on   = !!(device.Status && (
-            ['On','Group On','Chime','Panic','Mixed'].indexOf(device.Status) >= 0 ||
-            device.Status.indexOf('Set ') === 0));
-        var suffix = on ? '_On' : '_Off';
-        var src = 'images/' + typeImg + '48' + suffix + '.png';
+        var sw      = device.SwitchType || '';
+        var type    = device.Type       || '';
+        var subType = device.SubType    || '';
+        var typeImg = (device.TypeImg   || '').toLowerCase();
+        var image   = device.Image      || '';
+        /* TypeImg values that differ from DEVICE_MAP keys */
+        var ALIASES = { 'hum': 'humidity', 'temphum': 'temp', 'temphumbaroew': 'temp',
+                        'zwavemelding': 'alarm', 'elec': 'electricityusage' };
+        var src;
+
+        /* Mirror getDeviceIcon() special cases */
+        if (sw === 'Doorbell') {
+            src = 'images/doorbell48.png';
+        } else if (sw.indexOf('Blind') >= 0 || sw.indexOf('Venetian') >= 0) {
+            /* Show open state so the dialog preview uses the open-arrow icon */
+            src = 'images/' + (device.TypeImg || 'blinds') + 'open48sel.png';
+        } else if (sw === 'Smoke Detector') {
+            src = 'images/smoke48on.png';
+        } else if (sw === 'Motion Sensor') {
+            src = 'images/motion48-on.png';
+        } else if (sw === 'Dusk Sensor') {
+            /* uvdark/uvsunny are in the skip list — return lux spec directly */
+            var luxSpec = DEVICE_MAP['lux'];
+            return luxSpec ? { icon: luxSpec.icon, color: luxSpec.on } : null;
+        } else if (subType === 'Security Panel') {
+            src = 'images/security48.png';
+        } else if (sw === 'X10 Siren') {
+            /* siren-on/off are in skip list — use alarm */
+            var almSpec = DEVICE_MAP['alarm'];
+            return almSpec ? { icon: almSpec.icon, color: almSpec.on } : null;
+        } else if (sw === 'TPI') {
+            src = 'images/Fireplace48_On.png';
+        } else if (subType && (subType.indexOf('Itho') === 0 || subType.indexOf('Orcon') === 0 ||
+                   subType.indexOf('Lucci') === 0 || subType.indexOf('Falmec') === 0 ||
+                   subType.indexOf('Westinghouse') === 0)) {
+            src = 'images/Fan48_On.png';
+        } else if (type === 'Security') {
+            src = 'images/security48.png';
+        } else if (sw === 'Door Lock' || sw === 'Door Lock Inverted') {
+            var lockImg = image || 'Light';
+            if (device.CustomImage == 0) lockImg = lockImg.charAt(0).toUpperCase() + lockImg.slice(1);
+            src = 'images/' + lockImg + '48_On.png';
+        } else if (sw === 'Contact' || sw === 'Door Contact') {
+            var ctImg = image || (sw === 'Door Contact' ? 'Door' : 'Contact');
+            if (device.CustomImage == 0) ctImg = ctImg.charAt(0).toUpperCase() + ctImg.slice(1);
+            src = 'images/' + ctImg + '48_On.png';
+        } else if (!sw && typeImg) {
+            /* Sensor/meter (no SwitchType): look up TypeImg with alias normalisation */
+            var normKey = ALIASES[typeImg] || typeImg;
+            if (DEVICE_MAP[normKey]) {
+                var sSpec = DEVICE_MAP[normKey];
+                return { icon: sSpec.icon, color: sSpec.on || '#4e9af1' };
+            }
+            src = 'images/' + typeImg + '48.png';
+        } else {
+            /* Standard switch: getDeviceIcon() uses device.Image, not TypeImg */
+            var imgBase = image || 'Light';
+            if (device.CustomImage == 0) imgBase = imgBase.charAt(0).toUpperCase() + imgBase.slice(1);
+            src = 'images/' + imgBase + '48_On.png';
+        }
+
         var r = resolveIcon(src);
         if (r && r.cls) {
-            // strip dz-fa-device / dz-wind helper classes — just the FA classes
-            var fa = r.cls.split(' ').filter(function (c) {
-                return c.indexOf('fa-') === 0 || c === 'fa-solid' || c === 'fa-regular';
-            }).join(' ');
+            var fa = r.cls.split(' ').filter(function (c) { return c.indexOf('fa-') === 0; }).join(' ');
             return { icon: fa || r.cls, color: r.color };
+        }
+        /* Final fallback: typeImg alias lookup in DEVICE_MAP */
+        var fbKey = ALIASES[typeImg] || typeImg;
+        if (fbKey && DEVICE_MAP[fbKey]) {
+            var fbSpec = DEVICE_MAP[fbKey];
+            return { icon: fbSpec.icon, color: fbSpec.on || '#4e9af1' };
         }
         return null;
     };

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -1368,6 +1368,12 @@
                TypeImg 'hum' would alias to 'humidity' (droplet) which is wrong. */
             var humSpec = DEVICE_MAP['gauge'];
             return humSpec ? { icon: humSpec.icon, color: humSpec.on } : null;
+        } else if (typeof device.Temp !== 'undefined' || typeof device.Chill !== 'undefined') {
+            /* Temperature / weather combo devices (Temp, Temp+Hum, Temp+Hum+Baro, Wind…):
+               dzUtilityWidget uses GetTemp48Item(device.Temp) which returns range images.
+               In the dialog we show the fixed temp icon — we can't vary by live value. */
+            var tempSpec = DEVICE_MAP['temp'];
+            return tempSpec ? { icon: tempSpec.icon, color: tempSpec.on } : null;
         } else if (!sw && typeImg) {
             /* Sensor/meter (no SwitchType): look up TypeImg with alias normalisation */
             var normKey = ALIASES[typeImg] || typeImg;

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -1356,10 +1356,12 @@
             if (device.CustomImage == 0) ctImg = ctImg.charAt(0).toUpperCase() + ctImg.slice(1);
             src = 'images/' + ctImg + '48_On.png';
         } else if (type === 'Scene') {
-            var scSpec = DEVICE_MAP['scene'];
+            /* scene_widget.html hardcodes images/Push48_On.png → base='push' → fa-circle-dot */
+            var scSpec = DEVICE_MAP['push'];
             return scSpec ? { icon: scSpec.icon, color: scSpec.on } : null;
         } else if (type === 'Group') {
-            var grpSpec = DEVICE_MAP['group'];
+            /* scene_widget.html hardcodes images/Push48_On/Off.png → base='push' → fa-circle-dot */
+            var grpSpec = DEVICE_MAP['push'];
             return grpSpec ? { icon: grpSpec.icon, color: grpSpec.on } : null;
         } else if (type === 'Humidity') {
             /* dzUtilityWidget renders gauge48.png for Humidity, not humidity48.png.
@@ -1374,6 +1376,13 @@
                 return { icon: sSpec.icon, color: sSpec.on || '#4e9af1' };
             }
             src = 'images/' + typeImg + '48.png';
+        } else if (device.CustomImage == 0 && subType &&
+                   (subType.indexOf('RGB') >= 0 || subType.indexOf('WW') >= 0)) {
+            /* RGB/RGBW/CCT dimmers: dzLightWidget returns images/RGB48_On.png
+               → resolveIcon → DEVICE_MAP['rgb'] = fa-palette.
+               Must be checked before the generic image fallback below. */
+            var rgbSpec = DEVICE_MAP['rgb'];
+            return rgbSpec ? { icon: rgbSpec.icon, color: rgbSpec.on } : null;
         } else {
             /* Standard switch: getDeviceIcon() uses device.Image, not TypeImg */
             var imgBase = image || 'Light';

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -233,7 +233,11 @@
         'mode':            { icon: 'fa-solid fa-sliders',             on: '#4e9af1', off: null },
         'doorbell':        { icon: 'fa-solid fa-bell',                on: '#f0a832', off: null },
         'adjust':          { icon: 'fa-solid fa-sliders',             on: '#4e9af1', off: null },
-        'custom':          { icon: 'fa-solid fa-gear',                on: '#b0b3c6', off: '#555770' }
+        'custom':          { icon: 'fa-solid fa-gear',                on: '#b0b3c6', off: '#555770' },
+
+        /* Scenes & groups */
+        'scene':           { icon: 'fa-solid fa-layer-group',        on: '#4caf7d', off: '#555770' },
+        'group':           { icon: 'fa-solid fa-layer-group',        on: '#4caf7d', off: '#555770' }
     };
 
     /* -- Favorite star icons -------------------------------------- */
@@ -1344,6 +1348,12 @@
             var ctImg = image || (sw === 'Door Contact' ? 'Door' : 'Contact');
             if (device.CustomImage == 0) ctImg = ctImg.charAt(0).toUpperCase() + ctImg.slice(1);
             src = 'images/' + ctImg + '48_On.png';
+        } else if (type === 'Scene') {
+            var scSpec = DEVICE_MAP['scene'];
+            return scSpec ? { icon: scSpec.icon, color: scSpec.on } : null;
+        } else if (type === 'Group') {
+            var grpSpec = DEVICE_MAP['group'];
+            return grpSpec ? { icon: grpSpec.icon, color: grpSpec.on } : null;
         } else if (!sw && typeImg) {
             /* Sensor/meter (no SwitchType): look up TypeImg with alias normalisation */
             var normKey = ALIASES[typeImg] || typeImg;

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -643,7 +643,10 @@
     var iconMap = new WeakMap();
 
     /* ── Per-device icon overrides ─────────────────────────────────
-       Keyed by device IDX string → { icon, on, off }.
+       Keyed by device IDX string.
+       Schema: { iconOn, iconOff?, iconOpen?, iconClose?, iconStop?,
+                 on, off, keepColor?, name }
+       Legacy field 'icon' is treated as iconOn for backward compat.
        Populated by the settings module via window._dzSetDeviceIconOverrides. */
     var DEVICE_ICON_OVERRIDES = {};
 
@@ -652,16 +655,54 @@
     function applyDeviceOverride(devIdx, src, fallbackResolved) {
         if (!devIdx || !DEVICE_ICON_OVERRIDES[devIdx]) return null;
         var ov = DEVICE_ICON_OVERRIDES[devIdx];
-        if (!ov.icon) return null;
+        if (!ov.iconOn && !ov.iconOpen && !ov.icon) return null;
+
         var parsedSrc = parseDeviceSrc(src);
-        var isOn  = !parsedSrc || parsedSrc.state !== 'off';
+        var base      = parsedSrc ? parsedSrc.base : null;
+
+        /* Blinds: 'sel'→'on' is the only active state; null/no suffix = inactive.
+           Replicate the same special-case used in resolveIcon().              */
+        var isOn;
+        if (base === 'blinds' || base === 'blindsopen') {
+            isOn = !!(parsedSrc && parsedSrc.state === 'on');
+        } else {
+            isOn = !parsedSrc || parsedSrc.state !== 'off';
+        }
+
+        /* Select icon by image slot:
+           blindsopen* → Open button, blinds* → Close button, all else → on/off */
+        var iconCls;
+        if (base === 'blindsopen') {
+            iconCls = ov.iconOpen  || ov.iconOn || ov.icon;
+        } else if (base === 'blinds') {
+            iconCls = ov.iconClose || ov.iconOn || ov.icon;
+        } else {
+            iconCls = isOn
+                ? (ov.iconOn  || ov.icon)
+                : (ov.iconOff || ov.iconOn || ov.icon);
+        }
+        if (!iconCls) return null;
+
         var fbOn  = (fallbackResolved && fallbackResolved.colorOn)  || '#4e9af1';
         var fbOff = (fallbackResolved && fallbackResolved.colorOff) || '#555770';
         var ovOn  = ov.on  || fbOn;
         var ovOff = ov.off || fbOff;
+
+        /* keepColor: override only the icon shape; pass through the resolver's
+           dynamic color (temperature range, alert level, wind, etc.)          */
+        if (ov.keepColor && fallbackResolved) {
+            return {
+                type:     'device',
+                cls:      iconCls + ' dz-fa-device',
+                color:    fallbackResolved.color,
+                colorOn:  fallbackResolved.colorOn  || ovOn,
+                colorOff: fallbackResolved.colorOff || ovOff
+            };
+        }
+
         return {
             type:     'device',
-            cls:      ov.icon + ' dz-fa-device',
+            cls:      iconCls + ' dz-fa-device',
             color:    isOn ? ovOn : ovOff,
             colorOn:  ovOn,
             colorOff: ovOff

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -674,12 +674,15 @@
         }
 
         /* Select icon by image slot:
-           blindsopen* → Open button, blinds* → Close button, all else → on/off */
+           blindsopen* → Open button, blinds* → Close button,
+           blindsstop  → Stop button, all else → on/off        */
         var iconCls;
         if (base === 'blindsopen') {
             iconCls = ov.iconOpen  || ov.iconOn || ov.icon;
         } else if (base === 'blinds') {
             iconCls = ov.iconClose || ov.iconOn || ov.icon;
+        } else if (base === 'blindsstop') {
+            iconCls = ov.iconStop;
         } else {
             iconCls = isOn
                 ? (ov.iconOn  || ov.icon)
@@ -750,8 +753,10 @@
             return false;
         }
 
-        /* Per-device icon override — only for 48px device state icons */
-        if (resolved.type === 'device') {
+        /* Per-device icon override — for 48px device state icons and the blinds stop button.
+           blindsstop.png matches ICON_MAP (type='icon') so we check it explicitly here so
+           that iconStop overrides are applied even though it is not a 48px device icon. */
+        if (resolved.type === 'device' || src.indexOf('blindsstop') !== -1) {
             var angDev = getDeviceFromIcon(img);
             if (angDev) {
                 var devIdx = String(angDev.idx || angDev.IDX || '');
@@ -1299,8 +1304,9 @@
 
     /* Expose a device-icon lookup for other modules (e.g. settings dialog).
        Given a Domoticz device object, returns { icon, color } replicating
-       the logic of dzLightWidget.js::getDeviceIcon() so the dialog shows
-       the same icon that Domoticz actually renders.                        */
+       the logic of dzLightWidget.js::getDeviceIcon() and
+       dzUtilityWidget.js::getDeviceIcon() so the dialog shows the same icon
+       that Domoticz actually renders.                                       */
     window._dzIconForDevice = function (device) {
         var sw      = device.SwitchType || '';
         var type    = device.Type       || '';
@@ -1316,8 +1322,9 @@
         if (sw === 'Doorbell') {
             src = 'images/doorbell48.png';
         } else if (sw.indexOf('Blind') >= 0 || sw.indexOf('Venetian') >= 0) {
-            /* Show open state so the dialog preview uses the open-arrow icon */
-            src = 'images/' + (device.TypeImg || 'blinds') + 'open48sel.png';
+            /* Show open state so the dialog preview uses the open-arrow icon.
+               dzLightWidget always uses blindsopen48sel.png regardless of TypeImg. */
+            src = 'images/blindsopen48sel.png';
         } else if (sw === 'Smoke Detector') {
             src = 'images/smoke48on.png';
         } else if (sw === 'Motion Sensor') {
@@ -1354,6 +1361,11 @@
         } else if (type === 'Group') {
             var grpSpec = DEVICE_MAP['group'];
             return grpSpec ? { icon: grpSpec.icon, color: grpSpec.on } : null;
+        } else if (type === 'Humidity') {
+            /* dzUtilityWidget renders gauge48.png for Humidity, not humidity48.png.
+               TypeImg 'hum' would alias to 'humidity' (droplet) which is wrong. */
+            var humSpec = DEVICE_MAP['gauge'];
+            return humSpec ? { icon: humSpec.icon, color: humSpec.on } : null;
         } else if (!sw && typeImg) {
             /* Sensor/meter (no SwitchType): look up TypeImg with alias normalisation */
             var normKey = ALIASES[typeImg] || typeImg;

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -1661,6 +1661,62 @@
 
     /* ── Device Icon Override Dialog ──────────────────────────────── */
 
+    /* Classify a device into an icon/color model for the override editor.
+       Returns one of:
+         'binary'    standard switch — 1 icon, on/off colors
+         'selector'  selector switch — 1 icon, active/inactive colors
+         'lock'      door lock — 2 icons (unlocked + locked) + 2 colors
+         'contact'   contact/door sensor — 2 icons (open + closed) + 2 colors
+         'blinds-2'  directional blinds, no stop — Open + Close icons
+         'blinds-3'  directional blinds with stop — Open + Stop + Close icons
+         'sensor'    value-driven sensors (temp/humidity/etc.) — 1 icon + keepColor toggle */
+    function getDeviceColorModel(d) {
+        var sw      = d.SwitchType || '';
+        var type    = d.Type       || '';
+        var typeImg = (d.TypeImg   || '').toLowerCase();
+        var subType = d.SubType    || '';
+
+        /* Blinds — directional multi-icon cards */
+        if (sw.indexOf('Blinds') >= 0 || sw === 'Venetian Blinds US' || sw === 'Venetian Blinds EU') {
+            var hasStop = (
+                subType === 'RAEX'               || subType === 'Harrison'              ||
+                subType.indexOf('A-OK')       === 0 || subType.indexOf('Hasta')       >= 0 ||
+                subType.indexOf('Media Mount')=== 0 || subType.indexOf('Forest')      === 0 ||
+                subType.indexOf('Chamberlain')=== 0 || subType.indexOf('Sunpery')     === 0 ||
+                subType.indexOf('Dolat')      === 0 || subType.indexOf('ASP')         === 0 ||
+                subType.indexOf('RFY')        === 0 || subType.indexOf('ASA')         === 0 ||
+                subType.indexOf('DC106')      === 0 || subType.indexOf('Confexx')     === 0 ||
+                sw.indexOf('Venetian Blinds') === 0 || sw.indexOf('Stop')             >= 0
+            );
+            return hasStop ? 'blinds-3' : 'blinds-2';
+        }
+
+        /* Sensors — value-driven, dynamic color, no binary on/off */
+        var sensorTypes = ['Temp', 'Temp+Hum', 'Temp+Hum+Baro', 'Humidity', 'Rain', 'UV',
+                           'Wind', 'Lux', 'Air Quality', 'Soil Moisture', 'Leaf Wetness',
+                           'Visibility', 'Barometric Pressure', 'Current', 'Current/Energy', 'Weight'];
+        if (sensorTypes.indexOf(type) >= 0 || /^temp|^humid|^rain|^uv|^wind|^alert/i.test(typeImg)) {
+            return 'sensor';
+        }
+        if (type === 'General') {
+            var sensorSubs = ['Voltage', 'Current', 'Pressure', 'Sound Level', 'Solar Radiation',
+                              'Visibility', 'Distance', 'Soil Moisture', 'Leaf Wetness',
+                              'Waterflow', 'Lux', 'Percentage', 'Managed Counter', 'Counter Incremental'];
+            if (sensorSubs.indexOf(subType) >= 0) return 'sensor';
+        }
+
+        /* Door locks — benefit from different icons per state */
+        if (sw === 'Door Lock' || sw === 'Door Lock Inverted') return 'lock';
+
+        /* Contact sensors */
+        if (sw === 'Contact' || sw === 'Door Contact') return 'contact';
+
+        /* Selector switches */
+        if (sw === 'Selector') return 'selector';
+
+        return 'binary';
+    }
+
     function openDeviceIconOverrideDialog() {
         var existing = document.getElementById('ng-ov-overlay');
         if (existing) existing.remove();
@@ -1829,7 +1885,7 @@
                 item.title = 'Jump to ' + name;
 
                 var icon = document.createElement('i');
-                icon.className = ov.icon + ' ng-ov-si-icon';
+                icon.className = (ov.iconOn || ov.iconOpen || ov.icon || 'fa-solid fa-circle-question') + ' ng-ov-si-icon';
                 icon.style.color = on;
 
                 var info = document.createElement('div');
@@ -1863,7 +1919,7 @@
                         var rowFa   = row.querySelector('.ng-ov-row-fa');
                         var editBtn = row.querySelector('.ng-ov-edit-btn');
                         var editor  = row.querySelector('.ng-ov-editor');
-                        if (rowFa)   { rowFa.className = 'fa-solid fa-circle-question ng-ov-row-fa'; rowFa.style.color = '#555770'; rowFa.style.opacity = '.45'; }
+                        if (rowFa)   { rowFa.className = (row.dataset.defIcon || 'fa-solid fa-circle-question') + ' ng-ov-row-fa'; rowFa.style.color = row.dataset.defColor || '#555770'; rowFa.style.opacity = '.55'; }
                         if (editBtn) { editBtn.innerHTML = '<i class="fa-solid fa-plus"></i>'; }
                         if (editor)  { editor.style.display = 'none'; }
                     }
@@ -1963,65 +2019,84 @@
 
         /* Render one device row with its inline editor */
         function renderRow(d) {
-            var idxStr   = String(d.idx);
-            var ov       = pending[idxStr];
-            var hasOv    = !!(ov && ov.icon);
-            var curIcon  = hasOv ? ov.icon  : 'fa-solid fa-gear';
-            var curOn    = hasOv ? (ov.on  || '#4e9af1') : '#4e9af1';
-            var curOff   = hasOv ? (ov.off || '#555770') : '#555770';
+            var idxStr = String(d.idx);
+            var ov     = pending[idxStr];
+            var model  = getDeviceColorModel(d);
+            var hasOv  = !!(ov && (ov.iconOn || ov.iconOpen || ov.icon));
 
+            /* ── Resolve defaults via the icon replacement module ─────────── */
+            var dzIcon     = typeof window._dzIconForDevice === 'function' ? window._dzIconForDevice : null;
+            var defSpecOn  = dzIcon ? dzIcon(d) : null;
+            var defIconOn  = (defSpecOn && defSpecOn.icon)  || 'fa-solid fa-circle-question';
+            var defColorOn = (defSpecOn && defSpecOn.color) || '#4e9af1';
+            var defColorOff = '#555770';
+            var defIconOpen  = defIconOn;
+            var defIconClose = defIconOn;
+
+            if (model === 'blinds-2' || model === 'blinds-3') {
+                var sOp = dzIcon ? dzIcon({ TypeImg: (d.TypeImg || '') + 'open', Status: 'On'  }) : null;
+                var sCl = dzIcon ? dzIcon({ TypeImg:  d.TypeImg  || 'blinds',   Status: 'Off' }) : null;
+                defIconOpen  = (sOp && sOp.icon)  || 'fa-solid fa-chevron-up';
+                defIconClose = (sCl && sCl.icon)  || 'fa-solid fa-chevron-down';
+                defColorOn   = (sOp && sOp.color) || defColorOn;
+            }
+
+            /* ── Current values: override or defaults ─────────────────────── */
+            var curIconOn    = hasOv ? (ov.iconOn    || ov.icon || defIconOn)                 : defIconOn;
+            var curIconOff   = hasOv ? (ov.iconOff   || ov.iconOn || ov.icon || defIconOn)    : defIconOn;
+            var curIconOpen  = hasOv ? (ov.iconOpen  || ov.iconOn || ov.icon || defIconOpen)  : defIconOpen;
+            var curIconClose = hasOv ? (ov.iconClose || ov.iconOn || ov.icon || defIconClose) : defIconClose;
+            var curIconStop  = hasOv ? (ov.iconStop  || 'fa-solid fa-stop')                   : 'fa-solid fa-stop';
+            var curOn        = hasOv ? (ov.on  || defColorOn)  : defColorOn;
+            var curOff       = hasOv ? (ov.off || defColorOff) : defColorOff;
+            var keepColor    = !!(ov && ov.keepColor);
+
+            /* ── Row element ──────────────────────────────────────────────── */
             var row = document.createElement('div');
-            row.className = 'ng-ov-row' + (hasOv ? ' ng-ov-row--active' : '');
-            row.dataset.idx  = idxStr;
-            row.dataset.name = d.Name || '';
+            row.className        = 'ng-ov-row' + (hasOv ? ' ng-ov-row--active' : '');
+            row.dataset.idx      = idxStr;
+            row.dataset.name     = d.Name || '';
+            row.dataset.defIcon  = defIconOn;
+            row.dataset.defColor = defColorOn;
 
-            /* Row summary line */
+            /* ── Summary line ─────────────────────────────────────────────── */
             var summary = document.createElement('div');
             summary.className = 'ng-ov-row-summary';
+            var isBlinds = (model === 'blinds-2' || model === 'blinds-3');
+
+            var iconHtml = isBlinds
+                ? '<span class="ng-ov-row-icon ng-ov-row-icon--multi">' +
+                  '<i class="' + curIconOpen  + ' ng-ov-row-fa ng-ov-row-fa--open"  style="color:' + curOn  + ';' + (hasOv ? '' : 'opacity:.55') + '"></i>' +
+                  '<i class="' + curIconClose + ' ng-ov-row-fa ng-ov-row-fa--close" style="color:' + curOff + ';' + (hasOv ? '' : 'opacity:.55') + '"></i>' +
+                  '</span>'
+                : '<span class="ng-ov-row-icon">' +
+                  '<i class="' + curIconOn + ' ng-ov-row-fa" style="color:' + curOn + ';' + (hasOv ? '' : 'opacity:.55') + '"></i>' +
+                  '</span>';
+
+            var modelBadge = model === 'blinds-2' ? ' <span class="ng-ov-model-badge">2-icon</span>'
+                           : model === 'blinds-3' ? ' <span class="ng-ov-model-badge">3-icon</span>'
+                           : model === 'sensor'   ? ' <span class="ng-ov-model-badge ng-ov-model-badge--sensor">sensor</span>'
+                           : '';
+            var swLabel = (d.SwitchType && d.SwitchType !== d.Type) ? ' &middot; ' + d.SwitchType : '';
             summary.innerHTML =
-                '<span class="ng-ov-row-icon">' +
-                '  <i class="' + (hasOv ? curIcon : 'fa-solid fa-circle-question') + ' ng-ov-row-fa"' +
-                '     style="color:' + (hasOv ? curOn : '#555770') + ';' + (hasOv ? '' : 'opacity:.45') + '"></i>' +
-                '</span>' +
+                iconHtml +
                 '<span class="ng-bl-row-info">' +
                 '  <span class="ng-bl-row-name">' + (d.Name || 'Device ' + d.idx) + '</span>' +
-                '  <span class="ng-bl-row-type">IDX&nbsp;' + d.idx + (d.Type ? ' &middot; ' + d.Type : '') + (d.HardwareName ? ' &middot; ' + d.HardwareName : '') + '</span>' +
+                '  <span class="ng-bl-row-type">IDX&nbsp;' + d.idx +
+                    (d.Type ? ' &middot; ' + d.Type : '') + swLabel + modelBadge +
+                '  </span>' +
                 '</span>' +
                 '<button class="ng-ov-edit-btn" type="button" title="' + (hasOv ? 'Edit override' : 'Add override') + '">' +
                 '  <i class="fa-solid ' + (hasOv ? 'fa-pen-to-square' : 'fa-plus') + '"></i>' +
                 '</button>';
             row.appendChild(summary);
 
-            /* Inline editor */
+            /* ── Inline editor ────────────────────────────────────────────── */
             var editor = document.createElement('div');
-            editor.className = 'ng-ov-editor';
+            editor.className   = 'ng-ov-editor';
             editor.style.display = 'none';
 
-            /* Preview */
-            var preview = document.createElement('div');
-            preview.className = 'ng-ov-preview';
-            var previewI = document.createElement('i');
-            previewI.className = curIcon + ' ng-ov-preview-icon';
-            previewI.style.color = curOn;
-            var previewName = document.createElement('span');
-            previewName.className = 'ng-ov-preview-name';
-            previewName.textContent = d.Name || 'Device';
-            preview.appendChild(previewI);
-            preview.appendChild(previewName);
-            editor.appendChild(preview);
-
-            /* Icon picker */
-            var picker = buildIconPicker(curIcon, function (cls) {
-                curIcon = cls;
-                previewI.className = cls + ' ng-ov-preview-icon';
-                previewI.style.color = curOn;
-                var rowFa = summary.querySelector('.ng-ov-row-fa');
-                if (rowFa) { rowFa.className = cls + ' ng-ov-row-fa'; rowFa.style.color = curOn; rowFa.style.opacity = ''; }
-                commitOverride();
-            });
-            editor.appendChild(picker);
-
-            /* Color pickers — reuse the settings-panel HSV canvas picker */
+            /* colorRow is shared across all models; built and populated per-model below */
             var colorRow = document.createElement('div');
             colorRow.className = 'ng-ov-color-row';
 
@@ -2031,6 +2106,7 @@
                 '#c8a0ff','#ab47bc','#78909c','#555770'
             ];
 
+            /* HSV color picker (unchanged) */
             function makeOvColorPicker(labelText, initialColor, onChange) {
                 var wrap = document.createElement('div');
                 wrap.className = 'ng-ov-color-label';
@@ -2179,45 +2255,282 @@
                 return wrap;
             }
 
-            var onField  = makeOvColorPicker('On color',  curOn,  function (v) { curOn  = v; previewI.style.color = v; var fa = summary.querySelector('.ng-ov-row-fa'); if (fa) fa.style.color = v; commitOverride(); });
-            var offField = makeOvColorPicker('Off color', curOff, function (v) { curOff = v; commitOverride(); });
+            /* ── Editor helpers ───────────────────────────────────────────── */
 
-            var removeBtn = document.createElement('button');
-            removeBtn.type = 'button';
-            removeBtn.className = 'ng-ov-remove-btn';
-            removeBtn.innerHTML = '<i class="fa-solid fa-trash-can"></i> Remove';
-            removeBtn.addEventListener('click', function () {
-                delete pending[idxStr];
-                row.classList.remove('ng-ov-row--active');
-                var editBtn = summary.querySelector('.ng-ov-edit-btn');
-                if (editBtn) editBtn.innerHTML = '<i class="fa-solid fa-plus"></i>';
-                var rowFa = summary.querySelector('.ng-ov-row-fa');
-                if (rowFa) { rowFa.className = 'fa-solid fa-circle-question ng-ov-row-fa'; rowFa.style.color = '#555770'; rowFa.style.opacity = '.45'; }
-                editor.style.display = 'none';
-                updateCount();
-            });
+            /* One preview slot: icon + optional label underneath */
+            function makePreviewSlot(iconCls, color, labelText) {
+                var slot = document.createElement('div');
+                slot.className = 'ng-ov-preview-slot';
+                var ic = document.createElement('i');
+                ic.className   = iconCls + ' ng-ov-preview-icon';
+                ic.style.color = color;
+                slot.appendChild(ic);
+                if (labelText) {
+                    var lbl = document.createElement('span');
+                    lbl.className   = 'ng-ov-preview-label';
+                    lbl.textContent = labelText;
+                    slot.appendChild(lbl);
+                }
+                return slot;
+            }
 
-            colorRow.appendChild(onField);
-            colorRow.appendChild(offField);
-            colorRow.appendChild(removeBtn);
-            editor.appendChild(colorRow);
+            function updateSlotIcon(slot, iconCls, color) {
+                var ic = slot && slot.querySelector('.ng-ov-preview-icon');
+                if (ic) { ic.className = iconCls + ' ng-ov-preview-icon'; ic.style.color = color; }
+            }
 
+            /* Labeled wrapper around an icon picker grid */
+            function makePickerSection(labelText, noteText, initialCls, onSelectFn) {
+                var wrap = document.createElement('div');
+                wrap.className = 'ng-ov-picker-section';
+                if (labelText) {
+                    var lbl = document.createElement('div');
+                    lbl.className   = 'ng-ov-picker-label';
+                    lbl.textContent = labelText;
+                    wrap.appendChild(lbl);
+                }
+                if (noteText) {
+                    var note = document.createElement('div');
+                    note.className   = 'ng-ov-picker-note';
+                    note.textContent = noteText;
+                    wrap.appendChild(note);
+                }
+                wrap.appendChild(buildIconPicker(initialCls, onSelectFn));
+                return wrap;
+            }
+
+            /* Sync the summary's single primary icon */
+            function updateSummaryPrimary() {
+                var fa = summary.querySelector('.ng-ov-row-fa');
+                if (fa) { fa.className = curIconOn + ' ng-ov-row-fa'; fa.style.color = curOn; fa.style.opacity = ''; }
+            }
+
+            /* Sync the summary's blinds open + close icons */
+            function updateSummaryBlinds() {
+                var fo = summary.querySelector('.ng-ov-row-fa--open');
+                var fc = summary.querySelector('.ng-ov-row-fa--close');
+                if (fo) { fo.className = curIconOpen  + ' ng-ov-row-fa ng-ov-row-fa--open';  fo.style.color = curOn;  fo.style.opacity = ''; }
+                if (fc) { fc.className = curIconClose + ' ng-ov-row-fa ng-ov-row-fa--close'; fc.style.color = curOff; fc.style.opacity = ''; }
+            }
+
+            /* Remove button with model-aware reset callback */
+            function buildRemoveBtn(onRemove) {
+                var btn = document.createElement('button');
+                btn.type      = 'button';
+                btn.className = 'ng-ov-remove-btn';
+                btn.innerHTML = '<i class="fa-solid fa-trash-can"></i> Remove';
+                btn.addEventListener('click', function () {
+                    delete pending[idxStr];
+                    row.classList.remove('ng-ov-row--active');
+                    var eb = summary.querySelector('.ng-ov-edit-btn');
+                    if (eb) eb.innerHTML = '<i class="fa-solid fa-plus"></i>';
+                    editor.style.display = 'none';
+                    onRemove();
+                    updateCount();
+                });
+                return btn;
+            }
+
+            /* Persist pending entry + mark row active */
             function commitOverride() {
-                if (!curIcon) return;
-                pending[idxStr] = { icon: curIcon, on: curOn, off: curOff, name: d.Name || '' };
+                var obj = { name: d.Name || '', on: curOn, off: curOff };
+                if (model === 'blinds-2' || model === 'blinds-3') {
+                    obj.iconOpen  = curIconOpen;
+                    obj.iconClose = curIconClose;
+                    obj.iconOn    = curIconOpen;   /* sidebar display fallback */
+                    if (model === 'blinds-3') obj.iconStop = curIconStop;
+                } else if (model === 'lock' || model === 'contact') {
+                    obj.iconOn  = curIconOn;
+                    obj.iconOff = curIconOff;
+                } else if (model === 'sensor') {
+                    obj.iconOn    = curIconOn;
+                    obj.keepColor = keepColor;
+                } else {
+                    obj.iconOn = curIconOn;
+                }
+                pending[idxStr] = obj;
                 row.classList.add('ng-ov-row--active');
-                var editBtn = summary.querySelector('.ng-ov-edit-btn');
-                if (editBtn) editBtn.innerHTML = '<i class="fa-solid fa-pen-to-square"></i>';
+                var eb = summary.querySelector('.ng-ov-edit-btn');
+                if (eb) eb.innerHTML = '<i class="fa-solid fa-pen-to-square"></i>';
                 updateCount();
             }
 
-            /* Row click: apply preset (select mode) or open editor (normal mode) */
-            summary.addEventListener('click', function (e) {
-                if (_pendingPreset) {
-                    applyPresetToRow(idxStr);
-                    return;
+            /* ── Build editor body per model ──────────────────────────────── */
+
+            if (model === 'blinds-2' || model === 'blinds-3') {
+                var preview   = document.createElement('div');
+                preview.className = 'ng-ov-preview ng-ov-preview--multi';
+                var slotOpen  = makePreviewSlot(curIconOpen,  curOn,     'Open');
+                var slotStop  = model === 'blinds-3' ? makePreviewSlot(curIconStop, '#b0b3c6', 'Stop') : null;
+                var slotClose = makePreviewSlot(curIconClose, curOff,    'Close');
+                preview.appendChild(slotOpen);
+                if (slotStop) preview.appendChild(slotStop);
+                preview.appendChild(slotClose);
+                editor.appendChild(preview);
+
+                editor.appendChild(makePickerSection('Open button icon',
+                    'First icon — highlights when blind is open', curIconOpen, function (cls) {
+                        curIconOpen = cls;
+                        updateSlotIcon(slotOpen, curIconOpen, curOn);
+                        updateSummaryBlinds();
+                        commitOverride();
+                    }));
+                if (model === 'blinds-3') {
+                    editor.appendChild(makePickerSection('Stop button icon',
+                        'Middle icon — click to stop movement', curIconStop, function (cls) {
+                            curIconStop = cls;
+                            updateSlotIcon(slotStop, curIconStop, '#b0b3c6');
+                            commitOverride();
+                        }));
                 }
-                /* Normal: only toggle editor when the edit button itself was clicked */
+                editor.appendChild(makePickerSection('Close button icon',
+                    'Last icon — highlights when blind is closed', curIconClose, function (cls) {
+                        curIconClose = cls;
+                        updateSlotIcon(slotClose, curIconClose, curOff);
+                        updateSummaryBlinds();
+                        commitOverride();
+                    }));
+
+                colorRow.appendChild(makeOvColorPicker('Open color', curOn, function (v) {
+                    curOn = v; updateSlotIcon(slotOpen, curIconOpen, curOn); updateSummaryBlinds(); commitOverride();
+                }));
+                colorRow.appendChild(makeOvColorPicker('Close color', curOff, function (v) {
+                    curOff = v; updateSlotIcon(slotClose, curIconClose, curOff); updateSummaryBlinds(); commitOverride();
+                }));
+                colorRow.appendChild(buildRemoveBtn(function () {
+                    curIconOpen = defIconOpen; curIconClose = defIconClose; curIconStop = 'fa-solid fa-stop';
+                    curOn = defColorOn; curOff = defColorOff;
+                    updateSummaryBlinds();
+                    var fo = summary.querySelector('.ng-ov-row-fa--open');
+                    var fc = summary.querySelector('.ng-ov-row-fa--close');
+                    if (fo) fo.style.opacity = '.55';
+                    if (fc) fc.style.opacity = '.55';
+                }));
+                editor.appendChild(colorRow);
+
+            } else if (model === 'sensor') {
+                var preview    = document.createElement('div');
+                preview.className = 'ng-ov-preview';
+                var slotSensor = makePreviewSlot(curIconOn, keepColor ? defColorOn : curOn, null);
+                var nameSpan   = document.createElement('span');
+                nameSpan.className   = 'ng-ov-preview-name';
+                nameSpan.textContent = d.Name || 'Device';
+                preview.appendChild(slotSensor);
+                preview.appendChild(nameSpan);
+                editor.appendChild(preview);
+
+                editor.appendChild(makePickerSection('Icon',
+                    'Replaces the dynamic sensor range icon (temperature, humidity, etc.)', curIconOn, function (cls) {
+                        curIconOn = cls;
+                        updateSlotIcon(slotSensor, curIconOn, keepColor ? defColorOn : curOn);
+                        updateSummaryPrimary();
+                        commitOverride();
+                    }));
+
+                var keepWrap = document.createElement('div');
+                keepWrap.className = 'ng-ov-keepcolor-wrap';
+                var keepCb  = document.createElement('input');
+                keepCb.type    = 'checkbox';
+                keepCb.id      = 'ng-ov-kc-' + idxStr;
+                keepCb.checked = keepColor;
+                var keepLbl = document.createElement('label');
+                keepLbl.setAttribute('for', 'ng-ov-kc-' + idxStr);
+                keepLbl.textContent = 'Keep dynamic color (temperature range, alert levels, etc.)';
+                keepWrap.appendChild(keepCb);
+                keepWrap.appendChild(keepLbl);
+                keepCb.addEventListener('change', function () {
+                    keepColor = this.checked;
+                    updateSlotIcon(slotSensor, curIconOn, keepColor ? defColorOn : curOn);
+                    commitOverride();
+                });
+                editor.appendChild(keepWrap);
+
+                colorRow.appendChild(makeOvColorPicker('Accent color', curOn, function (v) {
+                    curOn = v;
+                    if (!keepColor) updateSlotIcon(slotSensor, curIconOn, v);
+                    commitOverride();
+                }));
+                colorRow.appendChild(buildRemoveBtn(function () {
+                    curIconOn = defIconOn; curOn = defColorOn; keepColor = false;
+                    var fa = summary.querySelector('.ng-ov-row-fa');
+                    if (fa) { fa.className = defIconOn + ' ng-ov-row-fa'; fa.style.color = defColorOn; fa.style.opacity = '.55'; }
+                }));
+                editor.appendChild(colorRow);
+
+            } else if (model === 'lock' || model === 'contact') {
+                var activeLabel   = model === 'lock' ? 'Unlocked' : 'Open';
+                var inactiveLabel = model === 'lock' ? 'Locked'   : 'Closed';
+                var preview      = document.createElement('div');
+                preview.className = 'ng-ov-preview ng-ov-preview--multi';
+                var slotActive   = makePreviewSlot(curIconOn,  curOn,  activeLabel);
+                var slotInactive = makePreviewSlot(curIconOff, curOff, inactiveLabel);
+                preview.appendChild(slotActive);
+                preview.appendChild(slotInactive);
+                editor.appendChild(preview);
+
+                editor.appendChild(makePickerSection(activeLabel + ' icon', null, curIconOn, function (cls) {
+                    curIconOn = cls;
+                    updateSlotIcon(slotActive, curIconOn, curOn);
+                    updateSummaryPrimary();
+                    commitOverride();
+                }));
+                editor.appendChild(makePickerSection(inactiveLabel + ' icon', null, curIconOff, function (cls) {
+                    curIconOff = cls;
+                    updateSlotIcon(slotInactive, curIconOff, curOff);
+                    commitOverride();
+                }));
+
+                colorRow.appendChild(makeOvColorPicker(activeLabel + ' color', curOn, function (v) {
+                    curOn = v; updateSlotIcon(slotActive, curIconOn, curOn); updateSummaryPrimary(); commitOverride();
+                }));
+                colorRow.appendChild(makeOvColorPicker(inactiveLabel + ' color', curOff, function (v) {
+                    curOff = v; updateSlotIcon(slotInactive, curIconOff, curOff); commitOverride();
+                }));
+                colorRow.appendChild(buildRemoveBtn(function () {
+                    curIconOn = defIconOn; curIconOff = defIconOn; curOn = defColorOn; curOff = defColorOff;
+                    var fa = summary.querySelector('.ng-ov-row-fa');
+                    if (fa) { fa.className = defIconOn + ' ng-ov-row-fa'; fa.style.color = defColorOn; fa.style.opacity = '.55'; }
+                }));
+                editor.appendChild(colorRow);
+
+            } else {
+                /* binary / selector / media: single icon, 2 colors */
+                var labelOn  = model === 'selector' ? 'Active color'   : 'On color';
+                var labelOff = model === 'selector' ? 'Inactive color' : 'Off color';
+                var preview  = document.createElement('div');
+                preview.className = 'ng-ov-preview';
+                var slotMain = makePreviewSlot(curIconOn, curOn, null);
+                var nameSpan = document.createElement('span');
+                nameSpan.className   = 'ng-ov-preview-name';
+                nameSpan.textContent = d.Name || 'Device';
+                preview.appendChild(slotMain);
+                preview.appendChild(nameSpan);
+                editor.appendChild(preview);
+
+                editor.appendChild(makePickerSection(null, null, curIconOn, function (cls) {
+                    curIconOn = cls;
+                    updateSlotIcon(slotMain, curIconOn, curOn);
+                    updateSummaryPrimary();
+                    commitOverride();
+                }));
+
+                colorRow.appendChild(makeOvColorPicker(labelOn, curOn, function (v) {
+                    curOn = v; updateSlotIcon(slotMain, curIconOn, v); updateSummaryPrimary(); commitOverride();
+                }));
+                colorRow.appendChild(makeOvColorPicker(labelOff, curOff, function (v) {
+                    curOff = v; commitOverride();
+                }));
+                colorRow.appendChild(buildRemoveBtn(function () {
+                    curIconOn = defIconOn; curOn = defColorOn; curOff = defColorOff;
+                    var fa = summary.querySelector('.ng-ov-row-fa');
+                    if (fa) { fa.className = defIconOn + ' ng-ov-row-fa'; fa.style.color = defColorOn; fa.style.opacity = '.55'; }
+                }));
+                editor.appendChild(colorRow);
+            }
+
+            /* ── Click to toggle editor ───────────────────────────────────── */
+            summary.addEventListener('click', function (e) {
+                if (_pendingPreset) { applyPresetToRow(idxStr); return; }
                 if (!e.target.closest('.ng-ov-edit-btn')) return;
                 var open = editor.style.display !== 'none';
                 listEl.querySelectorAll('.ng-ov-editor').forEach(function (ed) { ed.style.display = 'none'; });
@@ -2285,7 +2598,7 @@
         /* Apply the pending preset to a device row */
         function applyPresetToRow(idxStr) {
             var pp = _pendingPreset;
-            pending[idxStr] = { icon: pp.icon, on: pp.on, off: pp.off, name: pending[idxStr] && pending[idxStr].name || pp.label };
+            pending[idxStr] = { iconOn: pp.icon, on: pp.on, off: pp.off, name: pending[idxStr] && pending[idxStr].name || pp.label };
             var row = listEl.querySelector('[data-idx="' + idxStr + '"]');
             if (row) {
                 row.classList.add('ng-ov-row--active');

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -283,7 +283,9 @@
         liveToastFilter:    'meaningful',
         liveToastDuration:  '4',
         liveToastPosition:  'bottom-right',
-        toastBlacklist:     '[]'
+        toastBlacklist:     '[]',
+
+        deviceIconOverrides: '{}'
     };
 
     var _settings      = null;
@@ -1020,6 +1022,17 @@
 
         // Update toast stack position if the system is already running
         if (window.ngUpdateToastPosition) window.ngUpdateToastPosition();
+
+        // Push device icon overrides to the icon replacement module
+        if (typeof window._dzSetDeviceIconOverrides === 'function') {
+            try {
+                var raw = _settings.deviceIconOverrides || '{}';
+                var overrides = typeof raw === 'string' ? JSON.parse(raw) : raw;
+                window._dzSetDeviceIconOverrides(overrides);
+            } catch (e) {
+                window._dzSetDeviceIconOverrides({});
+            }
+        }
     }
 
     /* ── Build the settings panel HTML ─────────────────────────── */
@@ -1187,6 +1200,26 @@
             '    <i class="fa-solid fa-filter-circle-xmark"></i> Manage</button>' +
             '</div>' +
             '</div>' +
+
+            (function () {
+                var ovRaw = (s.deviceIconOverrides || '{}');
+                var ovCount = 0;
+                try { ovCount = Object.keys(typeof ovRaw === 'string' ? JSON.parse(ovRaw) : ovRaw).length; } catch (e) {}
+                var badge = ovCount > 0
+                    ? ' <span class="ng-override-badge">' + ovCount + '</span>'
+                    : '';
+                return '<div class="ng-settings-section">' +
+                    '<div class="ng-section-header"><i class="fa-solid fa-icons"></i> Device Icon Overrides</div>' +
+                    '<div class="ng-setting-row ng-setting-row--action">' +
+                    '  <div class="ng-setting-info">' +
+                    '    <span class="ng-setting-label">Per-Device Icons' + badge + '</span>' +
+                    '    <span class="ng-setting-desc">Assign any Font Awesome icon &amp; custom on/off colors to individual devices</span>' +
+                    '  </div>' +
+                    '  <button class="ng-action-chip" id="ng-override-manage-btn">' +
+                    '    <i class="fa-solid fa-wand-magic-sparkles"></i> Manage</button>' +
+                    '</div>' +
+                    '</div>';
+            })() +
 
             /* Right column: Color panels (together) */
             '<div class="ng-settings-section ng-settings-section--colors">' +
@@ -1626,6 +1659,716 @@
             });
     }
 
+    /* ── Device Icon Override Dialog ──────────────────────────────── */
+
+    function openDeviceIconOverrideDialog() {
+        var existing = document.getElementById('ng-ov-overlay');
+        if (existing) existing.remove();
+
+        // Parse current overrides
+        var currentOv = {};
+        try {
+            var raw = (window.dzNightglassSettings && window.dzNightglassSettings.get('deviceIconOverrides')) || '{}';
+            currentOv = typeof raw === 'string' ? JSON.parse(raw) : (raw || {});
+        } catch (e) {}
+
+        // Popular quick-override suggestions
+        var POPULAR_OVERRIDES = [
+            { label: 'WiFi Router',     icon: 'fa-solid fa-wifi',              on: '#4caf7d', off: '#555770' },
+            { label: 'Network Switch',  icon: 'fa-solid fa-network-wired',     on: '#4e9af1', off: '#555770' },
+            { label: 'Car',             icon: 'fa-solid fa-car',               on: '#4e9af1', off: '#555770' },
+            { label: 'EV Charger',      icon: 'fa-solid fa-charging-station',  on: '#4caf7d', off: '#555770' },
+            { label: 'Baby Monitor',    icon: 'fa-solid fa-baby',              on: '#c8a0ff', off: '#555770' },
+            { label: 'Camera',          icon: 'fa-solid fa-camera',            on: '#4e9af1', off: '#555770' },
+            { label: 'Doorbell',        icon: 'fa-solid fa-bell-concierge',    on: '#f0a832', off: '#555770' },
+            { label: 'Freezer',         icon: 'fa-solid fa-temperature-low',   on: '#29b6f6', off: '#555770' },
+            { label: 'Washing Machine', icon: 'fa-solid fa-shirt',             on: '#4e9af1', off: '#555770' },
+            { label: 'Dishwasher',      icon: 'fa-solid fa-sink',              on: '#4e9af1', off: '#555770' },
+            { label: 'Solar Panel',     icon: 'fa-solid fa-solar-panel',       on: '#f0a832', off: '#555770' },
+            { label: 'Battery/UPS',     icon: 'fa-solid fa-car-battery',       on: '#4caf7d', off: '#555770' },
+            { label: 'Server',          icon: 'fa-solid fa-server',            on: '#4e9af1', off: '#555770' },
+            { label: 'Smart Plug',      icon: 'fa-solid fa-plug',              on: '#4caf7d', off: '#555770' },
+            { label: 'Boiler',          icon: 'fa-solid fa-fire-flame-curved', on: '#ff7043', off: '#555770' },
+            { label: 'Ventilation',     icon: 'fa-solid fa-fan',               on: '#29b6f6', off: '#555770' },
+            { label: 'Garage Door',     icon: 'fa-solid fa-warehouse',         on: '#f0a832', off: '#4caf7d' },
+            { label: 'Pet Feeder',      icon: 'fa-solid fa-paw',               on: '#f0a832', off: '#555770' },
+            { label: 'NAS / Disk',      icon: 'fa-solid fa-hard-drive',        on: '#4e9af1', off: '#555770' },
+            { label: 'Vacuum Robot',    icon: 'fa-solid fa-robot',             on: '#4e9af1', off: '#555770' }
+        ];
+
+        // FA 6 Free Solid icon set for picker
+        var FA_ICONS = [
+            'fa-solid fa-wifi',              'fa-solid fa-network-wired',     'fa-solid fa-router',
+            'fa-solid fa-satellite-dish',    'fa-solid fa-tower-broadcast',   'fa-solid fa-signal',
+            'fa-solid fa-house',             'fa-solid fa-house-chimney',     'fa-solid fa-door-closed',
+            'fa-solid fa-door-open',         'fa-solid fa-window-maximize',   'fa-solid fa-warehouse',
+            'fa-solid fa-building',          'fa-solid fa-couch',             'fa-solid fa-bed',
+            'fa-solid fa-bath',              'fa-solid fa-sink',              'fa-solid fa-toilet',
+            'fa-solid fa-stairs',            'fa-solid fa-table',             'fa-solid fa-chair',
+            'fa-solid fa-lightbulb',         'fa-solid fa-circle-half-stroke','fa-solid fa-sun',
+            'fa-solid fa-moon',              'fa-solid fa-star',              'fa-solid fa-lamp',
+            'fa-solid fa-tv',                'fa-solid fa-display',           'fa-solid fa-computer',
+            'fa-solid fa-server',            'fa-solid fa-hard-drive',        'fa-solid fa-print',
+            'fa-solid fa-phone',             'fa-solid fa-mobile-screen',     'fa-solid fa-tablet',
+            'fa-solid fa-headphones',        'fa-solid fa-volume-high',       'fa-solid fa-music',
+            'fa-solid fa-gamepad',           'fa-solid fa-camera',            'fa-solid fa-video',
+            'fa-solid fa-blender',           'fa-solid fa-mug-hot',           'fa-solid fa-utensils',
+            'fa-solid fa-shirt',             'fa-solid fa-broom',             'fa-solid fa-baby',
+            'fa-solid fa-baby-carriage',     'fa-solid fa-robot',
+            'fa-solid fa-bolt',              'fa-solid fa-plug',              'fa-solid fa-charging-station',
+            'fa-solid fa-solar-panel',       'fa-solid fa-car-battery',       'fa-solid fa-battery-full',
+            'fa-solid fa-fire',              'fa-solid fa-fire-flame-curved', 'fa-solid fa-gauge',
+            'fa-solid fa-temperature-half',  'fa-solid fa-thermometer',       'fa-solid fa-snowflake',
+            'fa-solid fa-fan',               'fa-solid fa-wind',              'fa-solid fa-cloud',
+            'fa-solid fa-cloud-rain',        'fa-solid fa-umbrella',          'fa-solid fa-droplet',
+            'fa-solid fa-temperature-low',   'fa-solid fa-temperature-high',  'fa-solid fa-smog',
+            'fa-solid fa-seedling',          'fa-solid fa-leaf',              'fa-solid fa-tree',
+            'fa-solid fa-lock',              'fa-solid fa-lock-open',         'fa-solid fa-shield-halved',
+            'fa-solid fa-bell',              'fa-solid fa-bell-concierge',    'fa-solid fa-triangle-exclamation',
+            'fa-solid fa-circle-exclamation','fa-solid fa-eye',               'fa-solid fa-person-running',
+            'fa-solid fa-dog',               'fa-solid fa-paw',               'fa-solid fa-cat',
+            'fa-solid fa-car',               'fa-solid fa-car-side',          'fa-solid fa-truck',
+            'fa-solid fa-motorcycle',        'fa-solid fa-bicycle',           'fa-solid fa-plane',
+            'fa-solid fa-tractor',           'fa-solid fa-bus',
+            'fa-solid fa-water-ladder',      'fa-solid fa-hand-holding-droplet','fa-solid fa-faucet',
+            'fa-solid fa-pump-soap',         'fa-solid fa-spray-can',         'fa-solid fa-shovel',
+            'fa-solid fa-heart-pulse',       'fa-solid fa-weight-scale',      'fa-solid fa-lungs',
+            'fa-solid fa-syringe',           'fa-solid fa-pills',             'fa-solid fa-bed-pulse',
+            'fa-solid fa-gear',              'fa-solid fa-wrench',            'fa-solid fa-screwdriver',
+            'fa-solid fa-toolbox',           'fa-solid fa-box',               'fa-solid fa-bookmark',
+            'fa-solid fa-flag',              'fa-solid fa-circle-dot',        'fa-solid fa-power-off',
+            'fa-solid fa-toggle-on',         'fa-solid fa-sliders',           'fa-solid fa-clock',
+            'fa-solid fa-calendar',          'fa-solid fa-location-dot',      'fa-solid fa-map-location-dot',
+            'fa-solid fa-microchip',         'fa-solid fa-cpu',               'fa-solid fa-memory'
+        ];
+
+        // Mutable copy of current overrides
+        var pending = {};
+        Object.keys(currentOv).forEach(function (k) {
+            pending[k] = { icon: currentOv[k].icon, on: currentOv[k].on, off: currentOv[k].off, name: currentOv[k].name || '' };
+        });
+
+        var overlay = document.createElement('div');
+        overlay.id = 'ng-ov-overlay';
+        overlay.className = 'ng-bl-overlay';
+        overlay.innerHTML =
+            '<div class="ng-bl-dialog ng-ov-dialog" role="dialog" aria-label="Device Icon Overrides">' +
+            '  <div class="ng-bl-header">' +
+            '    <div class="ng-bl-title">' +
+            '      <i class="fa-solid fa-icons"></i>' +
+            '      <span>Device Icon Overrides</span>' +
+            '    </div>' +
+            '    <button class="ng-bl-close" aria-label="Close"><i class="fa-solid fa-xmark"></i></button>' +
+            '  </div>' +
+            '  <div class="ng-ov-body">' +
+            '    <div class="ng-ov-main">' +
+            '      <div class="ng-ov-popular">' +
+            '        <div class="ng-ov-popular-label"><i class="fa-solid fa-wand-magic-sparkles"></i> Quick Presets — click to assign to a device</div>' +
+            '        <div class="ng-ov-chips" id="ng-ov-chips"></div>' +
+            '      </div>' +
+            '      <div class="ng-bl-search-wrap">' +
+            '        <i class="fa-solid fa-magnifying-glass ng-bl-search-icon"></i>' +
+            '        <input class="ng-bl-search" id="ng-ov-search" placeholder="Search devices…" autocomplete="off">' +
+            '      </div>' +
+            '      <div class="ng-bl-list ng-ov-list" id="ng-ov-list">' +
+            '        <div class="ng-bl-loading"><i class="fa-solid fa-spinner fa-spin"></i> Loading devices…</div>' +
+            '      </div>' +
+            '    </div>' +
+            '    <div class="ng-ov-sidebar" id="ng-ov-sidebar">' +
+            '      <div class="ng-ov-sidebar-header">' +
+            '        <i class="fa-solid fa-list-check"></i> Active' +
+            '        <span class="ng-ov-sidebar-count" id="ng-ov-sidebar-count">0</span>' +
+            '      </div>' +
+            '      <div class="ng-ov-sidebar-list" id="ng-ov-sidebar-list">' +
+            '        <div class="ng-ov-sidebar-empty">No overrides yet</div>' +
+            '      </div>' +
+            '    </div>' +
+            '  </div>' +
+            '  <div class="ng-bl-footer">' +
+            '    <span class="ng-bl-count" id="ng-ov-count"></span>' +
+            '    <div class="ng-bl-footer-btns">' +
+            '      <button class="ng-bl-btn ng-bl-btn--cancel">Cancel</button>' +
+            '      <button class="ng-bl-btn ng-bl-btn--save">Save Overrides</button>' +
+            '    </div>' +
+            '  </div>' +
+            '</div>';
+
+        document.body.appendChild(overlay);
+        requestAnimationFrame(function () { overlay.classList.add('ng-bl-overlay--open'); });
+
+        var listEl         = overlay.querySelector('#ng-ov-list');
+        var searchEl       = overlay.querySelector('#ng-ov-search');
+        var countEl        = overlay.querySelector('#ng-ov-count');
+        var chipsEl        = overlay.querySelector('#ng-ov-chips');
+        var sidebarListEl  = overlay.querySelector('#ng-ov-sidebar-list');
+        var sidebarCountEl = overlay.querySelector('#ng-ov-sidebar-count');
+
+        function close() {
+            overlay.classList.remove('ng-bl-overlay--open');
+            setTimeout(function () { overlay.remove(); }, 260);
+        }
+
+        function renderSidebar() {
+            var keys = Object.keys(pending);
+            if (sidebarCountEl) sidebarCountEl.textContent = keys.length;
+            if (!sidebarListEl) return;
+            if (!keys.length) {
+                sidebarListEl.innerHTML = '<div class="ng-ov-sidebar-empty">No overrides yet</div>';
+                return;
+            }
+            sidebarListEl.innerHTML = '';
+            keys.forEach(function (idxStr) {
+                var ov   = pending[idxStr];
+                var name = ov.name || ('IDX ' + idxStr);
+                var on   = ov.on  || '#4e9af1';
+                var off  = ov.off || '#555770';
+
+                var item = document.createElement('div');
+                item.className = 'ng-ov-si';
+                item.dataset.idx = idxStr;
+                item.title = 'Jump to ' + name;
+
+                var icon = document.createElement('i');
+                icon.className = ov.icon + ' ng-ov-si-icon';
+                icon.style.color = on;
+
+                var info = document.createElement('div');
+                info.className = 'ng-ov-si-info';
+
+                var nameEl = document.createElement('span');
+                nameEl.className = 'ng-ov-si-name';
+                nameEl.textContent = name;
+
+                var dots = document.createElement('span');
+                dots.className = 'ng-ov-si-dots';
+                dots.innerHTML =
+                    '<span class="ng-ov-si-dot" style="background:' + on  + '" title="On: ' + on + '"></span>' +
+                    '<span class="ng-ov-si-dot" style="background:' + off + '" title="Off: ' + off + '"></span>';
+
+                info.appendChild(nameEl);
+                info.appendChild(dots);
+
+                var removeBtn = document.createElement('button');
+                removeBtn.type = 'button';
+                removeBtn.className = 'ng-ov-si-remove';
+                removeBtn.title = 'Remove override';
+                removeBtn.innerHTML = '<i class="fa-solid fa-xmark"></i>';
+                removeBtn.addEventListener('click', function (e) {
+                    e.stopPropagation();
+                    delete pending[idxStr];
+                    /* Reset the corresponding device row if visible */
+                    var row = listEl.querySelector('[data-idx="' + idxStr + '"]');
+                    if (row) {
+                        row.classList.remove('ng-ov-row--active');
+                        var rowFa   = row.querySelector('.ng-ov-row-fa');
+                        var editBtn = row.querySelector('.ng-ov-edit-btn');
+                        var editor  = row.querySelector('.ng-ov-editor');
+                        if (rowFa)   { rowFa.className = 'fa-solid fa-circle-question ng-ov-row-fa'; rowFa.style.color = '#555770'; rowFa.style.opacity = '.45'; }
+                        if (editBtn) { editBtn.innerHTML = '<i class="fa-solid fa-plus"></i>'; }
+                        if (editor)  { editor.style.display = 'none'; }
+                    }
+                    updateCount();
+                });
+
+                item.appendChild(icon);
+                item.appendChild(info);
+                item.appendChild(removeBtn);
+
+                /* Click to jump to + briefly highlight the device row */
+                item.addEventListener('click', function () {
+                    var target = listEl.querySelector('[data-idx="' + idxStr + '"]');
+                    if (!target) return;
+                    /* Clear search so the row is visible */
+                    if (searchEl && searchEl.value) { searchEl.value = ''; filterList(''); }
+                    target.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+                    target.classList.add('ng-ov-row--flash');
+                    setTimeout(function () { target.classList.remove('ng-ov-row--flash'); }, 900);
+                });
+
+                sidebarListEl.appendChild(item);
+            });
+        }
+
+        function updateCount() {
+            if (countEl) {
+                var n = Object.keys(pending).length;
+                countEl.textContent = n === 0 ? 'No overrides set' : n + ' override' + (n === 1 ? '' : 's');
+            }
+            renderSidebar();
+        }
+
+        /* Populate sidebar immediately for any pre-existing overrides */
+        renderSidebar();
+
+        function filterList(q) {
+            q = (q || '').toLowerCase();
+            listEl.querySelectorAll('.ng-ov-row').forEach(function (r) {
+                r.style.display = (!q || (r.dataset.name || '').toLowerCase().indexOf(q) !== -1) ? '' : 'none';
+            });
+        }
+
+        /* Build an inline FA icon picker, calls onSelect(cls) on pick */
+        function buildIconPicker(initialCls, onSelect) {
+            var wrap = document.createElement('div');
+            wrap.className = 'ng-ov-picker';
+
+            var si = document.createElement('input');
+            si.type = 'text';
+            si.className = 'ng-ov-picker-search';
+            si.placeholder = 'Search icons… (wifi, fan, bolt, car…)';
+            si.autocomplete = 'off';
+            wrap.appendChild(si);
+
+            var grid = document.createElement('div');
+            grid.className = 'ng-ov-icon-grid';
+            wrap.appendChild(grid);
+
+            var activeCls = initialCls;
+
+            function renderGrid(q) {
+                q = (q || '').toLowerCase().replace(/^fa-solid\s+fa-/, '').trim();
+                var hits = q
+                    ? FA_ICONS.filter(function (c) { return c.replace('fa-solid fa-', '').replace(/-/g, ' ').indexOf(q) !== -1; })
+                    : FA_ICONS;
+                grid.innerHTML = '';
+                hits.forEach(function (cls) {
+                    var btn = document.createElement('button');
+                    btn.type = 'button';
+                    btn.className = 'ng-ov-icon-btn' + (cls === activeCls ? ' ng-ov-icon-btn--active' : '');
+                    btn.title = cls.replace('fa-solid fa-', '').replace(/-/g, ' ');
+                    btn.setAttribute('data-icon', cls);
+                    var ic = document.createElement('i');
+                    ic.className = cls;
+                    btn.appendChild(ic);
+                    grid.appendChild(btn);
+                });
+            }
+
+            renderGrid('');
+
+            si.addEventListener('input', function () { renderGrid(this.value); });
+
+            grid.addEventListener('click', function (e) {
+                var btn = e.target.closest('.ng-ov-icon-btn');
+                if (!btn) return;
+                activeCls = btn.getAttribute('data-icon');
+                grid.querySelectorAll('.ng-ov-icon-btn').forEach(function (b) {
+                    b.classList.toggle('ng-ov-icon-btn--active', b === btn);
+                });
+                onSelect(activeCls);
+            });
+
+            return wrap;
+        }
+
+        /* Render one device row with its inline editor */
+        function renderRow(d) {
+            var idxStr   = String(d.idx);
+            var ov       = pending[idxStr];
+            var hasOv    = !!(ov && ov.icon);
+            var curIcon  = hasOv ? ov.icon  : 'fa-solid fa-gear';
+            var curOn    = hasOv ? (ov.on  || '#4e9af1') : '#4e9af1';
+            var curOff   = hasOv ? (ov.off || '#555770') : '#555770';
+
+            var row = document.createElement('div');
+            row.className = 'ng-ov-row' + (hasOv ? ' ng-ov-row--active' : '');
+            row.dataset.idx  = idxStr;
+            row.dataset.name = d.Name || '';
+
+            /* Row summary line */
+            var summary = document.createElement('div');
+            summary.className = 'ng-ov-row-summary';
+            summary.innerHTML =
+                '<span class="ng-ov-row-icon">' +
+                '  <i class="' + (hasOv ? curIcon : 'fa-solid fa-circle-question') + ' ng-ov-row-fa"' +
+                '     style="color:' + (hasOv ? curOn : '#555770') + ';' + (hasOv ? '' : 'opacity:.45') + '"></i>' +
+                '</span>' +
+                '<span class="ng-bl-row-info">' +
+                '  <span class="ng-bl-row-name">' + (d.Name || 'Device ' + d.idx) + '</span>' +
+                '  <span class="ng-bl-row-type">IDX&nbsp;' + d.idx + (d.Type ? ' &middot; ' + d.Type : '') + (d.HardwareName ? ' &middot; ' + d.HardwareName : '') + '</span>' +
+                '</span>' +
+                '<button class="ng-ov-edit-btn" type="button" title="' + (hasOv ? 'Edit override' : 'Add override') + '">' +
+                '  <i class="fa-solid ' + (hasOv ? 'fa-pen-to-square' : 'fa-plus') + '"></i>' +
+                '</button>';
+            row.appendChild(summary);
+
+            /* Inline editor */
+            var editor = document.createElement('div');
+            editor.className = 'ng-ov-editor';
+            editor.style.display = 'none';
+
+            /* Preview */
+            var preview = document.createElement('div');
+            preview.className = 'ng-ov-preview';
+            var previewI = document.createElement('i');
+            previewI.className = curIcon + ' ng-ov-preview-icon';
+            previewI.style.color = curOn;
+            var previewName = document.createElement('span');
+            previewName.className = 'ng-ov-preview-name';
+            previewName.textContent = d.Name || 'Device';
+            preview.appendChild(previewI);
+            preview.appendChild(previewName);
+            editor.appendChild(preview);
+
+            /* Icon picker */
+            var picker = buildIconPicker(curIcon, function (cls) {
+                curIcon = cls;
+                previewI.className = cls + ' ng-ov-preview-icon';
+                previewI.style.color = curOn;
+                var rowFa = summary.querySelector('.ng-ov-row-fa');
+                if (rowFa) { rowFa.className = cls + ' ng-ov-row-fa'; rowFa.style.color = curOn; rowFa.style.opacity = ''; }
+                commitOverride();
+            });
+            editor.appendChild(picker);
+
+            /* Color pickers — reuse the settings-panel HSV canvas picker */
+            var colorRow = document.createElement('div');
+            colorRow.className = 'ng-ov-color-row';
+
+            var OV_COLOR_PRESETS = [
+                '#4e9af1','#29b6f6','#4caf7d','#66bb6a',
+                '#f0a832','#ffa726','#ff7043','#e05555',
+                '#c8a0ff','#ab47bc','#78909c','#555770'
+            ];
+
+            function makeOvColorPicker(labelText, initialColor, onChange) {
+                var wrap = document.createElement('div');
+                wrap.className = 'ng-ov-color-label';
+
+                var span = document.createElement('span');
+                span.textContent = labelText;
+                wrap.appendChild(span);
+
+                var pickerWrap = document.createElement('div');
+                pickerWrap.className = 'ng-color-wrap';
+
+                var swatch = document.createElement('button');
+                swatch.type = 'button';
+                swatch.className = 'ng-cp-swatch';
+                swatch.style.background = initialColor;
+
+                var hexInput = document.createElement('input');
+                hexInput.type = 'text';
+                hexInput.className = 'ng-cp-hex';
+                hexInput.value = initialColor;
+                hexInput.maxLength = 7;
+                hexInput.spellcheck = false;
+
+                var popover = document.createElement('div');
+                popover.className = 'ng-cp-popover';
+                popover.style.display = 'none';
+
+                var svCanvas = document.createElement('canvas');
+                svCanvas.className = 'ng-cp-sv';
+                svCanvas.width = 232;
+                svCanvas.height = 148;
+
+                var hueCanvas = document.createElement('canvas');
+                hueCanvas.className = 'ng-cp-hue';
+                hueCanvas.width = 232;
+                hueCanvas.height = 14;
+
+                var presetsEl = document.createElement('div');
+                presetsEl.className = 'ng-cp-presets';
+                OV_COLOR_PRESETS.forEach(function (c) {
+                    var btn = document.createElement('button');
+                    btn.type = 'button';
+                    btn.className = 'ng-cp-preset' + (c.toLowerCase() === initialColor.toLowerCase() ? ' ng-cp-preset--active' : '');
+                    btn.setAttribute('data-color', c);
+                    btn.style.background = c;
+                    btn.title = c;
+                    presetsEl.appendChild(btn);
+                });
+
+                popover.appendChild(svCanvas);
+                popover.appendChild(hueCanvas);
+                popover.appendChild(presetsEl);
+                pickerWrap.appendChild(swatch);
+                pickerWrap.appendChild(hexInput);
+                pickerWrap.appendChild(popover);
+                wrap.appendChild(pickerWrap);
+
+                var hsv = hexToHsv(initialColor);
+                drawSV(svCanvas, hsv.h);
+                drawHueBar(hueCanvas);
+
+                function updateFromHsv() {
+                    var hex = hsvToHex(hsv.h, hsv.s, hsv.v);
+                    swatch.style.background = hex;
+                    hexInput.value = hex;
+                    drawSV(svCanvas, hsv.h);
+                    presetsEl.querySelectorAll('.ng-cp-preset').forEach(function (b) {
+                        b.classList.toggle('ng-cp-preset--active',
+                            b.getAttribute('data-color').toLowerCase() === hex.toLowerCase());
+                    });
+                    onChange(hex);
+                }
+
+                function closeOtherPopovers() {
+                    var dialog = wrap.closest('.ng-ov-dialog') || document.body;
+                    dialog.querySelectorAll('.ng-color-wrap .ng-cp-popover').forEach(function (p) {
+                        if (p !== popover) p.style.display = 'none';
+                    });
+                }
+
+                swatch.addEventListener('click', function (e) {
+                    e.stopPropagation();
+                    var open = popover.style.display === 'block';
+                    closeOtherPopovers();
+                    if (!open) {
+                        popover.style.display = 'block';
+                        var rect = swatch.getBoundingClientRect();
+                        var popW = 260;
+                        var left = rect.right - popW;
+                        var top  = rect.bottom + 8;
+                        if (left < 8) left = 8;
+                        if (top + 300 > window.innerHeight) top = rect.top - 308;
+                        popover.style.left = left + 'px';
+                        popover.style.top  = top  + 'px';
+                        drawSV(svCanvas, hsv.h);
+                        drawHueBar(hueCanvas);
+                    }
+                });
+
+                function handleSV(e) {
+                    var rect = svCanvas.getBoundingClientRect();
+                    hsv.s = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+                    hsv.v = 1 - Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height));
+                    updateFromHsv();
+                }
+                var svDragging = false;
+                svCanvas.addEventListener('pointerdown', function (e) {
+                    svDragging = true; svCanvas.setPointerCapture(e.pointerId); handleSV(e);
+                });
+                svCanvas.addEventListener('pointermove', function (e) { if (svDragging) handleSV(e); });
+                svCanvas.addEventListener('pointerup',   function ()  { svDragging = false; });
+
+                function handleHue(e) {
+                    var rect = hueCanvas.getBoundingClientRect();
+                    hsv.h = Math.max(0, Math.min(0.9999, (e.clientX - rect.left) / rect.width));
+                    updateFromHsv();
+                }
+                var hueDragging = false;
+                hueCanvas.addEventListener('pointerdown', function (e) {
+                    hueDragging = true; hueCanvas.setPointerCapture(e.pointerId); handleHue(e);
+                });
+                hueCanvas.addEventListener('pointermove', function (e) { if (hueDragging) handleHue(e); });
+                hueCanvas.addEventListener('pointerup',   function ()  { hueDragging = false; });
+
+                hexInput.addEventListener('input', function () {
+                    var v = this.value.trim();
+                    if (/^#[0-9a-fA-F]{6}$/.test(v)) { hsv = hexToHsv(v); updateFromHsv(); }
+                });
+                hexInput.addEventListener('blur', function () {
+                    if (!/^#[0-9a-fA-F]{6}$/.test(this.value)) {
+                        this.value = hsvToHex(hsv.h, hsv.s, hsv.v);
+                    }
+                });
+                hexInput.addEventListener('keydown', function (e) {
+                    if (e.key === 'Enter') this.blur();
+                });
+
+                presetsEl.querySelectorAll('.ng-cp-preset').forEach(function (btn) {
+                    btn.addEventListener('click', function (e) {
+                        e.stopPropagation();
+                        hsv = hexToHsv(this.getAttribute('data-color'));
+                        updateFromHsv();
+                    });
+                });
+
+                return wrap;
+            }
+
+            var onField  = makeOvColorPicker('On color',  curOn,  function (v) { curOn  = v; previewI.style.color = v; var fa = summary.querySelector('.ng-ov-row-fa'); if (fa) fa.style.color = v; commitOverride(); });
+            var offField = makeOvColorPicker('Off color', curOff, function (v) { curOff = v; commitOverride(); });
+
+            var removeBtn = document.createElement('button');
+            removeBtn.type = 'button';
+            removeBtn.className = 'ng-ov-remove-btn';
+            removeBtn.innerHTML = '<i class="fa-solid fa-trash-can"></i> Remove';
+            removeBtn.addEventListener('click', function () {
+                delete pending[idxStr];
+                row.classList.remove('ng-ov-row--active');
+                var editBtn = summary.querySelector('.ng-ov-edit-btn');
+                if (editBtn) editBtn.innerHTML = '<i class="fa-solid fa-plus"></i>';
+                var rowFa = summary.querySelector('.ng-ov-row-fa');
+                if (rowFa) { rowFa.className = 'fa-solid fa-circle-question ng-ov-row-fa'; rowFa.style.color = '#555770'; rowFa.style.opacity = '.45'; }
+                editor.style.display = 'none';
+                updateCount();
+            });
+
+            colorRow.appendChild(onField);
+            colorRow.appendChild(offField);
+            colorRow.appendChild(removeBtn);
+            editor.appendChild(colorRow);
+
+            function commitOverride() {
+                if (!curIcon) return;
+                pending[idxStr] = { icon: curIcon, on: curOn, off: curOff, name: d.Name || '' };
+                row.classList.add('ng-ov-row--active');
+                var editBtn = summary.querySelector('.ng-ov-edit-btn');
+                if (editBtn) editBtn.innerHTML = '<i class="fa-solid fa-pen-to-square"></i>';
+                updateCount();
+            }
+
+            /* Row click: apply preset (select mode) or open editor (normal mode) */
+            summary.addEventListener('click', function (e) {
+                if (_pendingPreset) {
+                    applyPresetToRow(idxStr);
+                    return;
+                }
+                /* Normal: only toggle editor when the edit button itself was clicked */
+                if (!e.target.closest('.ng-ov-edit-btn')) return;
+                var open = editor.style.display !== 'none';
+                listEl.querySelectorAll('.ng-ov-editor').forEach(function (ed) { ed.style.display = 'none'; });
+                editor.style.display = open ? 'none' : '';
+            });
+
+            row.appendChild(editor);
+            return row;
+        }
+
+        function renderDevices(devices) {
+            if (!devices || !devices.length) {
+                listEl.innerHTML = '<div class="ng-bl-empty">No devices found.</div>';
+                return;
+            }
+            listEl.innerHTML = '';
+
+            // Sort: devices with existing overrides first
+            var sorted = devices.slice().sort(function (a, b) {
+                var aHas = !!(pending[String(a.idx)]);
+                var bHas = !!(pending[String(b.idx)]);
+                if (aHas && !bHas) return -1;
+                if (!aHas && bHas) return 1;
+                return (a.Name || '').localeCompare(b.Name || '');
+            });
+
+            sorted.forEach(function (d) { listEl.appendChild(renderRow(d)); });
+            updateCount();
+        }
+
+        /* Selection mode — used when a preset chip is active */
+        var _pendingPreset = null;
+        var _pendingChip   = null;
+
+        /* Banner shown above the list when a preset is pending */
+        var banner = document.createElement('div');
+        banner.className = 'ng-ov-select-banner';
+        banner.style.display = 'none';
+        listEl.parentNode.insertBefore(banner, listEl);
+
+        function enterSelectMode(preset, chip) {
+            _pendingPreset = preset;
+            if (_pendingChip) _pendingChip.classList.remove('ng-ov-chip--active');
+            _pendingChip = chip;
+            chip.classList.add('ng-ov-chip--active');
+
+            banner.innerHTML =
+                '<span class="ng-ov-banner-icon"><i class="' + preset.icon + '" style="color:' + preset.on + '"></i></span>' +
+                '<span class="ng-ov-banner-text">Click any device to apply <strong>' + preset.label + '</strong></span>' +
+                '<button class="ng-ov-banner-cancel" type="button"><i class="fa-solid fa-xmark"></i> Cancel</button>';
+            banner.style.display = '';
+            listEl.classList.add('ng-ov-list--select-mode');
+
+            banner.querySelector('.ng-ov-banner-cancel').addEventListener('click', exitSelectMode);
+        }
+
+        function exitSelectMode() {
+            _pendingPreset = null;
+            if (_pendingChip) _pendingChip.classList.remove('ng-ov-chip--active');
+            _pendingChip = null;
+            banner.style.display = 'none';
+            listEl.classList.remove('ng-ov-list--select-mode');
+        }
+
+        /* Apply the pending preset to a device row */
+        function applyPresetToRow(idxStr) {
+            var pp = _pendingPreset;
+            pending[idxStr] = { icon: pp.icon, on: pp.on, off: pp.off, name: pending[idxStr] && pending[idxStr].name || pp.label };
+            var row = listEl.querySelector('[data-idx="' + idxStr + '"]');
+            if (row) {
+                row.classList.add('ng-ov-row--active');
+                var rowFa  = row.querySelector('.ng-ov-row-fa');
+                var editBtn = row.querySelector('.ng-ov-edit-btn');
+                if (rowFa)   { rowFa.className = pp.icon + ' ng-ov-row-fa'; rowFa.style.color = pp.on; rowFa.style.opacity = ''; }
+                if (editBtn) { editBtn.innerHTML = '<i class="fa-solid fa-pen-to-square"></i>'; }
+            }
+            updateCount();
+            exitSelectMode();
+        }
+
+        /* Popular preset chips */
+        POPULAR_OVERRIDES.forEach(function (p) {
+            var chip = document.createElement('button');
+            chip.type = 'button';
+            chip.className = 'ng-ov-chip';
+            chip.title = p.icon.replace('fa-solid fa-', '').replace(/-/g, ' ');
+            chip.innerHTML = '<i class="' + p.icon + '"></i> ' + p.label;
+
+            chip.addEventListener('click', function () {
+                /* Toggle: clicking the already-active chip exits select mode */
+                if (_pendingPreset === p) { exitSelectMode(); return; }
+                exitSelectMode();
+                enterSelectMode(p, chip);
+            });
+            chipsEl.appendChild(chip);
+        });
+
+        /* Close + Search + Save */
+        overlay.querySelector('.ng-bl-close').addEventListener('click', close);
+        overlay.querySelector('.ng-bl-btn--cancel').addEventListener('click', close);
+        overlay.addEventListener('click', function (e) {
+            if (e.target === overlay) { close(); return; }
+            /* Close any open HSV color-picker popovers when clicking outside them */
+            if (!e.target.closest('.ng-color-wrap')) {
+                overlay.querySelectorAll('.ng-cp-popover').forEach(function (p) { p.style.display = 'none'; });
+            }
+        });
+        overlay.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape') { if (_pendingPreset) { exitSelectMode(); e.stopPropagation(); } else { close(); } }
+        });
+        if (searchEl) searchEl.addEventListener('input', function () { filterList(this.value); });
+
+        overlay.querySelector('.ng-bl-btn--save').addEventListener('click', function () {
+            if (window.dzNightglassSettings) {
+                window.dzNightglassSettings.set('deviceIconOverrides', JSON.stringify(pending));
+            }
+            close();
+            // Refresh settings panel badge
+            var wrap = document.getElementById('ng-theme-settings-wrap');
+            if (wrap) {
+                var presetsBody = wrap.querySelector('#ngPresetsBody');
+                var presetsOpen = presetsBody && presetsBody.style.display !== 'none';
+                wrap.innerHTML = buildPanel({ presetsOpen: presetsOpen });
+                bindEvents(wrap);
+                loadPresets(wrap);
+            }
+        });
+
+        /* Fetch devices — window.__ngDemoDevices can be set by demo pages as a fallback */
+        fetch('/json.htm?type=command&param=getdevices&filter=all&used=true&order=Name', { credentials: 'same-origin' })
+            .then(function (r) { return r.json(); })
+            .then(function (data) { renderDevices(data.result || []); })
+            .catch(function () {
+                if (Array.isArray(window.__ngDemoDevices)) {
+                    renderDevices(window.__ngDemoDevices);
+                    listEl.insertAdjacentHTML('afterbegin',
+                        '<div class="ng-ov-demo-notice">' +
+                        '<i class="fa-solid fa-circle-info"></i> ' +
+                        'Demo mode \u2014 showing example devices.' +
+                        '</div>');
+                    return;
+                }
+                listEl.innerHTML =
+                    '<div class="ng-bl-empty">' +
+                    '  <i class="fa-solid fa-triangle-exclamation"></i>' +
+                    '  Could not load devices. Use Quick Presets above and enter a device IDX.' +
+                    '</div>';
+                updateCount();
+            });
+    }
+
     function bindEvents(container) {
         // Presets panel collapse/expand
         var presetsToggle = container.querySelector('#ngPresetsToggle');
@@ -1698,6 +2441,12 @@
         var blBtn = container.querySelector('#ng-bl-manage-btn');
         if (blBtn) {
             blBtn.addEventListener('click', openBlacklistDialog);
+        }
+
+        // Device icon override manage button
+        var ovBtn = container.querySelector('#ng-override-manage-btn');
+        if (ovBtn) {
+            ovBtn.addEventListener('click', openDeviceIconOverrideDialog);
         }
 
         // Export button

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -2049,7 +2049,7 @@
             var curIconStop  = hasOv ? (ov.iconStop  || 'fa-solid fa-stop')                   : 'fa-solid fa-stop';
             var curOn        = hasOv ? (ov.on  || defColorOn)  : defColorOn;
             var curOff       = hasOv ? (ov.off || defColorOff) : defColorOff;
-            var keepColor    = !!(ov && ov.keepColor);
+            var keepColor    = ov ? !!(ov.keepColor) : (model === 'sensor');
 
             /* ── Row element ──────────────────────────────────────────────── */
             var row = document.createElement('div');
@@ -2451,7 +2451,7 @@
                     commitOverride();
                 }));
                 colorRow.appendChild(buildRemoveBtn(function () {
-                    curIconOn = defIconOn; curOn = defColorOn; keepColor = false;
+                    curIconOn = defIconOn; curOn = defColorOn; keepColor = true;
                     var fa = summary.querySelector('.ng-ov-row-fa');
                     if (fa) { fa.className = defIconOn + ' ng-ov-row-fa'; fa.style.color = defColorOn; fa.style.opacity = '.55'; }
                 }));
@@ -2530,7 +2530,27 @@
 
             /* ── Click to toggle editor ───────────────────────────────────── */
             summary.addEventListener('click', function (e) {
-                if (_pendingPreset) { applyPresetToRow(idxStr); return; }
+                if (_pendingPreset) {
+                    /* In select mode: show per-row confirm instead of applying immediately */
+                    var existing = row.querySelector('.ng-ov-confirm-bar');
+                    if (existing) { existing.remove(); return; }
+                    listEl.querySelectorAll('.ng-ov-confirm-bar').forEach(function (b) { b.remove(); });
+                    var pp  = _pendingPreset;
+                    var bar = document.createElement('div');
+                    bar.className = 'ng-ov-confirm-bar';
+                    bar.innerHTML =
+                        '<span class="ng-ov-confirm-text">Apply <i class="' + pp.icon + '" style="color:' + pp.on + ';margin:0 3px"></i><strong>' + pp.label + '</strong>?</span>' +
+                        '<button class="ng-ov-confirm-apply" type="button">Apply</button>' +
+                        '<button class="ng-ov-confirm-skip" type="button"><i class="fa-solid fa-xmark"></i> Skip</button>';
+                    bar.querySelector('.ng-ov-confirm-apply').addEventListener('click', function (ev) {
+                        ev.stopPropagation(); applyPresetToRow(idxStr);
+                    });
+                    bar.querySelector('.ng-ov-confirm-skip').addEventListener('click', function (ev) {
+                        ev.stopPropagation(); bar.remove();
+                    });
+                    row.appendChild(bar);
+                    return;
+                }
                 if (!e.target.closest('.ng-ov-edit-btn')) return;
                 var open = editor.style.display !== 'none';
                 listEl.querySelectorAll('.ng-ov-editor').forEach(function (ed) { ed.style.display = 'none'; });
@@ -2593,6 +2613,7 @@
             _pendingChip = null;
             banner.style.display = 'none';
             listEl.classList.remove('ng-ov-list--select-mode');
+            listEl.querySelectorAll('.ng-ov-confirm-bar').forEach(function (b) { b.remove(); });
         }
 
         /* Apply the pending preset to a device row */

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -1717,6 +1717,27 @@
         return 'binary';
     }
 
+    /* Returns a human-readable group label for a device (shown as a tag in the dialog).
+       Groups mirror the Domoticz dashboard tabs. */
+    function getDeviceGroup(d) {
+        var type = d.Type || '';
+        var sw   = d.SwitchType || '';
+        if (['Temp','Temp+Hum','Temp+Hum+Baro','Humidity',
+             'Soil Temperature'].indexOf(type) >= 0) return 'Temperature';
+        if (['Rain','Wind','UV','Visibility','Barometric Pressure',
+             'Solar Radiation'].indexOf(type) >= 0) return 'Weather';
+        if (type === 'Security') return 'Security';
+        if (type === 'Scene') return 'Scene';
+        if (type === 'Group' || sw === 'Group') return 'Group';
+        if (['General','P1 Smart Meter','RFXMeter','YouLess Meter',
+             'Lux','Air Quality','Current','Current/Energy',
+             'Weight','Counter Incremental'].indexOf(type) >= 0) return 'Utility';
+        if (['Light/Switch','Lighting 1','Lighting 2','Lighting 3',
+             'Lighting 4','Lighting 5','Lighting 6','Fan','Chime',
+             'Color Switch'].indexOf(type) >= 0) return 'Light & Switch';
+        return null;
+    }
+
     function openDeviceIconOverrideDialog() {
         var existing = document.getElementById('ng-ov-overlay');
         if (existing) existing.remove();
@@ -2077,13 +2098,21 @@
                            : model === 'blinds-3' ? ' <span class="ng-ov-model-badge">3-icon</span>'
                            : model === 'sensor'   ? ' <span class="ng-ov-model-badge ng-ov-model-badge--sensor">sensor</span>'
                            : '';
+            var groupLabel = getDeviceGroup(d);
+            var groupTagCls = !groupLabel ? '' :
+                groupLabel === 'Temperature' ? ' ng-ov-group-tag--temp' :
+                groupLabel === 'Weather'     ? ' ng-ov-group-tag--weather' :
+                groupLabel === 'Security'    ? ' ng-ov-group-tag--security' :
+                groupLabel === 'Utility'     ? ' ng-ov-group-tag--utility' :
+                (groupLabel === 'Scene' || groupLabel === 'Group') ? ' ng-ov-group-tag--scene' : '';
+            var groupTag = groupLabel ? ' <span class="ng-ov-group-tag' + groupTagCls + '">' + groupLabel + '</span>' : '';
             var swLabel = (d.SwitchType && d.SwitchType !== d.Type) ? ' &middot; ' + d.SwitchType : '';
             summary.innerHTML =
                 iconHtml +
                 '<span class="ng-bl-row-info">' +
                 '  <span class="ng-bl-row-name">' + (d.Name || 'Device ' + d.idx) + '</span>' +
                 '  <span class="ng-bl-row-type">IDX&nbsp;' + d.idx +
-                    (d.Type ? ' &middot; ' + d.Type : '') + swLabel + modelBadge +
+                    (d.Type ? ' &middot; ' + d.Type : '') + swLabel + modelBadge + groupTag +
                 '  </span>' +
                 '</span>' +
                 '<button class="ng-ov-edit-btn" type="button" title="' + (hasOv ? 'Edit override' : 'Add override') + '">' +

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -1774,8 +1774,9 @@
         ];
 
         // FA 6 Free Solid icon set for picker
+        // Only FA 6 Free Solid icons — no Pro-only entries, no renamed/removed icons.
         var FA_ICONS = [
-            'fa-solid fa-wifi',              'fa-solid fa-network-wired',     'fa-solid fa-router',
+            'fa-solid fa-wifi',              'fa-solid fa-network-wired',     'fa-solid fa-ethernet',
             'fa-solid fa-satellite-dish',    'fa-solid fa-tower-broadcast',   'fa-solid fa-signal',
             'fa-solid fa-house',             'fa-solid fa-house-chimney',     'fa-solid fa-door-closed',
             'fa-solid fa-door-open',         'fa-solid fa-window-maximize',   'fa-solid fa-warehouse',
@@ -1783,19 +1784,19 @@
             'fa-solid fa-bath',              'fa-solid fa-sink',              'fa-solid fa-toilet',
             'fa-solid fa-stairs',            'fa-solid fa-table',             'fa-solid fa-chair',
             'fa-solid fa-lightbulb',         'fa-solid fa-circle-half-stroke','fa-solid fa-sun',
-            'fa-solid fa-moon',              'fa-solid fa-star',              'fa-solid fa-lamp',
+            'fa-solid fa-moon',              'fa-solid fa-star',              'fa-solid fa-house-signal',
             'fa-solid fa-tv',                'fa-solid fa-display',           'fa-solid fa-computer',
             'fa-solid fa-server',            'fa-solid fa-hard-drive',        'fa-solid fa-print',
-            'fa-solid fa-phone',             'fa-solid fa-mobile-screen',     'fa-solid fa-tablet',
+            'fa-solid fa-phone',             'fa-solid fa-mobile-screen',     'fa-solid fa-tablet-screen-button',
             'fa-solid fa-headphones',        'fa-solid fa-volume-high',       'fa-solid fa-music',
             'fa-solid fa-gamepad',           'fa-solid fa-camera',            'fa-solid fa-video',
             'fa-solid fa-blender',           'fa-solid fa-mug-hot',           'fa-solid fa-utensils',
             'fa-solid fa-shirt',             'fa-solid fa-broom',             'fa-solid fa-baby',
-            'fa-solid fa-baby-carriage',     'fa-solid fa-robot',
+            'fa-solid fa-carriage-baby',     'fa-solid fa-robot',
             'fa-solid fa-bolt',              'fa-solid fa-plug',              'fa-solid fa-charging-station',
             'fa-solid fa-solar-panel',       'fa-solid fa-car-battery',       'fa-solid fa-battery-full',
             'fa-solid fa-fire',              'fa-solid fa-fire-flame-curved', 'fa-solid fa-gauge',
-            'fa-solid fa-temperature-half',  'fa-solid fa-thermometer',       'fa-solid fa-snowflake',
+            'fa-solid fa-temperature-half',  'fa-solid fa-temperature-full',  'fa-solid fa-snowflake',
             'fa-solid fa-fan',               'fa-solid fa-wind',              'fa-solid fa-cloud',
             'fa-solid fa-cloud-rain',        'fa-solid fa-umbrella',          'fa-solid fa-droplet',
             'fa-solid fa-temperature-low',   'fa-solid fa-temperature-high',  'fa-solid fa-smog',
@@ -1810,19 +1811,32 @@
             'fa-solid fa-water-ladder',      'fa-solid fa-hand-holding-droplet','fa-solid fa-faucet',
             'fa-solid fa-pump-soap',         'fa-solid fa-spray-can',         'fa-solid fa-shovel',
             'fa-solid fa-heart-pulse',       'fa-solid fa-weight-scale',      'fa-solid fa-lungs',
-            'fa-solid fa-syringe',           'fa-solid fa-pills',             'fa-solid fa-bed-pulse',
+            'fa-solid fa-syringe',           'fa-solid fa-pills',             'fa-solid fa-hospital',
             'fa-solid fa-gear',              'fa-solid fa-wrench',            'fa-solid fa-screwdriver',
             'fa-solid fa-toolbox',           'fa-solid fa-box',               'fa-solid fa-bookmark',
             'fa-solid fa-flag',              'fa-solid fa-circle-dot',        'fa-solid fa-power-off',
             'fa-solid fa-toggle-on',         'fa-solid fa-sliders',           'fa-solid fa-clock',
             'fa-solid fa-calendar',          'fa-solid fa-location-dot',      'fa-solid fa-map-location-dot',
-            'fa-solid fa-microchip',         'fa-solid fa-cpu',               'fa-solid fa-memory'
+            'fa-solid fa-microchip',         'fa-solid fa-database',          'fa-solid fa-bars-progress'
         ];
 
-        // Mutable copy of current overrides
+        // Mutable copy of current overrides — copy every stored field so the
+        // sidebar and row editors reflect the saved state when the dialog reopens.
         var pending = {};
         Object.keys(currentOv).forEach(function (k) {
-            pending[k] = { icon: currentOv[k].icon, on: currentOv[k].on, off: currentOv[k].off, name: currentOv[k].name || '' };
+            var s = currentOv[k];
+            pending[k] = {
+                icon:      s.icon,
+                iconOn:    s.iconOn,
+                iconOff:   s.iconOff,
+                iconOpen:  s.iconOpen,
+                iconClose: s.iconClose,
+                iconStop:  s.iconStop,
+                keepColor: s.keepColor,
+                on:        s.on,
+                off:       s.off,
+                name:      s.name || ''
+            };
         });
 
         var overlay = document.createElement('div');

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -1773,51 +1773,194 @@
             { label: 'Vacuum Robot',    icon: 'fa-solid fa-robot',             on: '#4e9af1', off: '#555770' }
         ];
 
-        // FA 6 Free Solid icon set for picker
-        // Only FA 6 Free Solid icons — no Pro-only entries, no renamed/removed icons.
-        var FA_ICONS = [
+        // FA 7 Free icon picker sets.
+        // FA_ICONS_PRESET — shown by default (curated home-automation icons).
+        // FA_ICONS_ALL    — searched when the user types in the picker search box.
+        var FA_ICONS_PRESET = [
+            // Networking
             'fa-solid fa-wifi',              'fa-solid fa-network-wired',     'fa-solid fa-ethernet',
             'fa-solid fa-satellite-dish',    'fa-solid fa-tower-broadcast',   'fa-solid fa-signal',
-            'fa-solid fa-house',             'fa-solid fa-house-chimney',     'fa-solid fa-door-closed',
-            'fa-solid fa-door-open',         'fa-solid fa-window-maximize',   'fa-solid fa-warehouse',
-            'fa-solid fa-building',          'fa-solid fa-couch',             'fa-solid fa-bed',
-            'fa-solid fa-bath',              'fa-solid fa-sink',              'fa-solid fa-toilet',
-            'fa-solid fa-stairs',            'fa-solid fa-table',             'fa-solid fa-chair',
+            // House & Rooms
+            'fa-solid fa-house',             'fa-solid fa-house-chimney',     'fa-solid fa-house-signal',
+            'fa-solid fa-door-closed',       'fa-solid fa-door-open',         'fa-solid fa-window-maximize',
+            'fa-solid fa-warehouse',         'fa-solid fa-building',          'fa-solid fa-couch',
+            'fa-solid fa-bed',               'fa-solid fa-bath',              'fa-solid fa-sink',
+            'fa-solid fa-toilet',            'fa-solid fa-stairs',            'fa-solid fa-table',
+            'fa-solid fa-chair',             'fa-solid fa-shower',
+            // Lighting
             'fa-solid fa-lightbulb',         'fa-solid fa-circle-half-stroke','fa-solid fa-sun',
-            'fa-solid fa-moon',              'fa-solid fa-star',              'fa-solid fa-house-signal',
+            'fa-solid fa-moon',              'fa-solid fa-star',              'fa-solid fa-wand-magic-sparkles',
+            // Tech & AV
             'fa-solid fa-tv',                'fa-solid fa-display',           'fa-solid fa-computer',
             'fa-solid fa-server',            'fa-solid fa-hard-drive',        'fa-solid fa-print',
             'fa-solid fa-phone',             'fa-solid fa-mobile-screen',     'fa-solid fa-tablet-screen-button',
             'fa-solid fa-headphones',        'fa-solid fa-volume-high',       'fa-solid fa-music',
             'fa-solid fa-gamepad',           'fa-solid fa-camera',            'fa-solid fa-video',
+            // Appliances
             'fa-solid fa-blender',           'fa-solid fa-mug-hot',           'fa-solid fa-utensils',
             'fa-solid fa-shirt',             'fa-solid fa-broom',             'fa-solid fa-baby',
             'fa-solid fa-carriage-baby',     'fa-solid fa-robot',
+            // Energy & Power
             'fa-solid fa-bolt',              'fa-solid fa-plug',              'fa-solid fa-charging-station',
             'fa-solid fa-solar-panel',       'fa-solid fa-car-battery',       'fa-solid fa-battery-full',
+            'fa-solid fa-power-off',         'fa-solid fa-toggle-on',
+            // Climate & Sensors
             'fa-solid fa-fire',              'fa-solid fa-fire-flame-curved', 'fa-solid fa-gauge',
             'fa-solid fa-temperature-half',  'fa-solid fa-temperature-full',  'fa-solid fa-snowflake',
             'fa-solid fa-fan',               'fa-solid fa-wind',              'fa-solid fa-cloud',
             'fa-solid fa-cloud-rain',        'fa-solid fa-umbrella',          'fa-solid fa-droplet',
             'fa-solid fa-temperature-low',   'fa-solid fa-temperature-high',  'fa-solid fa-smog',
+            // Garden & Nature
             'fa-solid fa-seedling',          'fa-solid fa-leaf',              'fa-solid fa-tree',
+            'fa-solid fa-trowel',            'fa-solid fa-water-ladder',
+            // Security
             'fa-solid fa-lock',              'fa-solid fa-lock-open',         'fa-solid fa-shield-halved',
             'fa-solid fa-bell',              'fa-solid fa-bell-concierge',    'fa-solid fa-triangle-exclamation',
             'fa-solid fa-circle-exclamation','fa-solid fa-eye',               'fa-solid fa-person-running',
+            // Pets & Animals
             'fa-solid fa-dog',               'fa-solid fa-paw',               'fa-solid fa-cat',
+            // Transport
             'fa-solid fa-car',               'fa-solid fa-car-side',          'fa-solid fa-truck',
             'fa-solid fa-motorcycle',        'fa-solid fa-bicycle',           'fa-solid fa-plane',
             'fa-solid fa-tractor',           'fa-solid fa-bus',
-            'fa-solid fa-water-ladder',      'fa-solid fa-hand-holding-droplet','fa-solid fa-faucet',
-            'fa-solid fa-pump-soap',         'fa-solid fa-spray-can',         'fa-solid fa-shovel',
+            // Water & Plumbing
+            'fa-solid fa-hand-holding-droplet','fa-solid fa-faucet',          'fa-solid fa-pump-soap',
+            'fa-solid fa-spray-can',
+            // Health
             'fa-solid fa-heart-pulse',       'fa-solid fa-weight-scale',      'fa-solid fa-lungs',
             'fa-solid fa-syringe',           'fa-solid fa-pills',             'fa-solid fa-hospital',
+            // Tools
             'fa-solid fa-gear',              'fa-solid fa-wrench',            'fa-solid fa-screwdriver',
-            'fa-solid fa-toolbox',           'fa-solid fa-box',               'fa-solid fa-bookmark',
-            'fa-solid fa-flag',              'fa-solid fa-circle-dot',        'fa-solid fa-power-off',
-            'fa-solid fa-toggle-on',         'fa-solid fa-sliders',           'fa-solid fa-clock',
+            'fa-solid fa-toolbox',
+            // Controls & Misc
+            'fa-solid fa-box',               'fa-solid fa-bookmark',          'fa-solid fa-flag',
+            'fa-solid fa-circle-dot',        'fa-solid fa-sliders',           'fa-solid fa-clock',
             'fa-solid fa-calendar',          'fa-solid fa-location-dot',      'fa-solid fa-map-location-dot',
             'fa-solid fa-microchip',         'fa-solid fa-database',          'fa-solid fa-bars-progress'
+        ];
+
+        // All searchable icons — FA 7 Free Solid, verified against the Domoticz bundle.
+        // Shown only when the user types a search query in the icon picker.
+        var FA_ICONS_ALL = [
+            // Networking
+            'fa-solid fa-wifi',              'fa-solid fa-network-wired',     'fa-solid fa-ethernet',
+            'fa-solid fa-satellite-dish',    'fa-solid fa-satellite',         'fa-solid fa-tower-broadcast',
+            'fa-solid fa-tower-cell',        'fa-solid fa-signal',            'fa-solid fa-globe',
+            'fa-solid fa-server',            'fa-solid fa-database',          'fa-solid fa-microchip',
+            'fa-solid fa-hard-drive',        'fa-solid fa-radio',             'fa-solid fa-walkie-talkie',
+            // House & Rooms
+            'fa-solid fa-house',             'fa-solid fa-house-chimney',     'fa-solid fa-house-signal',
+            'fa-solid fa-house-lock',        'fa-solid fa-house-fire',        'fa-solid fa-house-flood-water',
+            'fa-solid fa-house-laptop',      'fa-solid fa-house-user',        'fa-solid fa-house-chimney-window',
+            'fa-solid fa-house-medical',     'fa-solid fa-house-chimney-crack','fa-solid fa-building',
+            'fa-solid fa-building-columns',  'fa-solid fa-building-lock',     'fa-solid fa-warehouse',
+            'fa-solid fa-igloo',             'fa-solid fa-door-closed',       'fa-solid fa-door-open',
+            'fa-solid fa-window-maximize',   'fa-solid fa-window-restore',    'fa-solid fa-window-minimize',
+            'fa-solid fa-couch',             'fa-solid fa-bed',               'fa-solid fa-chair',
+            'fa-solid fa-table',             'fa-solid fa-bath',              'fa-solid fa-sink',
+            'fa-solid fa-toilet',            'fa-solid fa-toilet-paper',      'fa-solid fa-shower',
+            'fa-solid fa-stairs',            'fa-solid fa-archway',
+            // Lighting
+            'fa-solid fa-lightbulb',         'fa-solid fa-circle-half-stroke','fa-solid fa-sun',
+            'fa-solid fa-moon',              'fa-solid fa-star',              'fa-solid fa-wand-magic-sparkles',
+            'fa-solid fa-wand-magic',        'fa-solid fa-wand-sparkles',
+            // Tech & AV
+            'fa-solid fa-tv',                'fa-solid fa-display',           'fa-solid fa-computer',
+            'fa-solid fa-computer-mouse',    'fa-solid fa-keyboard',          'fa-solid fa-print',
+            'fa-solid fa-phone',             'fa-solid fa-mobile-screen',     'fa-solid fa-mobile-screen-button',
+            'fa-solid fa-tablet-screen-button','fa-solid fa-headphones',      'fa-solid fa-volume-high',
+            'fa-solid fa-volume-low',        'fa-solid fa-volume-off',        'fa-solid fa-volume-xmark',
+            'fa-solid fa-microphone',        'fa-solid fa-camera',            'fa-solid fa-video',
+            'fa-solid fa-music',             'fa-solid fa-gamepad',           'fa-solid fa-record-vinyl',
+            'fa-solid fa-fax',
+            // Appliances & Home
+            'fa-solid fa-blender',           'fa-solid fa-mug-hot',           'fa-solid fa-mug-saucer',
+            'fa-solid fa-utensils',          'fa-solid fa-pizza-slice',       'fa-solid fa-broom',
+            'fa-solid fa-shirt',             'fa-solid fa-soap',              'fa-solid fa-spray-can',
+            'fa-solid fa-spray-can-sparkles','fa-solid fa-baby',              'fa-solid fa-carriage-baby',
+            'fa-solid fa-robot',
+            // Energy & Power
+            'fa-solid fa-bolt',              'fa-solid fa-bolt-lightning',    'fa-solid fa-plug',
+            'fa-solid fa-plug-circle-bolt',  'fa-solid fa-plug-circle-check', 'fa-solid fa-plug-circle-exclamation',
+            'fa-solid fa-charging-station',  'fa-solid fa-solar-panel',       'fa-solid fa-car-battery',
+            'fa-solid fa-battery-full',      'fa-solid fa-battery-three-quarters','fa-solid fa-battery-half',
+            'fa-solid fa-battery-quarter',   'fa-solid fa-battery-empty',     'fa-solid fa-power-off',
+            'fa-solid fa-toggle-on',         'fa-solid fa-toggle-off',
+            // Climate & Weather sensors
+            'fa-solid fa-temperature-half',  'fa-solid fa-temperature-full',  'fa-solid fa-temperature-empty',
+            'fa-solid fa-temperature-quarter','fa-solid fa-temperature-three-quarters','fa-solid fa-temperature-high',
+            'fa-solid fa-temperature-low',   'fa-solid fa-temperature-up',    'fa-solid fa-temperature-down',
+            'fa-solid fa-thermometer',       'fa-solid fa-thermometer-half',  'fa-solid fa-thermometer-full',
+            'fa-solid fa-snowflake',         'fa-solid fa-fan',               'fa-solid fa-wind',
+            'fa-solid fa-cloud',             'fa-solid fa-cloud-sun',         'fa-solid fa-cloud-rain',
+            'fa-solid fa-cloud-bolt',        'fa-solid fa-cloud-showers-heavy','fa-solid fa-cloud-showers-water',
+            'fa-solid fa-umbrella',          'fa-solid fa-droplet',           'fa-solid fa-smog',
+            'fa-solid fa-gauge',             'fa-solid fa-gauge-high',        'fa-solid fa-tornado',
+            'fa-solid fa-hurricane',         'fa-solid fa-sun-plant-wilt',    'fa-solid fa-rainbow',
+            // Fire & Safety
+            'fa-solid fa-fire',              'fa-solid fa-fire-flame-curved', 'fa-solid fa-fire-flame-simple',
+            'fa-solid fa-fire-extinguisher', 'fa-solid fa-bell',              'fa-solid fa-bell-slash',
+            'fa-solid fa-bell-concierge',    'fa-solid fa-radiation',
+            // Security
+            'fa-solid fa-lock',              'fa-solid fa-lock-open',         'fa-solid fa-unlock',
+            'fa-solid fa-unlock-keyhole',    'fa-solid fa-shield',            'fa-solid fa-shield-halved',
+            'fa-solid fa-shield-heart',      'fa-solid fa-eye',               'fa-solid fa-eye-slash',
+            'fa-solid fa-person-running',    'fa-solid fa-triangle-exclamation','fa-solid fa-circle-exclamation',
+            // Garden & Nature
+            'fa-solid fa-seedling',          'fa-solid fa-leaf',              'fa-solid fa-tree',
+            'fa-solid fa-tree-city',         'fa-solid fa-spa',               'fa-solid fa-water',
+            'fa-solid fa-water-ladder',      'fa-solid fa-hand-holding-droplet','fa-solid fa-hand-holding-water',
+            'fa-solid fa-faucet',            'fa-solid fa-faucet-drip',       'fa-solid fa-tractor',
+            'fa-solid fa-trowel',            'fa-solid fa-trowel-bricks',     'fa-solid fa-recycle',
+            // Transport
+            'fa-solid fa-car',               'fa-solid fa-car-side',          'fa-solid fa-car-battery',
+            'fa-solid fa-truck',             'fa-solid fa-truck-fast',        'fa-solid fa-van-shuttle',
+            'fa-solid fa-bus',               'fa-solid fa-motorcycle',        'fa-solid fa-bicycle',
+            'fa-solid fa-plane',             'fa-solid fa-train',             'fa-solid fa-train-subway',
+            'fa-solid fa-helicopter',        'fa-solid fa-route',             'fa-solid fa-traffic-light',
+            // Health & Wellness
+            'fa-solid fa-heart-pulse',       'fa-solid fa-weight-scale',      'fa-solid fa-lungs',
+            'fa-solid fa-syringe',           'fa-solid fa-pills',             'fa-solid fa-hospital',
+            'fa-solid fa-stethoscope',       'fa-solid fa-wheelchair',        'fa-solid fa-dumbbell',
+            'fa-solid fa-tooth',             'fa-solid fa-pump-medical',
+            // Water & Plumbing
+            'fa-solid fa-pump-soap',         'fa-solid fa-spray-can',         'fa-solid fa-glass-water',
+            // Tools & Work
+            'fa-solid fa-gear',              'fa-solid fa-gears',             'fa-solid fa-wrench',
+            'fa-solid fa-screwdriver',       'fa-solid fa-screwdriver-wrench','fa-solid fa-toolbox',
+            'fa-solid fa-ruler',             'fa-solid fa-ruler-combined',    'fa-solid fa-paintbrush',
+            'fa-solid fa-hammer',
+            // Animals & Pets
+            'fa-solid fa-dog',               'fa-solid fa-paw',               'fa-solid fa-cat',
+            'fa-solid fa-fish',              'fa-solid fa-kiwi-bird',         'fa-solid fa-hippo',
+            'fa-solid fa-frog',
+            // People
+            'fa-solid fa-baby',              'fa-solid fa-carriage-baby',     'fa-solid fa-person',
+            'fa-solid fa-user',              'fa-solid fa-users',             'fa-solid fa-person-walking',
+            'fa-solid fa-person-running',    'fa-solid fa-person-hiking',     'fa-solid fa-person-biking',
+            'fa-solid fa-person-swimming',   'fa-solid fa-person-pregnant',   'fa-solid fa-child',
+            'fa-solid fa-wheelchair',
+            // Controls & Status
+            'fa-solid fa-sliders',           'fa-solid fa-power-off',         'fa-solid fa-toggle-on',
+            'fa-solid fa-toggle-off',        'fa-solid fa-circle-dot',        'fa-solid fa-layer-group',
+            'fa-solid fa-palette',           'fa-solid fa-arrows-rotate',     'fa-solid fa-rotate',
+            'fa-solid fa-expand',            'fa-solid fa-compress',          'fa-solid fa-check',
+            'fa-solid fa-check-double',      'fa-solid fa-list-check',        'fa-solid fa-bars-progress',
+            // Time & Location
+            'fa-solid fa-clock',             'fa-solid fa-calendar',          'fa-solid fa-stopwatch',
+            'fa-solid fa-hourglass-half',    'fa-solid fa-location-dot',      'fa-solid fa-map-location-dot',
+            'fa-solid fa-map',               'fa-solid fa-map-pin',           'fa-solid fa-compass',
+            // Misc Utility
+            'fa-solid fa-box',               'fa-solid fa-bookmark',          'fa-solid fa-flag',
+            'fa-solid fa-tag',               'fa-solid fa-tags',              'fa-solid fa-barcode',
+            'fa-solid fa-qrcode',            'fa-solid fa-clipboard',         'fa-solid fa-microchip',
+            'fa-solid fa-database',          'fa-solid fa-server',            'fa-solid fa-graduation-cap',
+            'fa-solid fa-trophy',            'fa-solid fa-medal',             'fa-solid fa-crown',
+            'fa-solid fa-piggy-bank',        'fa-solid fa-coins',             'fa-solid fa-gift',
+            'fa-solid fa-cart-shopping',     'fa-solid fa-scissors',          'fa-solid fa-anchor',
+            'fa-solid fa-dice',              'fa-solid fa-handshake',         'fa-solid fa-heart',
+            'fa-solid fa-infinity',          'fa-solid fa-rocket',            'fa-solid fa-spinner',
+            'fa-solid fa-hourglass'
         ];
 
         // Mutable copy of current overrides — copy every stored field so the
@@ -2019,8 +2162,8 @@
             function renderGrid(q) {
                 q = (q || '').toLowerCase().replace(/^fa-solid\s+fa-/, '').trim();
                 var hits = q
-                    ? FA_ICONS.filter(function (c) { return c.replace('fa-solid fa-', '').replace(/-/g, ' ').indexOf(q) !== -1; })
-                    : FA_ICONS;
+                    ? FA_ICONS_ALL.filter(function (c) { return c.replace('fa-solid fa-', '').replace(/-/g, ' ').indexOf(q) !== -1; })
+                    : FA_ICONS_PRESET;
                 grid.innerHTML = '';
                 hits.forEach(function (cls) {
                     var btn = document.createElement('button');

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -2652,10 +2652,17 @@
             var row = listEl.querySelector('[data-idx="' + idxStr + '"]');
             if (row) {
                 row.classList.add('ng-ov-row--active');
-                var rowFa  = row.querySelector('.ng-ov-row-fa');
+                /* Update all FA icons in the summary — blinds rows have open + close icons,
+                   so querySelectorAll is needed instead of just querySelector for the first. */
+                row.querySelectorAll('.ng-ov-row-fa').forEach(function (fa) {
+                    var keepCls = fa.classList.contains('ng-ov-row-fa--open')  ? ' ng-ov-row-fa--open'  :
+                                  fa.classList.contains('ng-ov-row-fa--close') ? ' ng-ov-row-fa--close' : '';
+                    fa.className   = pp.icon + ' ng-ov-row-fa' + keepCls;
+                    fa.style.color   = fa.classList.contains('ng-ov-row-fa--close') ? pp.off : pp.on;
+                    fa.style.opacity = '';
+                });
                 var editBtn = row.querySelector('.ng-ov-edit-btn');
-                if (rowFa)   { rowFa.className = pp.icon + ' ng-ov-row-fa'; rowFa.style.color = pp.on; rowFa.style.opacity = ''; }
-                if (editBtn) { editBtn.innerHTML = '<i class="fa-solid fa-pen-to-square"></i>'; }
+                if (editBtn) editBtn.innerHTML = '<i class="fa-solid fa-pen-to-square"></i>';
             }
             updateCount();
             exitSelectMode();


### PR DESCRIPTION
This pull request enhances the `demo/settings.html` page by adding a comprehensive demo for the Device Icon Override feature, improving the user experience and providing clear guidance on how to use the feature. It also updates the default tab behavior to highlight the Nightglass settings panel for new visitors.

**Device Icon Override Feature Demo:**

* Introduced a new section that visually demonstrates the Device Icon Override feature, including example device cards with various Font Awesome icons and custom colors to showcase possible overrides.
* Added a "How it works" explainer with step-by-step instructions for managing device icon overrides in the Nightglass settings tab.
* Included a demo device list (`window.__ngDemoDevices`) in JavaScript to serve as a fallback for the icon override dialog when the API is unavailable.

**UI/UX Improvements:**

* Changed the default tab behavior so that the Nightglass tab is opened automatically when the page loads, making the settings panel immediately visible to visitors. Falls back to the System tab if the Nightglass tab is not present.
* Adjusted the visibility of the System settings pane to be hidden by default, only showing it when the System tab is active.