### PR TITLE
Some fixes on mobile dashboard / filtering and users with specific tabs turned off

### DIFF
--- a/src/css/components.css
+++ b/src/css/components.css
@@ -771,6 +771,15 @@ table.mobileitem,
         border-bottom: none;
     }
 
+/* Ensure dimmer sliders in mobile rows always fill the available td width.
+   jQuery UI measures the container on init; if the row was hidden at that
+   moment the slider may render at zero width until refreshed. */
+.dashboardMobile .mobileitem .dimslider,
+.dashboardMobile .mobileitem .ui-slider {
+    width: 100% !important;
+    box-sizing: border-box;
+}
+
 /* Selector buttons outside .btn-group (mobile dashboard selectorlevels-mobile) */
 .selectorlevels-mobile .btn-selected,
 .selectorlevels-mobile-wrap .btn-selected,
@@ -800,7 +809,9 @@ body.ng-mobile-dashboard #tbFiltSearch.ng-hide {
 /* ── Mobile room filter / search row hiding ──────────────────────── */
 
 .dashboardMobile tr.ng-rf-filtered,
-.dashboardMobile tr.ng-mobile-search-hidden {
+.dashboardMobile tbody.ng-rf-filtered,
+.dashboardMobile tr.ng-mobile-search-hidden,
+.dashboardMobile tbody.ng-mobile-search-hidden {
     display: none !important;
 }
 

--- a/src/css/components.css
+++ b/src/css/components.css
@@ -771,15 +771,6 @@ table.mobileitem,
         border-bottom: none;
     }
 
-/* Ensure dimmer sliders in mobile rows always fill the available td width.
-   jQuery UI measures the container on init; if the row was hidden at that
-   moment the slider may render at zero width until refreshed. */
-.dashboardMobile .mobileitem .dimslider,
-.dashboardMobile .mobileitem .ui-slider {
-    width: 100% !important;
-    box-sizing: border-box;
-}
-
 /* Selector buttons outside .btn-group (mobile dashboard selectorlevels-mobile) */
 .selectorlevels-mobile .btn-selected,
 .selectorlevels-mobile-wrap .btn-selected,
@@ -809,9 +800,14 @@ body.ng-mobile-dashboard #tbFiltSearch.ng-hide {
 /* ── Mobile room filter / search row hiding ──────────────────────── */
 
 .dashboardMobile tr.ng-rf-filtered,
-.dashboardMobile tbody.ng-rf-filtered,
-.dashboardMobile tr.ng-mobile-search-hidden,
-.dashboardMobile tbody.ng-mobile-search-hidden {
+.dashboardMobile tr.ng-mobile-search-hidden {
+    display: none !important;
+}
+
+/* Dimmer/TPI/Blinds devices have a sibling <tr ng-if> containing the slider.
+   Hide it whenever its preceding device row is filtered or search-hidden. */
+.dashboardMobile .mobileitem tr.ng-rf-filtered ~ tr,
+.dashboardMobile .mobileitem tr.ng-mobile-search-hidden ~ tr {
     display: none !important;
 }
 

--- a/src/js/command-palette.js
+++ b/src/js/command-palette.js
@@ -12,6 +12,38 @@
     var _fetched    = false;
     var _pendingHighlight = null; // idx to scroll+highlight after route change
 
+    // ── Tab config ─────────────────────────────────────────────────
+
+    // Route → GetConfig flag name
+    var ROUTE_TAB = {
+        '/LightSwitches': 'EnableTabLights',
+        '/Scenes':        'EnableTabScenes',
+        '/Temperature':   'EnableTabTemp',
+        '/Weather':       'EnableTabWeather',
+        '/Utility':       'EnableTabUtility',
+        '/Dashboard':     'EnableTabDashboard',
+        '/Floorplans':    'EnableTabFloorplans',
+    };
+
+    function fetchConfig() {
+        var url = 'json.htm?type=command&param=getconfig';
+        fetch(url, { credentials: 'same-origin', cache: 'no-store' })
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                // Expose globally so other modules (notifications.js) can read it
+                window._dzTabConfig = (data && data.result) ? data.result : {};
+            })
+            .catch(function () { window._dzTabConfig = {}; });
+    }
+
+    function isTabEnabled(route) {
+        var cfg = window._dzTabConfig;
+        if (!cfg) return true; // not loaded yet — allow navigation
+        var flag = ROUTE_TAB[route];
+        if (!flag) return true; // unknown route — allow
+        return cfg[flag] !== false;
+    }
+
     // ── Device data ────────────────────────────────────────────────
 
     function fetchAll() {
@@ -697,6 +729,13 @@
 
     function navigateToDevice(device) {
         var route = deviceRoute(device);
+
+        if (!isTabEnabled(route)) {
+            // User doesn't have access to this tab — close palette and stop
+            closePalette();
+            return;
+        }
+
         closePalette();
 
         setTimeout(function () {
@@ -846,6 +885,7 @@
         render('');
         requestAnimationFrame(function () { _input && _input.focus(); });
         if (!_fetched) fetchAll();
+        if (!window._dzTabConfig) fetchConfig();
     }
 
     function closePalette() {

--- a/src/js/command-palette.js
+++ b/src/js/command-palette.js
@@ -15,6 +15,8 @@
     // ── Device data ────────────────────────────────────────────────
 
     function fetchAll() {
+        // filter=all&used=true — Domoticz's API already scopes the result to
+        // devices the logged-in user has permission to access.
         var url = 'json.htm?type=command&param=getdevices&filter=all&used=true&order=Name';
         fetch(url, { credentials: 'same-origin', cache: 'no-store' })
             .then(function (r) { return r.json(); })
@@ -28,13 +30,17 @@
     function patchDevice(d) {
         var idx = String(d.idx || d.ID || '');
         if (!idx) return;
+        var found = false;
         for (var i = 0; i < _allDevices.length; i++) {
             if (String(_allDevices[i].idx) === idx) {
                 var keys = Object.keys(d);
                 for (var k = 0; k < keys.length; k++) _allDevices[i][keys[k]] = d[keys[k]];
+                found = true;
                 break;
             }
         }
+        // Only track recent events for devices the user has access to.
+        if (!found) return;
         _recentMap[idx] = { device: d, ts: Date.now() };
         _recentKeys = Object.keys(_recentMap)
             .sort(function (a, b) { return _recentMap[b].ts - _recentMap[a].ts; })

--- a/src/js/notifications.js
+++ b/src/js/notifications.js
@@ -249,8 +249,33 @@
         }, 100);
     }
 
+    // Route → GetConfig flag name (mirrors command-palette.js)
+    var ROUTE_TAB = {
+        '/LightSwitches': 'EnableTabLights',
+        '/Scenes':        'EnableTabScenes',
+        '/Temperature':   'EnableTabTemp',
+        '/Weather':       'EnableTabWeather',
+        '/Utility':       'EnableTabUtility',
+        '/Dashboard':     'EnableTabDashboard',
+        '/Floorplans':    'EnableTabFloorplans',
+    };
+
+    function isTabEnabled(route) {
+        var cfg = window._dzTabConfig;
+        if (!cfg) return true; // config not yet loaded — allow navigation
+        var flag = ROUTE_TAB[route];
+        if (!flag) return true;
+        return cfg[flag] !== false;
+    }
+
     function navigateToDevice(device) {
         var route = deviceRoute(device);
+
+        if (!isTabEnabled(route)) {
+            if (_open) closePanel();
+            return;
+        }
+
         if (_open) closePanel();
 
         setTimeout(function () {
@@ -416,6 +441,18 @@
     function init() {
         injectButton();
         attachAngularHooks();
+        fetchAllowedDevices();
+        // Fetch tab config if command-palette.js hasn't done it yet
+        if (!window._dzTabConfig) {
+            fetch('json.htm?type=command&param=getconfig', { credentials: 'same-origin', cache: 'no-store' })
+                .then(function (r) { return r.json(); })
+                .then(function (data) {
+                    if (!window._dzTabConfig) {
+                        window._dzTabConfig = (data && data.result) ? data.result : {};
+                    }
+                })
+                .catch(function () { if (!window._dzTabConfig) window._dzTabConfig = {}; });
+        }
     }
 
     if (document.readyState === 'loading') {

--- a/src/js/notifications.js
+++ b/src/js/notifications.js
@@ -10,12 +10,13 @@
 (function () {
     'use strict';
 
-    var MAX_EVENTS = 50;
-    var _events    = [];   // circular buffer, oldest first
-    var _unread    = 0;
-    var _panel     = null;
-    var _badge     = null;
-    var _open      = false;
+    var MAX_EVENTS    = 50;
+    var _events       = [];   // circular buffer, oldest first
+    var _unread       = 0;
+    var _panel        = null;
+    var _badge        = null;
+    var _open         = false;
+    var _allowedIdxs  = null; // null = not yet loaded; object = idx→true for allowed devices
 
     /* ── Icon / color helpers (same palette as toasts.js) ─────── */
 
@@ -274,7 +275,42 @@
     }
     window.ngNavigateToDevice = navigateToDevice;
 
+    /* ── Access-filtered device list ──────────────────────────── */
+
+    function fetchAllowedDevices() {
+        // filter=all&used=true — Domoticz's API already scopes the result to
+        // devices the logged-in user has permission to access.
+        var url = 'json.htm?type=command&param=getdevices&filter=all&used=true&order=Name';
+        fetch(url, { credentials: 'same-origin', cache: 'no-store' })
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                _allowedIdxs = {};
+                if (data && data.result) {
+                    data.result.forEach(function (d) {
+                        _allowedIdxs[String(d.idx)] = true;
+                    });
+                }
+                window.ngLog('[Notif]', 'allowed devices loaded:', Object.keys(_allowedIdxs).length);
+            })
+            .catch(function () {
+                // On error, fail open so notifications still work
+                _allowedIdxs = null;
+                window.ngLog('[Notif]', 'could not load allowed devices — showing all');
+            });
+    }
+
     function recordEvent(device) {
+        /* Skip devices the current user doesn't have access to.
+           device_update fires for every device system-wide; restrict
+           to the favorites list which matches the user's access scope. */
+        if (_allowedIdxs !== null) {
+            var idx = String(device.idx || device.ID || '');
+            if (idx && !_allowedIdxs[idx]) {
+                window.ngLog('[Notif]', 'skip (not in user favorites):', device.Name);
+                return;
+            }
+        }
+
         /* Skip devices not marked as Used in Domoticz.
            The WebSocket broadcasts updates for all devices; we only
            want the ones the user has explicitly enabled (Used=1).   */

--- a/src/js/room-filter.js
+++ b/src/js/room-filter.js
@@ -643,20 +643,6 @@
             sec.classList.toggle('ng-rf-section-hidden', !hasVisible);
         });
 
-        /* Refresh jQuery UI sliders in visible mobile rows.
-           Sliders initialised while their container was display:none (from a prior
-           filter pass or the ng-rf-reloading cloak) get width:0 from jQuery UI;
-           calling refresh() after they become visible restores the correct track width. */
-        if (typeof $ === 'function') {
-            document.querySelectorAll(
-                '.dashboardMobile table.mobileitem .ui-slider'
-            ).forEach(function (sliderEl) {
-                var parent = sliderEl.closest('tbody[id], tr[id]');
-                if (parent && parent.classList.contains('ng-rf-filtered')) return;
-                try { $(sliderEl).slider('refresh'); } catch (e) {}
-            });
-        }
-
         /* Result summary */
         var summaryEl = document.getElementById('ng-rf-summary');
         if (summaryEl && totalCount > 0) {
@@ -972,10 +958,40 @@
         });
     }
 
+    /* Re-apply mobile slider widths using Domoticz's own formula.
+       Domoticz runs ResizeDimSliders() at t+100ms after data loads; at that
+       moment the mobileitem layout may not be finalised and it measures ~64px,
+       giving a 1px track width.  We repeat the measurement at a later time
+       when the layout is stable and the sliders are in the DOM. */
+    function fixMobileSliderWidths() {
+        var tables = document.querySelectorAll('.dashboardMobile .mobileitem');
+        if (!tables.length) return;
+        /* Use the widest rendered mobileitem (ng-rf-section-hidden ones have 0) */
+        var w = 0;
+        tables.forEach(function (t) {
+            var tw = t.offsetWidth;
+            if (tw > w) w = tw;
+        });
+        if (w < 100) return;   /* layout not stable yet — skip silently */
+        var trackW = w - 63;
+        if (trackW <= 0) return;
+        document.querySelectorAll(
+            '.dashboardMobile .mobileitem .dimslidernorm,' +
+            '.dashboardMobile .mobileitem .dimslidersmall'
+        ).forEach(function (el) {
+            el.style.width = trackW + 'px';
+        });
+    }
+
     function setupMobilePage() {
         var isMobile = !!document.querySelector('.dashboardMobile');
         document.body.classList.toggle('ng-mobile-dashboard', isMobile);
-        if (isMobile) setTimeout(attachMobileSearch, 200);
+        if (isMobile) {
+            setTimeout(attachMobileSearch, 200);
+            /* Run at 300ms and 700ms to cover both fast and slow data-load paths */
+            setTimeout(fixMobileSliderWidths, 300);
+            setTimeout(fixMobileSliderWidths, 700);
+        }
     }
 
     /* ══ Build filter panel DOM ══════════════════════════════════════
@@ -1503,17 +1519,7 @@
                         _pendingDDPlan = null;
                         setTimeout(function () {
                             document.body.classList.remove('ng-rf-reloading');
-                            /* Refresh sliders that may have been measured at width:0
-                               while the opacity:0 cloak was active during rendering. */
-                            if (typeof $ === 'function') {
-                                document.querySelectorAll(
-                                    '.dashboardMobile table.mobileitem .ui-slider'
-                                ).forEach(function (sliderEl) {
-                                    var parent = sliderEl.closest('tbody[id], tr[id]');
-                                    if (parent && parent.classList.contains('ng-rf-filtered')) return;
-                                    try { $(sliderEl).slider('refresh'); } catch (e) {}
-                                });
-                            }
+                            fixMobileSliderWidths();
                         }, 2000);
                     } else {
                         _pendingDDPlan = null;

--- a/src/js/room-filter.js
+++ b/src/js/room-filter.js
@@ -277,6 +277,11 @@
         document.querySelectorAll('.span4.itemBlock').forEach(function (el) {
             if (!el.closest('.movable')) cards.push(el);
         });
+        /* Lights/Switches: device row is <tbody id="light_NNN"> */
+        document.querySelectorAll('.dashboardMobile table.mobileitem tbody[id]').forEach(function (el) {
+            cards.push(el);
+        });
+        /* Scenes/Temp/Weather/Utility: device row is <tr id="scene_NNN"> etc. */
         document.querySelectorAll('.dashboardMobile table.mobileitem tbody tr[id]').forEach(function (el) {
             cards.push(el);
         });
@@ -635,10 +640,24 @@
         /* Hide dashboard sections that have no visible cards */
         document.querySelectorAll('section.dashCategory').forEach(function (sec) {
             var hasVisible = !!sec.querySelector(
-                '.movable:not(.ng-rf-filtered), tr[id]:not(.ng-rf-filtered)'
+                '.movable:not(.ng-rf-filtered), tr[id]:not(.ng-rf-filtered), tbody[id]:not(.ng-rf-filtered)'
             );
             sec.classList.toggle('ng-rf-section-hidden', !hasVisible);
         });
+
+        /* Refresh jQuery UI sliders in visible mobile rows.
+           Sliders initialised while their container was display:none (from a prior
+           filter pass or the ng-rf-reloading cloak) get width:0 from jQuery UI;
+           calling refresh() after they become visible restores the correct track width. */
+        if (typeof $ === 'function') {
+            document.querySelectorAll(
+                '.dashboardMobile table.mobileitem .ui-slider'
+            ).forEach(function (sliderEl) {
+                var parent = sliderEl.closest('tbody[id], tr[id]');
+                if (parent && parent.classList.contains('ng-rf-filtered')) return;
+                try { $(sliderEl).slider('refresh'); } catch (e) {}
+            });
+        }
 
         /* Result summary */
         var summaryEl = document.getElementById('ng-rf-summary');
@@ -1486,6 +1505,17 @@
                         _pendingDDPlan = null;
                         setTimeout(function () {
                             document.body.classList.remove('ng-rf-reloading');
+                            /* Refresh sliders that may have been measured at width:0
+                               while the opacity:0 cloak was active during rendering. */
+                            if (typeof $ === 'function') {
+                                document.querySelectorAll(
+                                    '.dashboardMobile table.mobileitem .ui-slider'
+                                ).forEach(function (sliderEl) {
+                                    var parent = sliderEl.closest('tbody[id], tr[id]');
+                                    if (parent && parent.classList.contains('ng-rf-filtered')) return;
+                                    try { $(sliderEl).slider('refresh'); } catch (e) {}
+                                });
+                            }
                         }, 2000);
                     } else {
                         _pendingDDPlan = null;

--- a/src/js/room-filter.js
+++ b/src/js/room-filter.js
@@ -434,6 +434,20 @@
         return subtype || type || null;
     }
 
+    /* Returns the device set used for filter sections and pill counts.
+       On the plain Dashboard (no DD) the mobile template only renders the
+       five supported categories (scenes, lights, temp, weather, utility).
+       Favorites of other types (Setpoints, P1 Meter, etc.) are in _deviceMap
+       as Favorite=1 but never appear in the DOM.  Scoping to DOM devices here
+       prevents showing filter pills for categories the user cannot see.
+       All other routes use getRouteDevices() for pre-render accuracy. */
+    function getFilterableDevices() {
+        var path = currentHashPath().toLowerCase();
+        var isPlainDash = (path === 'dashboard' || path === '') &&
+                          !isDynamicDashboardEnabled();
+        return isPlainDash ? getPageDevices() : getRouteDevices();
+    }
+
     /* ══ Filter section computation ═════════════════════════════════ */
 
     /* Returns a string that uniquely identifies the current section structure
@@ -474,12 +488,10 @@
             });
         }
 
-        /* For type / hardware / favourites sections, always use _deviceMap filtered
-           by the current route — not DOM cards.  This guarantees filter options
-           reflect ALL devices for this page type regardless of whether Angular has
-           finished rendering and regardless of any prior room pre-selection that
-           may have limited what was loaded into the DOM (e.g. DD → Dashboard flow). */
-        var devices = getRouteDevices();
+        /* Use getFilterableDevices() which scopes to DOM devices on the plain
+           Dashboard (where the mobile template omits non-category favorites)
+           and to getRouteDevices() everywhere else for pre-render accuracy. */
+        var devices = getFilterableDevices();
 
         if (!devices.length) return;   /* _deviceMap not ready yet — rooms only */
 
@@ -681,7 +693,7 @@
        Returns null when device data or plan cache isn't ready yet. */
     function countForPill(dim, value) {
         if (!_planCacheReady) return null;
-        var devices = getRouteDevices();
+        var devices = getFilterableDevices();
         if (!devices.length) return null;
 
         /* Build a hypothetical filter state, overriding only this dim */

--- a/src/js/room-filter.js
+++ b/src/js/room-filter.js
@@ -277,11 +277,9 @@
         document.querySelectorAll('.span4.itemBlock').forEach(function (el) {
             if (!el.closest('.movable')) cards.push(el);
         });
-        /* Lights/Switches: device row is <tbody id="light_NNN"> */
-        document.querySelectorAll('.dashboardMobile table.mobileitem tbody[id]').forEach(function (el) {
-            cards.push(el);
-        });
-        /* Scenes/Temp/Weather/Utility: device row is <tr id="scene_NNN"> etc. */
+        /* Mobile layout: lights use <tbody ng-repeat><tr id="light_NNN">;
+           scenes/temp/weather/utility use <tr id="..."> directly in tbody.
+           Sibling slider rows (no id) are handled via CSS adjacent-sibling rule. */
         document.querySelectorAll('.dashboardMobile table.mobileitem tbody tr[id]').forEach(function (el) {
             cards.push(el);
         });
@@ -640,7 +638,7 @@
         /* Hide dashboard sections that have no visible cards */
         document.querySelectorAll('section.dashCategory').forEach(function (sec) {
             var hasVisible = !!sec.querySelector(
-                '.movable:not(.ng-rf-filtered), tr[id]:not(.ng-rf-filtered), tbody[id]:not(.ng-rf-filtered)'
+                '.movable:not(.ng-rf-filtered), tr[id]:not(.ng-rf-filtered)'
             );
             sec.classList.toggle('ng-rf-section-hidden', !hasVisible);
         });

--- a/src/js/room-filter.js
+++ b/src/js/room-filter.js
@@ -441,11 +441,25 @@
        as Favorite=1 but never appear in the DOM.  Scoping to DOM devices here
        prevents showing filter pills for categories the user cannot see.
        All other routes use getRouteDevices() for pre-render accuracy. */
-    function getFilterableDevices() {
+
+    /* True when the mobile dashboard is a plain favorites-only view.
+       Two scenarios render .dashboardMobile:
+         A) DD enabled + room selection → all devices + room filter pre-applied
+            (_cameFromDD = true)  → NOT plain, use getRouteDevices()
+         B) DD enabled but Domoticz fell back to mobile view (e.g. MobileType
+            setting) without room context (_cameFromDD = false) → favorites only
+         C) DD disabled → always favorites only
+    */
+    function isOnMobileDashboardView() {
         var path = currentHashPath().toLowerCase();
-        var isPlainDash = (path === 'dashboard' || path === '') &&
-                          !isDynamicDashboardEnabled();
-        return isPlainDash ? getPageDevices() : getRouteDevices();
+        if (path !== 'dashboard' && path !== '') return false;
+        if (!isDynamicDashboardEnabled()) return true;
+        // DD on: plain view only when we did NOT arrive via DD room selection
+        return !_cameFromDD && !!document.querySelector('.dashboardMobile');
+    }
+
+    function getFilterableDevices() {
+        return isOnMobileDashboardView() ? getPageDevices() : getRouteDevices();
     }
 
     /* ══ Filter section computation ═════════════════════════════════ */
@@ -535,10 +549,7 @@
            favourited and non-favourited devices.  Skip on the plain Dashboard
            when DD is disabled: it already shows only favorites, so this filter
            would be redundant. */
-        var dashPath = currentHashPath().toLowerCase();
-        var isPlainDashboard = (dashPath === 'dashboard' || dashPath === '') &&
-                               !isDynamicDashboardEnabled();
-        if (!isPlainDashboard) {
+        if (!isOnMobileDashboardView()) {
             var hasFavs    = devices.some(function (d) { return d.Favorite == 1; });
             var hasNonFavs = devices.some(function (d) { return d.Favorite != 1; });
             if (hasFavs && hasNonFavs) {


### PR DESCRIPTION
This pull request introduces a set of enhancements and bug fixes focused on improving user access control, device visibility, and UI consistency in the mobile dashboard, command palette, notifications, and room filter modules. The main themes are enforcing device and tab access based on user permissions, refining filtering logic to match visible devices, and ensuring UI elements (like sliders) render correctly after data loads.

**Access Control and Permissions**

* Added tab access checks in both `command-palette.js` and `notifications.js` to prevent users from navigating to tabs they don't have permission to access, using a shared `ROUTE_TAB` mapping and config fetch logic. (`src/js/command-palette.js`, `src/js/notifications.js`) [[1]](diffhunk://#diff-ab665c88d225f1451c6a589b2368bed3193763d9f8450fbcd2db2c11444cd0cfR15-R51) [[2]](diffhunk://#diff-ab665c88d225f1451c6a589b2368bed3193763d9f8450fbcd2db2c11444cd0cfR732-R738) [[3]](diffhunk://#diff-ab665c88d225f1451c6a589b2368bed3193763d9f8450fbcd2db2c11444cd0cfR888) [[4]](diffhunk://#diff-b80c4dc8247f0e1b5c994c09bb8f60e40ec6a8fed833d7c2ea04142415d3a992R252-R278)
* Implemented device-level access filtering in `notifications.js` by fetching the list of allowed devices for the current user and skipping notification events for devices outside this set. (`src/js/notifications.js`)

**Device Filtering and Dashboard Logic**

* Refined device filtering logic in `room-filter.js` so that filter sections and pill counts only consider devices actually rendered in the DOM on the plain mobile dashboard, preventing filter options for invisible categories. Introduced `isOnMobileDashboardView()` and `getFilterableDevices()` helpers for this purpose. (`src/js/room-filter.js`) [[1]](diffhunk://#diff-3c9b810d145b67d73ca0c7ea4a61eb1006b9fcc80430e1d2b09f63e42973fcb3R437-R464) [[2]](diffhunk://#diff-3c9b810d145b67d73ca0c7ea4a61eb1006b9fcc80430e1d2b09f63e42973fcb3L474-R508) [[3]](diffhunk://#diff-3c9b810d145b67d73ca0c7ea4a61eb1006b9fcc80430e1d2b09f63e42973fcb3L523-R552) [[4]](diffhunk://#diff-3c9b810d145b67d73ca0c7ea4a61eb1006b9fcc80430e1d2b09f63e42973fcb3L681-R707)

**Mobile UI Consistency and Bug Fixes**

* Fixed the rendering of slider rows in the mobile dashboard by adding a CSS rule that hides slider `<tr>` elements when their associated device row is filtered or hidden by search. (`src/css/components.css`)
* Added logic to correct mobile slider widths after the layout stabilizes, running at multiple timeouts to ensure correct sizing regardless of data load speed. This logic is also called after dynamic dashboard reloads. (`src/js/room-filter.js`) [[1]](diffhunk://#diff-3c9b810d145b67d73ca0c7ea4a61eb1006b9fcc80430e1d2b09f63e42973fcb3R984-R1017) [[2]](diffhunk://#diff-3c9b810d145b67d73ca0c7ea4a61eb1006b9fcc80430e1d2b09f63e42973fcb3R1545)

**Other Minor Improvements**

* Updated comments and documentation to clarify the handling of mobile dashboard layouts and device selection logic, aiding future maintainability. (`src/js/room-filter.js`)

These changes collectively improve security, usability, and visual consistency for users navigating and interacting with devices on the mobile dashboard.