### PR TITLE
Improvements around command palette and floorplan page

### DIFF
--- a/src/js/command-palette.js
+++ b/src/js/command-palette.js
@@ -967,6 +967,14 @@
             if (e.target === _overlay) closePalette();
         });
 
+        // Keep focus on _input while the user clicks buttons in the list.
+        // preventDefault on mousedown prevents focus transfer; click still fires.
+        // Exception: range sliders need native mousedown for drag interaction.
+        _list.addEventListener('mousedown', function (e) {
+            if (e.target.type === 'range') return;
+            e.preventDefault();
+        });
+
         render('');
         requestAnimationFrame(function () { _input && _input.focus(); });
         if (!_fetched) fetchAll();

--- a/src/js/command-palette.js
+++ b/src/js/command-palette.js
@@ -596,6 +596,59 @@
         }
     }
 
+    // ── Domoticz API helpers ────────────────────────────────────────
+
+    function apiToggle(d, cb) {
+        var param = (d.Type === 'Scene' || d.Type === 'Group') ? 'switchscene' : 'switchlight';
+        var cmd;
+        if (d.Type === 'Group') {
+            cmd = isOn(d) ? 'Off' : 'On';
+        } else if (d.Type === 'Scene') {
+            cmd = 'On';
+        } else {
+            cmd = 'Toggle';
+        }
+        fetch('json.htm?type=command&param=' + param +
+              '&idx=' + d.idx + '&switchcmd=' + cmd,
+              { credentials: 'same-origin' })
+            .then(function (r) { return r.json(); })
+            .then(function () {
+                if (cmd === 'Toggle') {
+                    d.Status = isOn(d) ? 'Off' : 'On';
+                } else {
+                    d.Status = cmd;
+                }
+                if (cb) cb(d);
+            })
+            .catch(function () {});
+    }
+
+    function apiCommand(d, cmd, cb) {
+        var param = (d.Type === 'Scene' || d.Type === 'Group') ? 'switchscene' : 'switchlight';
+        fetch('json.htm?type=command&param=' + param +
+              '&idx=' + d.idx + '&switchcmd=' + encodeURIComponent(cmd),
+              { credentials: 'same-origin' })
+            .then(function (r) { return r.json(); })
+            .then(function () { d.Status = cmd; if (cb) cb(); })
+            .catch(function () {});
+    }
+
+    function apiSetLevel(d, level, cb) {
+        fetch('json.htm?type=command&param=switchlight&idx=' + d.idx +
+              '&switchcmd=Set+Level&level=' + level,
+              { credentials: 'same-origin' })
+            .then(function () { if (cb) cb(); })
+            .catch(function () {});
+    }
+
+    function apiSetSelector(d, level, cb) {
+        fetch('json.htm?type=command&param=switchlight&idx=' + d.idx +
+              '&switchcmd=Set+Level&level=' + level,
+              { credentials: 'same-origin' })
+            .then(function () { if (cb) cb(); })
+            .catch(function () {});
+    }
+
     function onItemClick(device, el, iconWrap) {
         var cls = deviceClass(device);
         // For sensors/readonly → navigate

--- a/src/js/command-palette.js
+++ b/src/js/command-palette.js
@@ -318,7 +318,7 @@
         });
         el.appendChild(navBtn);
 
-        el.addEventListener('mouseenter', function () { setActive(index); });
+        el.addEventListener('mouseenter', function () { setActive(index, false); });
         el.addEventListener('click', function (e) {
             if (e.target.closest('.dz-cmd-controls')) return; // controls handle themselves
             if (e.target.classList.contains('dz-cmd-nav-btn') ||
@@ -479,6 +479,10 @@
                 });
             });
             slider.addEventListener('click', function (e) { e.stopPropagation(); });
+            slider.addEventListener('keydown', function (e) {
+                if (e.key === 'Tab') { e.preventDefault(); if (_input) _input.focus(); }
+                else if (e.key === 'Escape') { closePalette(); }
+            });
             offBtn.addEventListener('click', function (e) {
                 e.stopPropagation();
                 apiCommand(device, 'Off', function () {
@@ -651,9 +655,7 @@
 
     function onItemClick(device, el, iconWrap) {
         var cls = deviceClass(device);
-        // For sensors/readonly → navigate
         if (cls === 'sensor' || cls === 'readonly') { navigateToDevice(device); return; }
-        // For toggle → quick toggle
         if (cls === 'toggle') {
             apiToggle(device, function (d) {
                 var nowOn = isOn(d);
@@ -665,8 +667,26 @@
                 }
                 flashCard(d, nowOn);
             });
+            return;
         }
-        // Other types: controls in the row handle interactions, clicking body is no-op
+        if (cls === 'dimmer') {
+            var row = el.querySelector('.dz-cmd-slider-row');
+            if (row) {
+                row.classList.add('dz-cmd-slider-row--visible');
+                var slider = row.querySelector('.dz-cmd-slider');
+                if (slider) slider.focus();
+            }
+            return;
+        }
+        // scene / push: activate primary button immediately
+        if (cls === 'scene' || cls === 'push') {
+            var primaryBtn = el.querySelector('.dz-cmd-action-btn');
+            if (primaryBtn) primaryBtn.click();
+            return;
+        }
+        // group / lock / blinds / selector: focus first control so user can Tab/Space
+        var firstCtrl = el.querySelector('.dz-cmd-controls button');
+        if (firstCtrl) firstCtrl.focus();
     }
 
     // ── Fuzzy search ───────────────────────────────────────────────
@@ -839,16 +859,23 @@
 
     // ── Active item ────────────────────────────────────────────────
 
-    function setActive(index) {
+    // autoExpand=true: auto-show dimmer slider (keyboard nav); false: mouse hover, no expand
+    function setActive(index, autoExpand) {
         if (!_list) return;
         var items = _list.querySelectorAll('.dz-cmd-item');
         if (_activeIdx >= 0 && items[_activeIdx]) {
             items[_activeIdx].classList.remove('dz-cmd-item--active');
+            var prevRow = items[_activeIdx].querySelector('.dz-cmd-slider-row');
+            if (prevRow) prevRow.classList.remove('dz-cmd-slider-row--visible');
         }
         _activeIdx = index;
         if (_activeIdx >= 0 && items[_activeIdx]) {
             items[_activeIdx].classList.add('dz-cmd-item--active');
             items[_activeIdx].scrollIntoView({ block: 'nearest' });
+            if (autoExpand) {
+                var row = items[_activeIdx].querySelector('.dz-cmd-slider-row');
+                if (row) row.classList.add('dz-cmd-slider-row--visible');
+            }
         }
     }
 
@@ -913,10 +940,10 @@
             var n = items.length;
             if (e.key === 'ArrowDown') {
                 e.preventDefault();
-                setActive((_activeIdx + 1) % Math.max(n, 1));
+                setActive((_activeIdx + 1) % Math.max(n, 1), true);
             } else if (e.key === 'ArrowUp') {
                 e.preventDefault();
-                setActive((_activeIdx - 1 + n) % Math.max(n, 1));
+                setActive((_activeIdx - 1 + n) % Math.max(n, 1), true);
             } else if (e.key === 'Enter') {
                 e.preventDefault();
                 var target = _activeIdx >= 0 ? items[_activeIdx] : items[0];

--- a/src/js/command-palette.js
+++ b/src/js/command-palette.js
@@ -77,7 +77,12 @@
         _recentKeys = Object.keys(_recentMap)
             .sort(function (a, b) { return _recentMap[b].ts - _recentMap[a].ts; })
             .slice(0, 24);
-        if (_overlay && _input && !_input.value.trim()) render('');
+        if (_overlay && _input && !_input.value.trim()) {
+            // Don't re-render while the user is interacting with an expanded control
+            // (e.g. a dimmer slider) — it would collapse it mid-interaction.
+            var hasExpanded = _list && _list.querySelector('.dz-cmd-slider-row--visible');
+            if (!hasExpanded) render('');
+        }
     }
 
     // ── Icon lookup ────────────────────────────────────────────────

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -469,13 +469,17 @@
         var y      = parseFloat(el.getAttribute('y') || 0);
         var iconPx = Math.round(Math.min(w, h) * 0.72);
 
-        // Visually hide the original but keep it for event bubbling
-        el.style.opacity      = '0';
-        el.style.pointerEvents = 'none';
+        // Visually hide the original but keep it interactive so drag-and-drop
+        // in floorplan edit mode still works (opacity:0 is still hit-testable
+        // in SVG; pointer-events must NOT be none here).
+        el.style.opacity = '0';
         el.setAttribute('data-dz-replaced', 'true');
         el.setAttribute('data-dz-orig-href', src);
 
-        // <foreignObject> hosts an HTML <i> inside SVG
+        // <foreignObject> hosts an HTML <i> inside SVG.
+        // pointer-events:none makes it purely visual so events fall through
+        // to the underlying <image> element (needed for drag-and-drop in
+        // floorplan edit mode).
         var fo = document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject');
         fo.setAttribute('x',       x);
         fo.setAttribute('y',       y);
@@ -483,6 +487,7 @@
         fo.setAttribute('height',  h);
         fo.setAttribute('overflow', 'visible');
         fo.setAttribute('class',   'dz-fp-icon-wrap');
+        fo.style.pointerEvents = 'none';
 
         // Copy interactive attributes so floorplan device popups still trigger
         ['onclick', 'onmouseover', 'onmouseout', 'ontouchstart', 'ontouchend'].forEach(function (a) {


### PR DESCRIPTION
Related issues:
https://github.com/galadril/Domoticz-Nightglass-Theme/issues/182
https://github.com/galadril/Domoticz-Nightglass-Theme/issues/186

This pull request makes several improvements to the command palette's user experience, especially for device control interactions and keyboard accessibility. The changes enhance how device controls (like dimmers and toggles) behave, improve keyboard navigation, and add helper functions for interacting with the Domoticz API. There are also adjustments to SVG icon handling to maintain interactivity in floorplan edit mode.

**Device control and interaction improvements:**

* Improved device click handling in `onItemClick` to provide context-aware actions: toggles now update status and flash, dimmers auto-expand sliders, scenes/push devices trigger their primary action, and other devices focus the first control for keyboard accessibility.
* Added keyboard event handlers to dimmer sliders, allowing users to close the palette with Escape or return focus to the input with Tab.
* Prevented re-rendering of the palette while a control (like a dimmer slider) is expanded, avoiding UI disruptions during user interaction.

**Keyboard navigation enhancements:**

* Modified the `setActive` function to optionally auto-expand dimmer sliders when navigating with the keyboard, and updated keyboard navigation (Arrow keys) to use this feature. [[1]](diffhunk://#diff-ab665c88d225f1451c6a589b2368bed3193763d9f8450fbcd2db2c11444cd0cfL789-R883) [[2]](diffhunk://#diff-ab665c88d225f1451c6a589b2368bed3193763d9f8450fbcd2db2c11444cd0cfL863-R951)
* Updated mouse hover activation to avoid auto-expanding controls, maintaining expected behavior.

**API helper functions:**

* Introduced helper functions (`apiToggle`, `apiCommand`, `apiSetLevel`, `apiSetSelector`) for interacting with the Domoticz API, centralizing and simplifying device control logic.

**SVG icon handling:**

* Adjusted SVG icon replacement logic to keep original images interactive for drag-and-drop and event bubbling in floorplan edit mode, while making the visual icon overlay non-interactive.