### PR TITLE
Move/rework towards Domoticz native icon library manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,8 @@ Fine-tune every color with live preview:
 - Perfect for personalizing your dashboard
 
 ### 📦 Extra Icon Libraries
-- Add third-party icon sets with just a name, source URL, and class prefix
-- Nightglass downloads the stylesheet/fonts into a local browser cache automatically
-- Refresh/redownload any configured library from the Icon Studio manager
+- Install third-party icon sets in Domoticz itself, under **Setup → Custom Icons**
+- Every installed library shows up in the Icon Studio automatically, grouped and searchable
 
 ### 💾 Import/Export & Sync
 - **Export Settings** - Save your custom theme as a JSON file

--- a/docs/index.html
+++ b/docs/index.html
@@ -1499,13 +1499,14 @@
 <section id="icon-libraries">
     <h2><i class="fa-solid fa-box-archive" style="color:var(--accent);margin-right:8px;opacity:.7;"></i>Extra Icon Libraries</h2>
     <p class="section-intro">
-        Add extra icon fonts with a source URL and class prefix only — Nightglass downloads and caches
-        the stylesheet and font files locally in your browser automatically.
+        Extra icon fonts are installed in Domoticz itself, under <strong>Setup → Custom Icons</strong>:
+        give it a source URL and a class prefix and Domoticz downloads, stores and serves the library
+        for every browser on the server.
     </p>
     <ul>
-        <li>No manual local hosting path required for the user</li>
-        <li>Downloaded libraries are reused from the local cache on later visits</li>
-        <li>Each configured library has a refresh/redownload action in the Icon Studio manager</li>
+        <li>Nothing to configure in Nightglass — installed libraries appear in the Icon Studio on their own</li>
+        <li>Each one gets its own group in the picker, searchable alongside Font Awesome</li>
+        <li>Adding, refreshing and removing a library all happen on Domoticz's own page</li>
     </ul>
 </section>
 

--- a/src/css/animations.css
+++ b/src/css/animations.css
@@ -99,25 +99,9 @@ body table[id^="itemtable"] tr td:first-child + td + td:hover img {
     transform: scale(1.12);
 }
 
-/* Fan spinning (keep from extras) */
-@keyframes rotation {
-    from {
-        transform: rotate(0deg);
-    }
-
-    to {
-        transform: rotate(359deg);
-    }
-}
-
-body.dashboard div.item.Fan.onn .img1 img {
-    animation: rotation 15s infinite linear;
-    border-radius: 50% !important;
-}
-
-    body.dashboard div.item.Fan.onn .img1 img:hover {
-        animation: rotation 0.5s infinite linear;
-    }
+/* The PNG fan used to spin here purely because Domoticz had labelled the
+   card .item.Fan.  Animation is a per-device choice now (section 25), so a
+   device no longer animates on the strength of what type it is. */
 
 /* Dragging */
 .ui-draggable-dragging tr {
@@ -622,71 +606,151 @@ body.dashboard div.item.Fan.onn .img1 img {
 
 
 /* ══════════════════════════════════════════════════════════════════
-   25. ANIMATED DEVICE ICONS
+   25. DEVICE ICON ANIMATIONS
+   ══════════════════════════════════════════════════════════════════
+   Which icon animates is a per-device choice, made in the Icon Studio
+   and stored in the theme's own deviceIconOverrides blob.  icons.js
+   turns that choice into exactly one .dz-anim-<id> class on the icon.
+   Nothing animates on the strength of which glyph it is: an icon holds
+   still until somebody picks an animation for it.
+
+   Every keyframe list here animates transform and opacity only, with
+   one documented exception (glow).  A dashboard can have dozens of
+   icons animating at once, and those are the properties a browser can
+   run on the compositor without laying out or painting again.
+
+   The classes carry no element or state requirement, so the very same
+   class drives the live preview tiles in the picker.  A real device
+   icon is the one place that needs a gate, at the bottom of this
+   section: off means off.
    ══════════════════════════════════════════════════════════════════ */
 
-@keyframes dz-spin {
-    from {
-        transform: rotate(0deg);
-    }
-
-    to {
-        transform: rotate(360deg);
-    }
+/* Spin — fans, motors, pumps, vacuum robots. */
+@keyframes dz-anim-spin {
+    to { transform: rotate(360deg); }
 }
 
-@keyframes dz-flicker {
-    0%,100% {
-        opacity: 1;
-        transform: scaleY(1) scaleX(1);
-    }
-
-    25% {
-        opacity: 0.85;
-        transform: scaleY(1.05) scaleX(0.96);
-    }
-
-    50% {
-        opacity: 0.9;
-        transform: scaleY(0.96) scaleX(1.03);
-    }
-
-    75% {
-        opacity: 0.95;
-        transform: scaleY(1.03) scaleX(0.97);
-    }
+.dz-anim-spin {
+    animation: dz-anim-spin 3s linear infinite;
 }
 
-@keyframes dz-pulse-icon {
-    0%,100% {
-        transform: scale(1);
-    }
-
-    50% {
-        transform: scale(1.14);
-    }
+/* Breathe — presence, motion, occupancy, heart rate. */
+@keyframes dz-anim-breathe {
+    0%, 100% { transform: scale(1);    opacity: 0.82; }
+    50%      { transform: scale(1.10); opacity: 1; }
 }
 
-/* Spinning fan */
-i.dz-fa-device.fa-fan[data-dz-state="on"] {
-    animation: dz-spin 1.6s linear infinite;
-}
-/* Flickering flame */
-i.dz-fa-device[data-dz-state="on"].fa-fire,
-i.dz-fa-device[data-dz-state="on"].fa-fire-flame-curved,
-i.dz-fa-device[data-dz-state="on"].fa-fire-burner {
-    animation: dz-flicker 1.2s ease-in-out infinite;
-}
-/* Pulsing presence / alarm */
-i.dz-fa-device[data-dz-state="on"].fa-person-walking,
-i.dz-fa-device[data-dz-state="on"].fa-person,
-i.dz-fa-device[data-dz-state="on"].fa-heart {
-    animation: dz-pulse-icon 1.1s ease-in-out infinite;
+.dz-anim-breathe {
+    animation: dz-anim-breathe 2.8s ease-in-out infinite;
 }
 
-i.dz-fa-device[data-dz-state="on"].fa-bell,
-i.dz-fa-device[data-dz-state="on"].fa-triangle-exclamation {
-    animation: dz-pulse-icon 0.5s ease-in-out infinite;
+/* Flicker — flame, candle, fireplace, burner.  Deliberately uneven
+   keyframes: an evenly spaced flicker reads as a fault light. */
+@keyframes dz-anim-flicker {
+    0%, 100% { opacity: 1;    transform: scale(1, 1); }
+    12%      { opacity: 0.82; transform: scale(0.97, 1.04); }
+    26%      { opacity: 1;    transform: scale(1.02, 0.98); }
+    41%      { opacity: 0.88; transform: scale(0.99, 1.02); }
+    58%      { opacity: 1;    transform: scale(1.01, 1); }
+    72%      { opacity: 0.84; transform: scale(0.98, 1.03); }
+    88%      { opacity: 0.97; transform: scale(1.01, 0.99); }
+}
+
+.dz-anim-flicker {
+    animation: dz-anim-flicker 2.4s ease-in-out infinite;
+}
+
+/* Ring — bells, sirens, alarms.  Most of the cycle is a rest so it
+   reads as a bell that rings now and then, not a permanent tremble. */
+@keyframes dz-anim-ring {
+    0%, 62%, 100% { transform: rotate(0); }
+    66%           { transform: rotate(13deg); }
+    70%           { transform: rotate(-11deg); }
+    74%           { transform: rotate(8deg); }
+    78%           { transform: rotate(-6deg); }
+    82%           { transform: rotate(3deg); }
+    86%           { transform: rotate(0); }
+}
+
+.dz-anim-ring {
+    /* A bell hangs from its crown, so the pivot belongs at the top. */
+    transform-origin: top center;
+    animation: dz-anim-ring 2.6s ease-in-out infinite;
+}
+
+/* Bounce — doorbells, notifications, incoming calls. */
+@keyframes dz-anim-bounce {
+    0%, 55%, 100% { transform: translateY(0); }
+    64%           { transform: translateY(-22%); }
+    72%           { transform: translateY(0); }
+    80%           { transform: translateY(-10%); }
+    88%           { transform: translateY(0); }
+}
+
+.dz-anim-bounce {
+    animation: dz-anim-bounce 2.2s ease-in-out infinite;
+}
+
+/* Glow — lights, lamps, LED strips.  The exception to transform/opacity:
+   a lit bulb wants to look brighter, not bigger or more transparent.
+   filter: brightness() is the cheap way to say that — it composites like
+   opacity does, whereas the box-shadow this would otherwise need repaints
+   a halo around every icon on every frame. */
+@keyframes dz-anim-glow {
+    0%, 100% { filter: brightness(1);    transform: scale(1); }
+    50%      { filter: brightness(1.5);  transform: scale(1.04); }
+}
+
+.dz-anim-glow {
+    animation: dz-anim-glow 3.2s ease-in-out infinite;
+}
+
+/* Blink — recording, faults, anything reporting a problem.  Crisper than
+   breathe: it holds at each end rather than easing through. */
+@keyframes dz-anim-blink {
+    0%, 45%  { opacity: 1; }
+    55%, 95% { opacity: 0.18; }
+    100%     { opacity: 1; }
+}
+
+.dz-anim-blink {
+    animation: dz-anim-blink 1.8s ease-in-out infinite;
+}
+
+/* Swing — doors, gates, blinds, curtains. */
+@keyframes dz-anim-swing {
+    0%, 100% { transform: rotate(-7deg); }
+    50%      { transform: rotate(7deg); }
+}
+
+.dz-anim-swing {
+    /* Hinged at the top so it swings like a hanging door rather than
+       pivoting around its own middle. */
+    transform-origin: top center;
+    animation: dz-anim-swing 3.6s ease-in-out infinite;
+}
+
+/* Drift — wind, water flow, ventilation, air quality.
+   Animates the individual `translate` property rather than `transform`:
+   icons.js writes the wind direction as an inline transform: rotate(),
+   and the two compose, so a wind glyph can drift and still point the way
+   the wind is blowing.  A transform-based drift would replace it. */
+@keyframes dz-anim-drift {
+    0%, 100% { translate: -8% 0; opacity: 0.8; }
+    50%      { translate: 8% 0;  opacity: 1; }
+}
+
+.dz-anim-drift {
+    animation: dz-anim-drift 4.5s ease-in-out infinite;
+}
+
+/* The gate.  An animation is only meaningful while the device is on, and
+   the classes above are otherwise unconditional so the picker previews
+   can use them.  A read-only sensor (temperature, wind, air quality…)
+   publishes no state at all and is deliberately NOT gated: there is no
+   "on" for it to wait for, and its animation was still asked for. */
+i.dz-fa-device[data-dz-state="off"] {
+    animation: none;
 }
 
 
@@ -1432,6 +1496,18 @@ div.item.itemBlock:hover .dz-sparkline-wrap,
 /* ══════════════════════════════════════════════════════════════════
    ACCESSIBILITY — prefers-reduced-motion
    ══════════════════════════════════════════════════════════════════ */
+
+@media (prefers-reduced-motion: reduce) {
+    /* Device icon animations (section 25) are decorative without
+       exception — the device's state is already carried by the icon's
+       colour and by the card's own text, so dropping the motion loses
+       nothing.  Matched by class prefix rather than by listing the
+       catalogue, so a tenth animation cannot forget to opt in.  Covers
+       the picker's preview tiles too, which use the same classes. */
+    [class*="dz-anim-"] {
+        animation: none !important;
+    }
+}
 
 /* ══════════════════════════════════════════════════════════════════
    LIGHT MODE — About page & Login page overrides

--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -370,6 +370,14 @@ i.dz-fa-device {
    table indicators, chrome icons and scene buttons are unaffected. */
 i.dz-fa-device.dz-icon-glyph {
     font-size: calc(1.5rem * var(--ng-icon-scale, 1));
+    /* Domoticz centres its glyph by having it fill the sized host
+       (display:block; width/height:100%). That rule scores the same as
+       i.dz-fa-device, so the theme's own 40px inline-flex box won on load
+       order and left the glyph inline at the bottom-left of the frame.
+       Fill the host again and centre with flex instead of line-height. */
+    display: flex;
+    width: 100%;
+    height: 100%;
 }
 
 /* Wind direction arrow — smooth rotation transitions */

--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -1146,3 +1146,11 @@ SECTION.dashCategory .row,
 }
 
 
+
+/* Domoticz's Icon style setting adds a glyph of its own beside every navbar image.
+   The theme has already replaced that image, so the native one is suppressed to stop
+   the navbar rendering each icon twice in the glyph style. Hidden rather than removed
+   because Angular re-renders these menus. */
+i.dz-nav-glyph-hidden {
+    display: none !important;
+}

--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -361,6 +361,17 @@ i.dz-fa-device {
         opacity: 0.85;
     }
 
+/* Native glyph rendering: Domoticz sizes its own glyphs with
+   `.dz-icon-48 > .dz-icon-glyph { font-size: 0.8em }`, a two-class
+   selector that outranks the one-class-one-element rule above — so the
+   icon-size setting stopped scaling device icons once Domoticz began
+   rendering them itself.  Same declaration at matching specificity.
+   Only glyphs the native adapter decorated carry both classes, so 16px
+   table indicators, chrome icons and scene buttons are unaffected. */
+i.dz-fa-device.dz-icon-glyph {
+    font-size: calc(1.5rem * var(--ng-icon-scale, 1));
+}
+
 /* Wind direction arrow — smooth rotation transitions */
 i.dz-wind {
     transition: opacity 0.15s, color 0.2s, transform 0.4s ease;

--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -380,6 +380,18 @@ i.dz-fa-device.dz-icon-glyph {
     height: 100%;
 }
 
+/* Scene and group buttons carry the size and glyph classes on one element, so
+   the adapter's child selector never reaches them and they keep Domoticz's
+   28.8px in a 48px frame — noticeably tighter than the 24px the decorated
+   device glyphs use, and not scaling with the icon-size setting either.
+   Matching the device size evens the two out. The size class only ever sits on
+   the glyph itself in this one-element case, so nested glyphs (where the host
+   carries it) and the 12/16px table indicators cannot match. */
+i.dz-icon-glyph.dz-icon-40,
+i.dz-icon-glyph.dz-icon-48 {
+    font-size: calc(1.5rem * var(--ng-icon-scale, 1));
+}
+
 /* Wind direction arrow — smooth rotation transitions */
 i.dz-wind {
     transition: opacity 0.15s, color 0.2s, transform 0.4s ease;

--- a/src/css/pages.css
+++ b/src/css/pages.css
@@ -981,242 +981,82 @@
         white-space: nowrap;
     }
 
-/* ── Device icon: Nightglass picker box (device-detail.js) ────────────
-   Replaces the native icon combo on the Angular device page AND the
-   jQuery utility edit dialogs with one provenance + actions + custom-
-   image-picker control. The native combo stays hidden in the DOM as the
-   persistence bridge. */
+/* ── Device icon field (device-detail.js) ─────────────────────────────
+   Nightglass injects the same control Domoticz's native picker renders —
+   a 28px preview plus a small "Change…" button — and reuses its class
+   names, so on a build that ships the native picker the field IS the
+   native field and cannot drift from it. These rules restate that layout
+   in theme tokens, which is also what a Domoticz without the native
+   picker (and therefore without icons-chrome.css) needs. Scoped under
+   .ng-icon-field so only our own field is affected. */
 
-/* Hide the native icon combos from first paint (device-detail.js sets
-   .ng-dd-icons-managed as soon as it loads) so our box replaces them with no
+/* Hide the native icon controls from first paint (device-detail.js sets
+   .ng-dd-icons-managed as soon as it loads) so our field replaces them with no
    visible old→new swap. Absent the class (module didn't load), the native
-   combos remain as a graceful fallback. */
+   controls remain as a graceful fallback. */
 .ng-dd-icons-managed device-icon-select,
+.ng-dd-icons-managed .dz-icon-picker-host,
 .ng-dd-icons-managed #combosensoricon {
     display: none !important;
 }
 
-.ng-dd-icon-box {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    padding: 12px 14px;
-    /* Fade/slide in so appearing after the (already-hidden) native combo
-       reads as intentional rather than a flicker. */
-    animation: ngDdIconIn 0.16s ease both;
-    /* The surrounding container is --dz-surface-2, so use the lighter
-       surface-3 + an accent left bar to read as a distinct Nightglass
-       control rather than a flat table cell. */
-    background: var(--dz-surface-3);
-    border: 1px solid var(--dz-border-b);
-    border-left: 3px solid var(--dz-accent);
-    border-radius: 10px;
-    max-width: 520px;
-}
-
-@keyframes ngDdIconIn {
-    from { opacity: 0; transform: translateY(2px); }
-    to   { opacity: 1; transform: none; }
-}
-
-.ng-dd-icon-head {
-    display: flex;
-    align-items: center;
-    gap: 14px;
-}
-
-.ng-dd-icon-preview {
-    width: 46px;
-    height: 46px;
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--dz-surface);
-    border: 1px solid var(--dz-border);
-    border-radius: 10px;
-    font-size: 22px;
-}
-
-    .ng-dd-icon-preview img {
-        width: 28px;
-        height: 28px;
-        object-fit: contain;
-    }
-
-.ng-dd-icon-info {
-    flex: 1 1 160px;
-    min-width: 0;
-}
-
-.ng-dd-icon-source {
-    display: flex;
-    align-items: center;
-    gap: 7px;
-    font-weight: 600;
-    font-size: 0.86rem;
-    color: var(--dz-text);
-}
-
-.ng-dd-icon-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    flex-shrink: 0;
-    background: var(--dz-text-muted);
-}
-
-.ng-dd-icon-source--override .ng-dd-icon-dot { background: var(--dz-accent); }
-.ng-dd-icon-source--theme    .ng-dd-icon-dot { background: #4caf7d; }
-.ng-dd-icon-source--custom   .ng-dd-icon-dot { background: #f0a832; }
-.ng-dd-icon-source--builtin  .ng-dd-icon-dot { background: #b0b3c6; }
-
-.ng-dd-icon-hint {
-    margin-top: 2px;
-    font-size: 0.74rem;
-    color: var(--dz-text-muted);
-    line-height: 1.35;
-}
-
-.ng-dd-icon-actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-}
-
-/* ── Custom uploaded-image picker (our own — getcustomiconset) ──── */
-.ng-dd-icon-picker {
-    border-top: 1px solid var(--dz-border);
-    padding-top: 10px;
-}
-
-.ng-dd-icon-picker-loading,
-.ng-dd-icon-picker-empty {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 0.78rem;
-    color: var(--dz-text-muted);
-    padding: 6px 2px;
-}
-
-.ng-dd-icon-picker-note {
-    display: flex;
-    align-items: flex-start;
-    gap: 6px;
-    font-size: 0.73rem;
-    line-height: 1.4;
-    color: var(--dz-text-muted);
-    margin-bottom: 8px;
-}
-
-    .ng-dd-icon-picker-note i,
-    .ng-dd-icon-picker-empty i { color: var(--dz-accent); margin-top: 1px; }
-
-    .ng-dd-icon-picker-note strong { color: var(--dz-text-soft); }
-
-.ng-dd-icon-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(84px, 1fr));
-    gap: 8px;
-    max-height: 260px;
-    overflow-y: auto;
-    scrollbar-width: thin;
-    scrollbar-color: var(--dz-border) transparent;
-}
-
-.ng-dd-icon-tile {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 5px;
-    padding: 8px 6px;
-    background: var(--dz-surface-2);
-    border: 1px solid var(--dz-border);
-    border-radius: 9px;
-    cursor: pointer;
-    transition: border-color 0.12s, background 0.12s, transform 0.08s;
-}
-
-    .ng-dd-icon-tile:hover {
-        border-color: var(--dz-accent);
-        background: var(--dz-surface);
-        transform: translateY(-1px);
-    }
-
-    .ng-dd-icon-tile img {
-        width: 32px;
-        height: 32px;
-        object-fit: contain;
-    }
-
-    .ng-dd-icon-tile span {
-        font-size: 0.68rem;
-        color: var(--dz-text-soft);
-        text-align: center;
-        line-height: 1.2;
-        max-width: 100%;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-    }
-
-.ng-dd-icon-tile--active {
-    border-color: var(--dz-accent);
-    background: rgba(var(--dz-accent-rgb), 0.14);
-    box-shadow: inset 0 0 0 1px var(--dz-accent);
-}
-
-.ng-dd-icon-btn {
+.ng-icon-field {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
-    padding: 6px 12px;
-    font-size: 0.8rem;
-    font-weight: 500;
-    border-radius: 7px;
-    border: 1px solid var(--dz-border-b);
-    background: var(--dz-surface-2);
-    color: var(--dz-text-soft);
+    gap: 8px;
+    /* Fade in so appearing after the (already-hidden) native control reads
+       as intentional rather than a flicker. */
+    animation: ngIconFieldIn 0.16s ease both;
+}
+
+@keyframes ngIconFieldIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+.ng-icon-field .dz-icon-field-preview {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    min-width: 28px;
+    height: 28px;
+    font-size: 22px;
+    line-height: 1;
+    color: var(--dz-accent);
+}
+
+    .ng-icon-field .dz-icon-field-preview img {
+        max-width: 26px;
+        max-height: 26px;
+        object-fit: contain;
+    }
+
+/* .btnsmall carries Domoticz's own button styling; only the stray table
+   margins it inherits need neutralising here. */
+.ng-icon-field .btnsmall {
+    margin: 0;
     cursor: pointer;
-    transition: background 0.12s, color 0.12s, border-color 0.12s;
 }
 
-    .ng-dd-icon-btn:hover {
-        background: var(--dz-surface);
-        border-color: var(--dz-accent);
-        color: var(--dz-text);
+/* The reset is the quieter of the two actions and only appears when there
+   is something to reset, so it reads as text until hovered. */
+.ng-icon-field-reset {
+    background: transparent !important;
+    border-color: transparent !important;
+    color: var(--dz-text-muted) !important;
+}
+
+    .ng-icon-field-reset:hover {
+        color: var(--dz-danger) !important;
+        border-color: var(--dz-danger) !important;
     }
 
-.ng-dd-icon-btn--primary {
-    background: var(--dz-accent);
-    border-color: transparent;
-    color: #fff;
-}
-
-    .ng-dd-icon-btn--primary:hover {
-        background: var(--dz-accent-light, var(--dz-accent));
-        color: #fff;
-    }
-
-.ng-dd-icon-btn--danger:hover {
-    background: rgba(var(--dz-danger-rgb), 0.15);
-    border-color: var(--dz-danger);
-    color: var(--dz-danger);
-}
-
-.ng-dd-icon-btn--link {
-    background: transparent;
-    border-color: transparent;
+.ng-icon-field-note {
+    font-size: 0.72rem;
+    font-style: normal;
     color: var(--dz-text-muted);
-    padding-left: 4px;
-    padding-right: 4px;
 }
-
-    .ng-dd-icon-btn--link:hover {
-        background: transparent;
-        color: var(--dz-accent);
-    }
 
 @media (max-width: 767px) {
     /* Header: stack title + buttons vertically */

--- a/src/css/settings-panel.css
+++ b/src/css/settings-panel.css
@@ -2287,7 +2287,7 @@ body.dz-light .ng-toast {
     scrollbar-width: thin;
     scrollbar-color: var(--dz-border) transparent;
 }
-.ng-is-rail-item, .ng-is-rail-manage {
+.ng-is-rail-item {
     display: flex;
     align-items: center;
     gap: 10px;
@@ -2302,9 +2302,9 @@ body.dz-light .ng-toast {
     cursor: pointer;
     transition: background 0.12s, color 0.12s;
 }
-    .ng-is-rail-item i, .ng-is-rail-manage i { width: 16px; text-align: center; color: var(--dz-text-muted); }
-    .ng-is-rail-item span, .ng-is-rail-manage span { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .ng-is-rail-item:hover, .ng-is-rail-manage:hover { background: rgba(var(--dz-accent-rgb), 0.08); color: var(--dz-text); }
+    .ng-is-rail-item i { width: 16px; text-align: center; color: var(--dz-text-muted); }
+    .ng-is-rail-item span { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .ng-is-rail-item:hover { background: rgba(var(--dz-accent-rgb), 0.08); color: var(--dz-text); }
 .ng-is-rail-count {
     font-style: normal;
     font-size: 0.7rem;
@@ -2318,12 +2318,6 @@ body.dz-light .ng-toast {
     color: var(--dz-accent) !important;
 }
     .ng-is-rail-item--active i { color: var(--dz-accent); }
-.ng-is-rail-manage {
-    margin-top: auto;
-    border: 1px dashed var(--dz-border-b);
-    color: var(--dz-text-muted);
-}
-    .ng-is-rail-manage:hover { border-color: var(--dz-accent); color: var(--dz-accent); }
 
 .ng-is-main {
     flex: 1;
@@ -2513,100 +2507,6 @@ body.dz-light .ng-toast {
 }
     .ng-is-manual-msg:empty { display: none; }
 
-/* Library manager */
-.ng-is-lib-list { display: flex; flex-direction: column; gap: 6px; margin: 8px 0 14px; }
-.ng-is-lib-row {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 8px 10px;
-    background: var(--dz-surface-2);
-    border: 1px solid var(--dz-border);
-    border-radius: 9px;
-}
-.ng-is-lib-row--busy { opacity: 0.85; }
-/* Its stored copy vanished from the server (removed on Domoticz's own Custom
-   Icons page) — the entry is kept, but flagged as not currently usable. */
-.ng-is-lib-row--missing {
-    border-color: rgba(var(--dz-warning-rgb), 0.5);
-    background: rgba(var(--dz-warning-rgb), 0.08);
-}
-    .ng-is-lib-row--missing .ng-is-lib-status { color: var(--dz-warning); }
-.ng-is-lib-meta { flex: 1; min-width: 0; display: flex; flex-direction: column; }
-    .ng-is-lib-meta strong { font-size: 0.85rem; color: var(--dz-text); }
-    .ng-is-lib-meta span {
-        font-size: 0.72rem; color: var(--dz-text-muted);
-        overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-    }
-.ng-is-lib-status {
-    margin-top: 3px;
-    font-style: normal;
-    font-size: 0.7rem;
-    color: var(--dz-text-dim);
-}
-.ng-is-lib-actions { display: flex; align-items: center; gap: 6px; }
-.ng-is-lib-refresh, .ng-is-lib-remove {
-    flex-shrink: 0;
-    width: 30px; height: 30px;
-    border: 1px solid var(--dz-border-b);
-    border-radius: 8px;
-    background: var(--dz-surface);
-    color: var(--dz-text-muted);
-    cursor: pointer;
-}
-.ng-is-lib-refresh:disabled, .ng-is-lib-remove:disabled {
-    opacity: 0.6;
-    cursor: default;
-}
-.ng-is-lib-refresh:hover { border-color: var(--dz-accent); color: var(--dz-accent); }
-    .ng-is-lib-remove:hover { border-color: var(--dz-danger); color: var(--dz-danger); }
-.ng-is-lib-suggest { margin: 4px 0 14px; }
-.ng-is-lib-suggest-label {
-    font-size: 0.76rem;
-    color: var(--dz-text-muted);
-    margin-bottom: 6px;
-}
-.ng-is-lib-suggest-chips { display: flex; flex-wrap: wrap; gap: 6px; }
-.ng-is-lib-suggest-chip {
-    padding: 5px 12px;
-    font-size: 0.76rem;
-    border: 1px dashed var(--dz-border-b);
-    border-radius: 20px;
-    background: var(--dz-surface-2);
-    color: var(--dz-text-soft);
-    cursor: pointer;
-    transition: background 0.12s, color 0.12s, border-color 0.12s;
-}
-    .ng-is-lib-suggest-chip:hover {
-        border-style: solid;
-        border-color: var(--dz-accent);
-        color: var(--dz-accent);
-    }
-
-.ng-is-lib-form { display: flex; flex-wrap: wrap; gap: 8px; }
-    .ng-is-lib-form input {
-        flex: 1 1 180px;
-        background: var(--dz-input-bg) !important;
-        color: var(--dz-input-text) !important;
-        border: 1px solid var(--dz-border) !important;
-        border-radius: 8px !important;
-        padding: 8px 11px !important;
-        font-size: 0.82rem;
-        outline: none;
-    }
-    .ng-is-lib-form input.ng-is-invalid { border-color: var(--dz-danger) !important; }
-.ng-is-lib-add {
-    flex: 0 0 auto;
-    padding: 8px 16px;
-    border: none;
-    border-radius: 8px;
-    background: var(--dz-accent);
-    color: #fff;
-    font-weight: 600;
-    font-size: 0.82rem;
-    cursor: pointer;
-}
-
 /* Picker launcher (inside the override row editor) */
 .ng-ov-picker-current {
     display: flex;
@@ -2659,7 +2559,6 @@ body.dz-light .ng-toast {
         border-right: none;
         border-bottom: 1px solid var(--dz-border);
     }
-    .ng-is-rail-manage { margin-top: 0; margin-left: auto; }
     .ng-is-head { flex-wrap: wrap; }
     .ng-is-search-wrap { order: 3; flex-basis: 100%; }
 }

--- a/src/css/settings-panel.css
+++ b/src/css/settings-panel.css
@@ -2429,6 +2429,15 @@ body.dz-light .ng-toast {
         flex-shrink: 0;
     }
 
+    /* The uploaded-PNG twin of the glyph above: same 24px box, so the bar
+       keeps one height whichever kind the slot holds. */
+    .ng-is-slot > img {
+        width: 24px;
+        height: 24px;
+        object-fit: contain;
+        flex-shrink: 0;
+    }
+
     .ng-is-slot-label {
         font-size: 0.8rem;
         font-weight: 600;
@@ -2451,6 +2460,18 @@ body.dz-light .ng-toast {
     background: rgba(var(--dz-accent-rgb), 0.14);
     box-shadow: inset 0 0 0 1px var(--dz-accent);
 }
+
+/* An uploaded image is the whole icon, so the bar shows one entry and there
+   is nothing to switch to: it states what is set rather than behaving like
+   a target button, hover included. */
+.ng-is-slot--img {
+    cursor: default;
+}
+
+    .ng-is-slot--img:hover {
+        border-color: var(--dz-accent);
+        background: rgba(var(--dz-accent-rgb), 0.14);
+    }
 
 /* Done button — the explicit finish now that an icon pick keeps the
    dialog open (there is an off icon and/or an animation still to set). */
@@ -2590,6 +2611,16 @@ body.dz-light .ng-toast {
         height: 26px;
         font-size: 20px;
         color: var(--dz-accent);
+    }
+
+    /* An uploaded PNG previews the animations exactly as a glyph does — the
+       .dz-anim-* classes only move transform and opacity — so it gets the same
+       fixed box to move inside. */
+    .ng-is-anim-tile img {
+        display: block;
+        width: 26px;
+        height: 26px;
+        object-fit: contain;
     }
 
     .ng-is-anim-tile span {

--- a/src/css/settings-panel.css
+++ b/src/css/settings-panel.css
@@ -2525,6 +2525,13 @@ body.dz-light .ng-toast {
     border-radius: 9px;
 }
 .ng-is-lib-row--busy { opacity: 0.85; }
+/* Its stored copy vanished from the server (removed on Domoticz's own Custom
+   Icons page) — the entry is kept, but flagged as not currently usable. */
+.ng-is-lib-row--missing {
+    border-color: rgba(var(--dz-warning-rgb), 0.5);
+    background: rgba(var(--dz-warning-rgb), 0.08);
+}
+    .ng-is-lib-row--missing .ng-is-lib-status { color: var(--dz-warning); }
 .ng-is-lib-meta { flex: 1; min-width: 0; display: flex; flex-direction: column; }
     .ng-is-lib-meta strong { font-size: 0.85rem; color: var(--dz-text); }
     .ng-is-lib-meta span {

--- a/src/css/settings-panel.css
+++ b/src/css/settings-panel.css
@@ -2361,6 +2361,15 @@ body.dz-light .ng-toast {
         transform: translateY(-1px);
     }
         .ng-is-tile:hover i { color: var(--dz-accent); }
+
+/* Uploaded custom icons are PNGs, so they get no colour treatment — only a
+   box the same height as a glyph tile's 22px line, so a mixed grid keeps one
+   baseline instead of images making their rows taller. */
+    .ng-is-tile--img img {
+        width: 26px;
+        height: 26px;
+        object-fit: contain;
+    }
 .ng-is-tile--active {
     border-color: var(--dz-accent);
     background: rgba(var(--dz-accent-rgb), 0.14);

--- a/src/css/settings-panel.css
+++ b/src/css/settings-panel.css
@@ -1456,10 +1456,10 @@
 .alerts { display: none !important; }
 
 /* ══════════════════════════════════════════════════════════════════
-   DEVICE ICON OVERRIDE DIALOG
+   DEVICE ICONS DIALOG
    ══════════════════════════════════════════════════════════════════ */
 
-/* Wider dialog to accommodate sidebar */
+/* One column, so the whole width goes to the device list */
 .ng-ov-dialog {
     max-width: 900px;
     width: calc(100vw - 32px);
@@ -1468,7 +1468,6 @@
     flex-direction: column;
 }
 
-/* Body: main column + sidebar side-by-side */
 .ng-ov-body {
     display: flex;
     flex: 1;
@@ -1482,113 +1481,69 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    border-right: 1px solid var(--dz-border);
 }
 
-/* ── Active Overrides sidebar ─────────────────────────────── */
-
-.ng-ov-sidebar {
-    width: 220px;
-    flex-shrink: 0;
+/* One line saying which of the two stores holds what. Quiet by design —
+   it explains the layout, it is not an instruction. */
+.ng-ov-store-note {
     display: flex;
-    flex-direction: column;
-    background: var(--dz-surface-2);
-}
-
-.ng-ov-sidebar-header {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 11px 14px;
-    font-size: 0.78rem;
-    font-weight: 700;
+    align-items: flex-start;
+    gap: 7px;
+    padding: 10px 16px;
+    font-size: 0.76rem;
+    line-height: 1.45;
     color: var(--dz-text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
+    background: rgba(var(--dz-accent-rgb), 0.05);
     border-bottom: 1px solid var(--dz-border);
-    flex-shrink: 0;
 }
 
-    .ng-ov-sidebar-header i {
+    .ng-ov-store-note i {
+        margin-top: 2px;
         color: var(--dz-accent);
-        opacity: 0.75;
+        opacity: 0.8;
+        flex-shrink: 0;
     }
 
-.ng-ov-sidebar-count {
-    margin-left: auto;
+/* ── Row markers ──────────────────────────────────────────────
+   The theme styling a device carries — the information the old "Active
+   overrides" sidebar held, moved onto the row it describes. */
+.ng-ov-row-marks {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    flex-shrink: 0;
+}
+
+    .ng-ov-row-marks:empty { display: none; }
+
+.ng-ov-mark {
     display: inline-flex;
     align-items: center;
-    justify-content: center;
-    min-width: 20px;
-    height: 18px;
-    padding: 0 5px;
-    background: rgba(var(--dz-accent-rgb), 0.18);
-    color: var(--dz-accent);
-    font-size: 0.72rem;
-    font-weight: 700;
-    border-radius: 9px;
-}
-
-.ng-ov-sidebar-list {
-    flex: 1;
-    overflow-y: auto;
-    padding: 4px 0;
-}
-
-.ng-ov-sidebar-empty {
-    padding: 20px 14px;
-    font-size: 0.8rem;
-    color: var(--dz-text-faint);
-    text-align: center;
-    font-style: italic;
-}
-
-/* Sidebar override item */
-.ng-ov-si {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 7px 10px 7px 14px;
-    cursor: pointer;
-    transition: background 0.12s;
-}
-
-    .ng-ov-si:hover {
-        background: rgba(var(--dz-accent-rgb), 0.07);
-    }
-
-.ng-ov-si-icon {
-    font-size: 1.05rem;
-    flex-shrink: 0;
-    width: 20px;
-    text-align: center;
-    transition: color 0.2s;
-}
-
-.ng-ov-si-info {
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-}
-
-.ng-ov-si-name {
-    font-size: 0.78rem;
-    font-weight: 600;
-    color: var(--dz-text);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.ng-ov-si-dots {
-    display: flex;
     gap: 4px;
-    align-items: center;
+    padding: 2px 7px;
+    border-radius: 10px;
+    font-size: 0.68rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+    cursor: help;
 }
 
-.ng-ov-si-dot {
+    .ng-ov-mark i { font-size: 0.9em; }
+
+.ng-ov-mark--anim {
+    background: rgba(200, 160, 255, 0.13);
+    color: #c8a0ff;
+}
+
+.ng-ov-mark-dots {
+    display: inline-flex;
+    gap: 3px;
+    align-items: center;
+    cursor: help;
+}
+
+.ng-ov-mark-dot {
     width: 9px;
     height: 9px;
     border-radius: 50%;
@@ -1596,30 +1551,11 @@
     border: 1px solid rgba(255, 255, 255, 0.12);
 }
 
-.ng-ov-si-remove {
-    flex-shrink: 0;
-    padding: 3px 6px;
-    background: transparent;
-    border: 1px solid transparent;
-    border-radius: 5px;
-    color: var(--dz-text-faint);
-    cursor: pointer;
-    font-size: 0.78rem;
-    opacity: 0;
-    transition: opacity 0.15s, background 0.15s, color 0.15s;
+body.dz-light .ng-ov-mark-dot {
+    border-color: rgba(0, 0, 0, 0.14);
 }
 
-    .ng-ov-si:hover .ng-ov-si-remove {
-        opacity: 1;
-    }
-
-    .ng-ov-si-remove:hover {
-        background: rgba(224, 85, 85, 0.15);
-        border-color: rgba(224, 85, 85, 0.3);
-        color: var(--dz-danger, #e05555);
-    }
-
-/* Flash highlight when jumping from sidebar to list row */
+/* Flash highlight when the dialog is opened targeting one device */
 .ng-ov-row--flash {
     animation: ngRowFlash 0.9s ease;
 }
@@ -1629,40 +1565,14 @@
     100% { background: transparent; }
 }
 
-/* Collapse sidebar to icon-only on narrow screens */
+/* Narrow screens: the animation's name goes, its icon and the colours stay */
 @media (max-width: 600px) {
-    .ng-ov-sidebar {
-        width: 48px;
+    .ng-ov-mark {
+        padding: 2px 5px;
+        font-size: 0;
+        gap: 0;
     }
-    .ng-ov-sidebar-header span:not(.ng-ov-sidebar-count),
-    .ng-ov-si-info,
-    .ng-ov-si-remove {
-        display: none;
-    }
-    .ng-ov-si {
-        justify-content: center;
-        padding: 8px 0;
-    }
-    .ng-ov-si-icon {
-        font-size: 1.15rem;
-    }
-}
-
-/* Badge showing override count in the settings panel row */
-.ng-override-badge {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 20px;
-    height: 20px;
-    padding: 0 6px;
-    background: var(--dz-accent);
-    color: #fff;
-    font-size: 0.72rem;
-    font-weight: 700;
-    border-radius: 10px;
-    margin-left: 6px;
-    vertical-align: middle;
+        .ng-ov-mark i { font-size: 0.78rem; }
 }
 
 /* Popular presets strip */
@@ -1736,8 +1646,11 @@
     transition: background 0.15s;
 }
 
+/* Carries customisation — the one marker that reads at a glance while
+   scanning; the chips on the row say what and from where. */
 .ng-ov-row--active {
     background: rgba(var(--dz-accent-rgb), 0.06);
+    box-shadow: inset 3px 0 0 rgba(var(--dz-accent-rgb), 0.55);
 }
 
 /* Preset focus: the dialog was opened targeting one device (from the device
@@ -1771,6 +1684,14 @@
     .ng-ov-row-fa {
         font-size: 1.1rem;
         transition: color 0.2s;
+    }
+
+    /* An uploaded PNG in the same 28px slot a glyph occupies, so a row with one
+       lines up with every other row. Never tinted: it is the user's artwork. */
+    .ng-ov-row-img {
+        width: 22px;
+        height: 22px;
+        object-fit: contain;
     }
 
 .ng-ov-edit-btn {
@@ -1877,6 +1798,8 @@
         font-size: 0.78rem;
     }
 
+/* "Use default" — a reset, not a delete, so it reads neutral rather than
+   red: it puts the device back on the icon Domoticz picks for its type. */
 .ng-ov-remove-btn {
     margin-left: auto;
     display: inline-flex;
@@ -1884,16 +1807,18 @@
     gap: 5px;
     padding: 4px 10px;
     font-size: 0.78rem;
-    background: rgba(var(--dz-danger, 224, 85, 85), 0.08);
-    border: 1px solid rgba(224, 85, 85, 0.25);
+    background: var(--dz-surface-3);
+    border: 1px solid var(--dz-border);
     border-radius: 7px;
-    color: var(--dz-danger, #e05555);
+    color: var(--dz-text-muted);
     cursor: pointer;
-    transition: background 0.15s;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
 
     .ng-ov-remove-btn:hover {
-        background: rgba(224, 85, 85, 0.18);
+        background: rgba(var(--dz-accent-rgb), 0.14);
+        border-color: var(--dz-accent);
+        color: var(--dz-text);
     }
 
 /* ── Demo mode notice ───────────────────────────────────────── */
@@ -2708,6 +2633,17 @@ body.dz-light .ng-toast {
         display: flex; align-items: center; justify-content: center;
         background: var(--dz-surface); border: 1px solid var(--dz-border);
         border-radius: 8px; font-size: 17px; color: var(--dz-accent);
+        flex-shrink: 0;
+    }
+    /* The uploaded-PNG twin of the preview above — same frame, so swapping
+       between a glyph and an image does not move the row. */
+    .ng-ov-picker-img {
+        width: 34px; height: 34px;
+        padding: 4px;
+        box-sizing: border-box;
+        object-fit: contain;
+        background: var(--dz-surface); border: 1px solid var(--dz-border);
+        border-radius: 8px;
         flex-shrink: 0;
     }
 .ng-ov-picker-label {

--- a/src/css/settings-panel.css
+++ b/src/css/settings-panel.css
@@ -2459,6 +2459,90 @@ body.dz-light .ng-toast {
     }
 .ng-is-section--collapsed .ng-is-section-body { display: none; }
 
+/* ── On/off target bar ────────────────────────────────────────────
+   Shown only when the caller opens the Studio with slots (the device
+   icon field, so it can offer a distinct off-state icon like Domoticz's
+   own native picker now does). Grid clicks land on whichever slot is
+   active. */
+.ng-is-slotbar {
+    flex-shrink: 0;
+    display: flex;
+    align-items: stretch;
+    gap: 8px;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--dz-border);
+    background: var(--dz-surface);
+}
+
+.ng-is-slotbar-lead {
+    align-self: center;
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: var(--dz-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+.ng-is-slot {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    padding: 6px 14px 6px 10px;
+    background: var(--dz-surface-2);
+    border: 1px solid var(--dz-border);
+    border-radius: 10px;
+    cursor: pointer;
+    text-align: left;
+    transition: border-color 0.1s, background 0.1s;
+}
+
+    .ng-is-slot > i {
+        width: 24px;
+        text-align: center;
+        font-size: 18px;
+        color: var(--dz-accent);
+        flex-shrink: 0;
+    }
+
+    .ng-is-slot-label {
+        font-size: 0.8rem;
+        font-weight: 600;
+        color: var(--dz-text);
+    }
+
+    .ng-is-slot-cls {
+        font-style: normal;
+        font-size: 0.72rem;
+        color: var(--dz-text-muted);
+    }
+
+    .ng-is-slot:hover {
+        border-color: var(--dz-accent);
+        background: var(--dz-surface-3);
+    }
+
+.ng-is-slot--active {
+    border-color: var(--dz-accent);
+    background: rgba(var(--dz-accent-rgb), 0.14);
+    box-shadow: inset 0 0 0 1px var(--dz-accent);
+}
+
+/* Done button — the explicit finish now that an icon pick keeps the
+   dialog open (there is an off icon and/or an animation still to set). */
+.ng-is-done {
+    flex-shrink: 0;
+    padding: 9px 18px;
+    border: none;
+    border-radius: 9px;
+    background: var(--dz-accent);
+    color: #fff;
+    font-weight: 700;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+    .ng-is-done:hover { background: var(--dz-accent-light, var(--dz-accent)); }
+
 /* Footer manual-class field */
 .ng-is-foot {
     flex-shrink: 0;
@@ -2516,6 +2600,103 @@ body.dz-light .ng-toast {
 }
     .ng-is-manual-msg:empty { display: none; }
 
+/* ── Animation row (footer, per-device callers only) ──────────────
+   Every tile renders the icon that is actually selected, with one
+   catalogue animation applied, so the choice is made by watching rather
+   than by reading a label.  The tiles use the same .dz-anim-* classes as
+   the real card icons — see section 25 of animations.css. */
+.ng-is-anim {
+    border-bottom: 1px solid var(--dz-border);
+    margin-bottom: 12px;
+    padding-bottom: 10px;
+}
+
+.ng-is-anim-head {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    font-size: 0.76rem;
+    font-weight: 700;
+    color: var(--dz-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 8px;
+}
+
+    .ng-is-anim-head em {
+        font-size: 0.72rem;
+        font-weight: 400;
+        text-transform: none;
+        letter-spacing: 0;
+        font-style: normal;
+        opacity: 0.8;
+    }
+
+/* Scrolls rather than wraps: the catalogue is one glanceable row of
+   moving icons, and a second line of them would fight for attention. */
+.ng-is-anim-strip {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    padding-bottom: 4px;
+}
+
+.ng-is-anim-tile {
+    flex: 0 0 auto;
+    width: 68px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 5px;
+    padding: 8px 4px 6px;
+    background: var(--dz-surface-2);
+    border: 1px solid var(--dz-border);
+    border-radius: 10px;
+    cursor: pointer;
+    transition: border-color 0.1s, background 0.1s;
+}
+
+    /* Fixed box so a tile cannot resize while its icon moves inside it. */
+    .ng-is-anim-tile i {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 26px;
+        height: 26px;
+        font-size: 20px;
+        color: var(--dz-accent);
+    }
+
+    .ng-is-anim-tile span {
+        font-size: 0.66rem;
+        color: var(--dz-text-muted);
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .ng-is-anim-tile:hover {
+        border-color: var(--dz-accent);
+        background: var(--dz-surface-3);
+    }
+
+.ng-is-anim-tile--active {
+    border-color: var(--dz-accent);
+    background: rgba(var(--dz-accent-rgb), 0.14);
+    box-shadow: inset 0 0 0 1px var(--dz-accent);
+}
+
+    .ng-is-anim-tile--active span { color: var(--dz-text); }
+
+/* "No animation" — the default, so it is set apart from the catalogue
+   by a dashed edge rather than by being the odd tile out in a row. */
+.ng-is-anim-tile--off {
+    border-style: dashed;
+}
+
+    .ng-is-anim-tile--off i { color: var(--dz-text-muted); }
+
 /* Picker launcher (inside the override row editor) */
 .ng-ov-picker-current {
     display: flex;
@@ -2555,6 +2736,23 @@ body.dz-light .ng-toast {
         border-color: var(--dz-accent);
         color: var(--dz-accent);
     }
+
+/* Animation state, shown next to the launcher so the editor says what is
+   set without having to open the Studio.  Absent when nothing is set. */
+.ng-ov-picker-anim {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 3px 9px;
+    border-radius: 20px;
+    background: rgba(var(--dz-accent-rgb), 0.12);
+    color: var(--dz-accent);
+    font-size: 0.72rem;
+    font-weight: 600;
+}
+
+    .ng-ov-picker-anim:empty { display: none; }
 
 /* Responsive: stack rail on top for narrow screens */
 @media (max-width: 640px) {

--- a/src/css/settings-panel.css
+++ b/src/css/settings-panel.css
@@ -2372,6 +2372,15 @@ body.dz-light .ng-toast {
     background: rgba(var(--dz-accent-rgb), 0.14);
     box-shadow: inset 0 0 0 1px var(--dz-accent);
 }
+/* Keyboard cursor. Deliberately louder than :hover so it stays findable
+   while arrow-keying, and distinct from --active (the current selection). */
+.ng-is-tile--hi {
+    border-color: var(--dz-accent);
+    background: var(--dz-surface-3);
+    outline: 2px solid var(--dz-accent);
+    outline-offset: 1px;
+}
+    .ng-is-tile--hi i { color: var(--dz-accent); }
 
 .ng-is-note {
     grid-column: 1 / -1;
@@ -2493,6 +2502,16 @@ body.dz-light .ng-toast {
     cursor: pointer;
 }
     .ng-is-manual-use:hover { background: var(--dz-accent-light, var(--dz-accent)); }
+    .ng-is-manual-input.ng-is-invalid { border-color: var(--dz-danger) !important; }
+/* Rejected-input message. Collapses out of the layout when empty so the
+   footer keeps its height until there is something to say. */
+.ng-is-manual-msg {
+    margin-top: 6px;
+    padding-left: 48px;            /* clears the 38px preview swatch + gap */
+    font-size: 0.76rem;
+    color: var(--dz-danger);
+}
+    .ng-is-manual-msg:empty { display: none; }
 
 /* Library manager */
 .ng-is-lib-list { display: flex; flex-direction: column; gap: 6px; margin: 8px 0 14px; }

--- a/src/js/card-features.js
+++ b/src/js/card-features.js
@@ -1023,6 +1023,13 @@ document.addEventListener('DOMContentLoaded', function () {
         var stateObs = new MutationObserver(function (mutations) {
             mutations.forEach(function (m) {
                 if (m.attributeName !== 'data-dz-state') return;
+                /* First appearance of the attribute is not a state *change*.
+                   PNG-era icons were built detached and inserted with
+                   data-dz-state already set, so this observer only ever saw
+                   real transitions. Native glyphs are already in the document
+                   when the adapter tags them, so without this guard every card
+                   would flash once on load and on every SPA navigation. */
+                if (m.oldValue === null) return;
                 var icon = m.target;
                 var newState = icon.getAttribute('data-dz-state');
                 // Walk up to card (desktop: .item.itemBlock; mobile: <tr id="...">)
@@ -1059,6 +1066,7 @@ document.addEventListener('DOMContentLoaded', function () {
             stateObs.observe(document.body, {
                 subtree: true,
                 attributes: true,
+                attributeOldValue: true,
                 attributeFilter: ['data-dz-state']
             });
         }

--- a/src/js/device-detail.js
+++ b/src/js/device-detail.js
@@ -1,8 +1,7 @@
 /* ══════════════════════════════════════════════════════════════════
    DEVICE ICON — Nightglass takeover of the native icon pickers
    ──────────────────────────────────────────────────────────────────
-   Domoticz lets you set a device icon in two places, both via a ddslick
-   combo listing the ENTIRE built-in icon set:
+   Domoticz lets you set a device icon in two places:
 
      1. Setup ▸ Devices ▸ a device — Angular <device-icon-select>
         (ng-model vm.device.CustomImage; persisted by the page's Save).
@@ -10,17 +9,23 @@
         (persisted by the dialog's Update button, which reads
         $.ddData[selectedIndex].value → &customimage=).
 
-   Nightglass replaces BOTH combos with one consistent UI that:
-     • shows where the icon currently comes from (Nightglass override /
-       theme icon / Domoticz built-in / uploaded custom image),
-     • sets a Font-Awesome icon through our Device Icon Overrides dialog,
-     • and — for the old-school path — offers ONLY the user's own uploaded
-       custom images (getcustomiconset), not the whole built-in list.
+   Nightglass replaces both with ONE control, and that control is
+   deliberately the shape Domoticz itself settled on for its native
+   picker: the current icon at 28px, then a small "Change…" button.
+   Same markup, same class names (.dz-icon-field / -preview / -btn), so
+   on a Domoticz that ships the native picker our field is visually the
+   native field — only the button routes to Nightglass's Icon Studio
+   instead of Domoticz's own dialog. On a Domoticz without it, the theme
+   CSS supplies the same appearance from scratch.
 
-   The native combo stays in the DOM (hidden) purely as the persistence
-   bridge: we drive its selection / ng-model, so Domoticz's own Save /
-   Update code writes CustomImage exactly as before. Custom-icon ZIP
-   uploads (Setup ▸ More Options ▸ Custom Icons) remain fully supported.
+   "Use default" sits in the field rather than inside the Studio: the
+   Studio is shared with the settings panel's override editor, where
+   "default" means nothing, and keeping the reset next to the preview
+   puts the state and the action that clears it in one place.
+
+   The native combo / picker stays in the DOM (hidden) purely as the
+   persistence bridge: we drive its selection / ng-model, so Domoticz's
+   own Save / Update code writes CustomImage exactly as before.
    ══════════════════════════════════════════════════════════════════ */
 (function () {
     'use strict';
@@ -170,16 +175,19 @@
         };
     }
 
-    /* ── Provenance + preview ─────────────────────────────────────── */
+    /* ── Provenance + preview ─────────────────────────────────────────
+       The compact field has room for one line of text, so provenance moves
+       into the preview's tooltip: what the icon is, then where it came
+       from. Native puts the class string there for the same reason. */
 
     function resolveSource(surface, device) {
         var s = settings();
         var ov = s && s.getDeviceOverride ? s.getDeviceOverride(surface.idx) : null;
         if (ov && (ov.iconOn || ov.iconOpen || ov.icon)) {
+            var cls = ov.iconOn || ov.iconOpen || ov.icon;
             return {
-                kind: 'override', label: 'Nightglass override',
-                hint: 'A Font Awesome icon you set for this device in Nightglass.',
-                iconCls: ov.iconOn || ov.iconOpen || ov.icon, color: ov.on || '#4e9af1'
+                kind: 'override', name: cls, origin: 'Nightglass override',
+                iconCls: cls, color: ov.on || '#4e9af1', isDefault: false
             };
         }
 
@@ -187,30 +195,31 @@
         if (ci >= 100) {
             var up = findUploaded(ci);
             return {
-                kind: 'custom', label: 'Uploaded custom image',
-                hint: 'One of your own uploaded custom icons (Setup ▸ More Options ▸ Custom Icons).',
+                kind: 'custom', name: (up && up.Title) || ('#' + ci),
+                origin: 'Uploaded custom image',
                 pngSrc: up ? up.IconFile48On : (selectedImg(surface) || null),
-                iconCls: null, color: null
+                iconCls: null, color: null, isDefault: false
             };
         }
         if (ci > 0) {
             var spec = device && typeof window._dzIconForDevice === 'function'
                 ? window._dzIconForDevice(device) : null;
             return {
-                kind: 'builtin', label: 'Domoticz built-in icon',
-                hint: 'A stock Domoticz icon. Prefer a Nightglass icon for a themed look.',
+                kind: 'builtin', name: device && device.Image ? String(device.Image) : ('#' + ci),
+                origin: 'Domoticz built-in icon',
                 iconCls: (spec && spec.icon) || null,
                 color:   (spec && spec.color) || null,
-                pngSrc:  (spec && spec.icon) ? null : (selectedImg(surface) || null)
+                pngSrc:  (spec && spec.icon) ? null : (selectedImg(surface) || null),
+                isDefault: false
             };
         }
         var themeSpec = device && typeof window._dzIconForDevice === 'function'
             ? window._dzIconForDevice(device) : null;
         return {
-            kind: 'theme', label: 'Nightglass theme icon',
-            hint: 'Automatically chosen by Nightglass from the device type.',
+            kind: 'theme', name: 'Default', origin: 'chosen from the device type',
             iconCls: (themeSpec && themeSpec.icon)  || 'fa-solid fa-circle-question',
-            color:   (themeSpec && themeSpec.color) || '#4e9af1'
+            color:   (themeSpec && themeSpec.color) || '#4e9af1',
+            isDefault: true
         };
     }
 
@@ -229,8 +238,9 @@
     }
 
     function buildPreview(src) {
-        var wrap = document.createElement('div');
-        wrap.className = 'ng-dd-icon-preview';
+        var wrap = document.createElement('span');
+        wrap.className = 'dz-icon-field-preview';
+        wrap.title = src.name + ' — ' + src.origin;
         if (src.pngSrc) {
             var im = document.createElement('img');
             im.src = src.pngSrc; im.alt = '';
@@ -238,8 +248,8 @@
             return wrap;
         }
         var i = document.createElement('i');
-        i.className = src.iconCls || 'fa-solid fa-image';
-        i.style.color = src.color || 'var(--dz-accent)';
+        i.className = src.iconCls || 'fa-regular fa-square';
+        if (src.color) i.style.color = src.color;
         wrap.appendChild(i);
         return wrap;
     }
@@ -250,14 +260,17 @@
         var td = surface.td;
         if (!td) return;
 
-        /* Create the box synchronously so concurrent async (device-fetch)
-           renders can't each insert a duplicate. The native combo is a
+        /* Create the field synchronously so concurrent async (device-fetch)
+           renders can't each insert a duplicate. The native combo/picker is a
            persistence bridge only — never shown. */
         var box = td.querySelector('#' + BOX_ID);
         if (!box) {
-            box = document.createElement('div');
+            box = document.createElement('span');
             box.id = BOX_ID;
-            box.className = 'ng-dd-icon-box';
+            /* Native's own class names first: on a Domoticz that ships the
+               native picker this inherits its layout verbatim, so the two
+               fields cannot drift apart. ng-icon-field is our own hook. */
+            box.className = 'dz-icon-field ng-icon-field';
             td.insertBefore(box, surface.comboEl);
         }
         surface.comboEl.style.display = 'none';
@@ -267,149 +280,83 @@
             var src = resolveSource(surface, device);
             var ci  = surface.getCustomImage();
 
-            var pickerOpen = box.getAttribute('data-picker-open') === '1';
+            /* An uploaded image only knows its title and PNG once the set has
+               been read; re-render when it lands rather than showing "#101". */
+            if (ci >= 100 && !_customSet) fetchCustomSet(function () { render(surface); });
 
             var sig = [surface.idx, src.kind, src.iconCls || '', src.color || '',
-                       src.pngSrc || '', ci, pickerOpen ? 1 : 0].join('|');
+                       src.pngSrc || '', ci, box.getAttribute('data-dirty') || ''].join('|');
             if (box.getAttribute('data-sig') === sig) return;
-
             box.setAttribute('data-sig', sig);
-            box.setAttribute('data-picker-open', pickerOpen ? '1' : '0');
 
             box.innerHTML = '';
+            box.appendChild(buildPreview(src));
 
-            var head = document.createElement('div');
-            head.className = 'ng-dd-icon-head';
-            head.appendChild(buildPreview(src));
-            var info = document.createElement('div');
-            info.className = 'ng-dd-icon-info';
-            info.innerHTML =
-                '<div class="ng-dd-icon-source ng-dd-icon-source--' + src.kind + '">' +
-                '<span class="ng-dd-icon-dot"></span>' + src.label + '</div>' +
-                '<div class="ng-dd-icon-hint">' + src.hint + '</div>';
-            head.appendChild(info);
-            box.appendChild(head);
+            box.appendChild(mkBtn('dz-icon-field-btn', 'Change…', function () {
+                openStudio(surface, device, src);
+            }));
 
-            var actions = document.createElement('div');
-            actions.className = 'ng-dd-icon-actions';
+            if (!src.isDefault) {
+                box.appendChild(mkBtn('ng-icon-field-reset', 'Use default', function () {
+                    useDefault(surface);
+                }));
+            }
 
-            var setBtn = mkBtn('ng-dd-icon-btn--primary',
-                '<i class="fa-solid fa-wand-magic-sparkles"></i> ' +
-                (src.kind === 'override' ? 'Change Nightglass icon' : 'Set Nightglass icon'),
-                function () {
-                    var s = settings();
-                    /* Open the Icon Studio directly for this device and apply
-                       the pick as an override (preserving any existing colors).
-                       Falls back to the full override dialog if the Studio
-                       module isn't available. */
-                    if (typeof window.dzOpenIconStudio === 'function' && s && s.setDeviceOverrideIcon) {
-                        window.dzOpenIconStudio({
-                            current: src.iconCls || '',
-                            title: 'Set icon for ' + ((device && device.Name) || 'device'),
-                            onPick: function (cls) {
-                                s.setDeviceOverrideIcon(surface.idx, cls, device && device.Name);
-                                render(surface);
-                            }
-                        });
-                    } else if (s && s.openIconOverride) {
-                        s.openIconOverride(surface.idx);
-                        scheduleRefresh(surface);
-                    }
-                });
-            actions.appendChild(setBtn);
+            /* Neither surface saves on pick — the page's Save / the dialog's
+               Update does. Say so, but only once there is something to lose. */
+            if (box.getAttribute('data-dirty') === '1') {
+                var note = document.createElement('em');
+                note.className = 'ng-icon-field-note';
+                note.textContent = 'click ' + surface.applyLabel + ' to save';
+                box.appendChild(note);
+            }
+        });
+    }
 
-            var pickBtn = mkBtn('ng-dd-icon-btn--link',
-                pickerOpen
-                    ? '<i class="fa-solid fa-chevron-up"></i> Hide custom images'
-                    : '<i class="fa-solid fa-images"></i> Use a custom uploaded image',
-                function () {
-                    box.setAttribute('data-picker-open', pickerOpen ? '0' : '1');
+    /* Domoticz renders its own Change… as an <a class="btnsmall">; match that
+       so the button is a real Domoticz small button on either build. */
+    function mkBtn(cls, text, onClick) {
+        var a = document.createElement('a');
+        a.className = 'btnsmall ' + cls;
+        a.setAttribute('role', 'button');
+        a.appendChild(document.createTextNode(text));
+        a.addEventListener('click', function (e) { e.preventDefault(); onClick(); });
+        return a;
+    }
+
+    function openStudio(surface, device, src) {
+        var s = settings();
+        /* Open the Icon Studio for this device and apply the pick as an
+           override (preserving any existing colors). Falls back to the full
+           override dialog if the Studio module isn't available. */
+        if (typeof window.dzOpenIconStudio === 'function' && s && s.setDeviceOverrideIcon) {
+            window.dzOpenIconStudio({
+                current: src.iconCls || '',
+                title: 'Set icon for ' + ((device && device.Name) || 'device'),
+                onPick: function (cls) {
+                    s.setDeviceOverrideIcon(surface.idx, cls, device && device.Name);
                     render(surface);
-                });
-            actions.appendChild(pickBtn);
-
-            if (src.kind === 'override') {
-                actions.appendChild(mkBtn('ng-dd-icon-btn--danger',
-                    '<i class="fa-solid fa-rotate-left"></i> Remove override',
-                    function () {
-                        var s = settings();
-                        if (s && s.removeDeviceOverride) s.removeDeviceOverride(surface.idx);
-                        render(surface);
-                    }));
-            } else if (ci > 0) {
-                actions.appendChild(mkBtn('ng-dd-icon-btn--danger',
-                    '<i class="fa-solid fa-rotate-left"></i> Reset to default',
-                    function () {
-                        surface.setCustomImage(0);
-                        render(surface);
-                    }));
-            }
-
-            box.appendChild(actions);
-
-            if (pickerOpen) box.appendChild(buildPicker(surface));
-        });
-    }
-
-    function mkBtn(cls, html, onClick) {
-        var b = document.createElement('button');
-        b.type = 'button';
-        b.className = 'ng-dd-icon-btn ' + cls;
-        b.innerHTML = html;
-        b.addEventListener('click', onClick);
-        return b;
-    }
-
-    /* Our own custom-image picker — uploaded icons ONLY (getcustomiconset). */
-    function buildPicker(surface) {
-        var panel = document.createElement('div');
-        panel.className = 'ng-dd-icon-picker';
-        panel.innerHTML = '<div class="ng-dd-icon-picker-loading">' +
-            '<i class="fa-solid fa-spinner fa-spin"></i> Loading your custom images…</div>';
-
-        fetchCustomSet(function (list) {
-            panel.innerHTML = '';
-            var note = document.createElement('div');
-            note.className = 'ng-dd-icon-picker-note';
-            note.innerHTML = '<i class="fa-solid fa-circle-info"></i> Your own uploaded ' +
-                'custom images. Manage them in Setup ▸ More Options ▸ Custom Icons. ' +
-                'Selecting one sets it as the Domoticz image — click <strong>' +
-                surface.applyLabel + '</strong> to save.';
-            panel.appendChild(note);
-
-            if (!list.length) {
-                var empty = document.createElement('div');
-                empty.className = 'ng-dd-icon-picker-empty';
-                empty.innerHTML = '<i class="fa-solid fa-cloud-arrow-up"></i> ' +
-                    'No custom images uploaded yet. Upload a ZIP via ' +
-                    'Setup ▸ More Options ▸ Custom Icons.';
-                panel.appendChild(empty);
-                return;
-            }
-
-            var grid = document.createElement('div');
-            grid.className = 'ng-dd-icon-grid';
-            var curCi = surface.getCustomImage();
-
-            list.forEach(function (icon) {
-                var value = (parseInt(icon.idx, 10) || 0) + 100;   // stored CustomImage
-                var tile = document.createElement('button');
-                tile.type = 'button';
-                tile.className = 'ng-dd-icon-tile' + (value === curCi ? ' ng-dd-icon-tile--active' : '');
-                tile.title = (icon.Title || '') + (icon.Description ? ' — ' + icon.Description : '');
-                tile.innerHTML =
-                    '<img src="' + icon.IconFile48On + '" alt="">' +
-                    '<span>' + (icon.Title || ('#' + icon.idx)) + '</span>';
-                tile.addEventListener('click', function () {
-                    surface.setCustomImage(value);
-                    render(surface);              // reflect new provenance immediately
-                });
-                grid.appendChild(tile);
+                }
             });
-            panel.appendChild(grid);
-        });
+        } else if (s && s.openIconOverride) {
+            s.openIconOverride(surface.idx);
+            scheduleRefresh(surface);
+        }
+    }
 
-        return panel;
+    function useDefault(surface) {
+        var s = settings();
+        if (s && s.removeDeviceOverride) s.removeDeviceOverride(surface.idx);
+        if (surface.getCustomImage() > 0) {
+            surface.setCustomImage(0);
+            markDirty(surface);
+        }
+        render(surface);
+    }
+
+    function markDirty(surface) {
+        var box = surface.td && surface.td.querySelector('#' + BOX_ID);
+        if (box) box.setAttribute('data-dirty', '1');
     }
 
     /* The override dialog saves asynchronously; poll briefly so provenance

--- a/src/js/device-detail.js
+++ b/src/js/device-detail.js
@@ -44,6 +44,96 @@
     function settings() { return window.dzNightglassSettings || null; }
     function jq()       { return window.jQuery || window.$ || null; }
 
+    function injector() {
+        try {
+            return (window.angular && angular.element(document.body).injector()) || null;
+        } catch (e) { return null; }
+    }
+
+    /* ── Where an icon choice is stored ───────────────────────────────
+       Domoticz grew a per-device icon of its own: a DeviceStatus.Icon
+       column holding {"t":"<prefix>","on":"<class>"[,"off":"<class>"]},
+       written by setused's &icon=, plus CustomImage for an uploaded PNG.
+       Where that exists it is the right home for a Nightglass pick — the
+       server renders it, so the choice survives without the theme, and
+       the theme's own override blob stays what it always was rather than
+       growing a second, parallel icon store.
+
+       Stable Domoticz has neither the column nor the endpoint, and
+       silently posting &icon= there would be rejected ("Invalid icon")
+       or ignored. So this is version-gated: without native storage the
+       behaviour below is byte-for-byte what it was — glyph to the theme
+       blob, image to the ddslick.
+
+       The gate is dzIconService: it owns the Icon column's JSON contract
+       on the client, and www ships with the binary, so its presence IS
+       the server's. It is route-loaded, which is fine — the two routes
+       that load it are exactly the two surfaces this module drives. The
+       DOM check covers the Utility dialogs, which are jQuery and may run
+       before the injector is reachable. Latched: once seen, never
+       re-probed, so a route that hasn't loaded the module yet cannot
+       downgrade a device page mid-edit. */
+    var _nativeStore = false;
+    function nativeIconStorage() {
+        if (_nativeStore) return true;
+        var inj = injector();
+        try {
+            if (inj && inj.has('dzIconService')) { _nativeStore = true; return true; }
+        } catch (e) {}
+        if (document.querySelector('dz-icon-picker, .dz-icon-picker-host')) {
+            _nativeStore = true;
+            return true;
+        }
+        return false;
+    }
+
+    /* The Icon JSON, exactly as dzIconPicker.serializeIcon() writes it and
+       NormaliseDeviceIcon() in main/WebServerCmds.cpp accepts it: "t" is the
+       library prefix (required, no spaces, ≤32 chars), "on" the full class
+       string (≤128, spaces allowed) and "off" is omitted when it would equal
+       "on" — dzIconService.resolveIconClass() reads `off || on`. Classes are
+       restricted to [A-Za-z0-9 _-]; anything else is refused outright with
+       {"error":"Invalid icon"} and nothing is written. The server re-serialises
+       what it accepts, so only the values have to match, not the key order. */
+    function iconProviderOf(cls) {
+        var token = String(cls || '').trim().split(/\s+/)[0] || '';
+        return (token === 'fa' || token.indexOf('fa-') === 0) ? 'fa' : token;
+    }
+
+    function serializeIcon(on, off) {
+        on = String(on || '').replace(/\s+/g, ' ').trim();
+        if (!on) return '';
+        var payload = { t: iconProviderOf(on), on: on };
+        if (off && off !== on) payload.off = off;
+        return JSON.stringify(payload);
+    }
+
+    function parseIcon(json) {
+        if (!json) return null;
+        var parsed = json;
+        if (typeof json === 'string') {
+            try { parsed = JSON.parse(json); } catch (e) { return null; }
+        }
+        if (!parsed || typeof parsed !== 'object' || typeof parsed.on !== 'string') return null;
+        var on = parsed.on.replace(/\s+/g, ' ').trim();
+        if (!on) return null;
+        return { on: on, off: (typeof parsed.off === 'string' ? parsed.off.trim() : '') };
+    }
+
+    /* A pick is not saved until the page's Save / the dialog's Update, so it
+       has to be remembered somewhere until then. The Angular surface has the
+       live scope model for that; the Utility dialogs don't, and detectSurface()
+       rebuilds their surface object on every mutation burst, so the pending
+       choice lives here instead of in the surface closure. Keyed by idx so
+       opening a different device drops it. */
+    var _pending = null;
+    function pendingFor(idx) {
+        return (_pending && _pending.idx === String(idx)) ? _pending : null;
+    }
+    function setPending(idx, ci, icon) {
+        _pending = { idx: String(idx), ci: ci, icon: icon || '' };
+    }
+
     /* ── Data ─────────────────────────────────────────────────────── */
 
     function fetchCustomSet(cb) {
@@ -124,20 +214,53 @@
             device: device,
             applyLabel: 'Save',
             getCustomImage: function () { return parseInt(device.CustomImage, 10) || 0; },
+            /* vm.device is the model the page's Save serialises (customimage +
+               icon), so it is both the store and the source of truth here — no
+               pending copy needed. */
+            getIcon: function () { return device.Icon || ''; },
             withDevice: function (cb) { cb(device); },
-            setCustomImage: function (value) {
+            setCustomImage: function (value) { this.setSelection(value, this.getIcon()); },
+            setSelection: function (value, icon) {
                 var dev = scope.vm ? scope.vm.device : scope.device;
+                var native = nativeIconStorage();
+                function assign() {
+                    dev.CustomImage = value;
+                    /* Only touch Icon where the column exists: on stable it is
+                       not in the model and setused would reject &icon=. */
+                    if (native) dev.Icon = icon || '';
+                }
                 /* Our click runs outside Angular, so a digest usually isn't in
                    flight — $apply commits the model + updates Save. Guard on
                    $$phase to avoid "digest already in progress". */
                 if (scope.$$phase || (scope.$root && scope.$root.$$phase)) {
-                    dev.CustomImage = value;
+                    assign();
                 } else {
-                    scope.$apply(function () { dev.CustomImage = value; });
+                    scope.$apply(assign);
                 }
                 device.CustomImage = value;
+                if (native) device.Icon = icon || '';
+                return native;
             }
         };
+    }
+
+    /* On native, the Utility dialog's persistence bridge is
+       dzIconPickerService: UtilityController.iconParams() reads
+       getCustomImage()/getIcon() off it when Update is pressed. mount() is its
+       only setter, so re-mount the (CSS-hidden) native field with the new
+       values — the same "drive the native control, let Domoticz save" trick the
+       ddslick path uses, one API up. */
+    function mountNativeBridge(surface, value, icon) {
+        var inj = injector();
+        if (!inj) return false;
+        var svc;
+        try { svc = inj.get('dzIconPickerService'); } catch (e) { return false; }
+        var host = surface.td && surface.td.querySelector('.dz-icon-picker-host');
+        if (!host || !svc || typeof svc.mount !== 'function') return false;
+        try {
+            svc.mount(host, { customImage: value, icon: icon || '', device: surface.device });
+            return true;
+        } catch (e) { return false; }
     }
 
     function makeJquerySurface(comboEl, idx) {
@@ -151,8 +274,15 @@
             device: _devByIdx[idx] || null,
             applyLabel: 'Update',
             getCustomImage: function () {
+                var p = pendingFor(idx);
+                if (p) return p.ci;
                 var v = comboEl.querySelector('.dd-selected-value');
                 return v ? (parseInt(v.value, 10) || 0) : curVal;
+            },
+            getIcon: function () {
+                var p = pendingFor(idx);
+                if (p) return p.icon;
+                return (this.device && this.device.Icon) || '';
             },
             withDevice: function (cb) {
                 if (this.device) { cb(this.device); return; }
@@ -160,9 +290,14 @@
                 var self = this;
                 fetchDevice(idx, function (d) { self.device = d; cb(d); });
             },
-            setCustomImage: function (value) {
+            setCustomImage: function (value) { this.setSelection(value, this.getIcon()); },
+            setSelection: function (value, icon) {
+                if (nativeIconStorage() && mountNativeBridge(this, value, icon)) {
+                    setPending(idx, value, icon);
+                    return true;
+                }
                 var $ = jq();
-                if (!$) return;
+                if (!$) return false;
                 var data = $.ddData || [];
                 var sel = -1;
                 for (var i = 0; i < data.length; i++) {
@@ -171,6 +306,7 @@
                 }
                 if (sel < 0 && value === 0) sel = 0;   // Default row
                 if (sel >= 0) { try { $(comboEl).ddslick('select', { index: sel }); } catch (e) {} }
+                return false;
             }
         };
     }
@@ -183,11 +319,27 @@
     function resolveSource(surface, device) {
         var s = settings();
         var ov = s && s.getDeviceOverride ? s.getDeviceOverride(surface.idx) : null;
-        if (ov && (ov.iconOn || ov.iconOpen || ov.icon)) {
-            var cls = ov.iconOn || ov.iconOpen || ov.icon;
+        var ovCls = ov && (ov.iconOn || ov.iconOpen || ov.icon);
+        var native = nativeIconStorage();
+
+        /* Native fields first where they exist: Domoticz renders the Icon
+           column / CustomImage itself, so that is what is actually on screen
+           — the theme blob only tints a native glyph, it cannot reshape it.
+           Without native storage the blob comes first, exactly as before. */
+        if (native) {
+            var icon = parseIcon(surface.getIcon());
+            if (icon) {
+                return {
+                    kind: 'nativeIcon',
+                    name: icon.on + (icon.off ? ' / ' + icon.off : ''),
+                    origin: 'icon set on this device',
+                    iconCls: icon.on, color: null, isDefault: false
+                };
+            }
+        } else if (ovCls) {
             return {
-                kind: 'override', name: cls, origin: 'Nightglass override',
-                iconCls: cls, color: ov.on || '#4e9af1', isDefault: false
+                kind: 'override', name: ovCls, origin: 'Nightglass override',
+                iconCls: ovCls, color: (ov && ov.on) || '#4e9af1', isDefault: false
             };
         }
 
@@ -213,6 +365,16 @@
                 isDefault: false
             };
         }
+        /* Nothing native is set, so an override written before this Domoticz
+           had the Icon column is still the effective shape everywhere the
+           theme replaces PNGs, and reads as the current pick here too. */
+        if (native && ovCls) {
+            return {
+                kind: 'override', name: ovCls, origin: 'Nightglass override (theme-only)',
+                iconCls: ovCls, color: (ov && ov.on) || '#4e9af1', isDefault: false
+            };
+        }
+
         var themeSpec = device && typeof window._dzIconForDevice === 'function'
             ? window._dzIconForDevice(device) : null;
         return {
@@ -326,17 +488,13 @@
 
     function openStudio(surface, device, src) {
         var s = settings();
-        /* Open the Icon Studio for this device and apply the pick as an
-           override (preserving any existing colors). Falls back to the full
-           override dialog if the Studio module isn't available. */
-        if (typeof window.dzOpenIconStudio === 'function' && s && s.setDeviceOverrideIcon) {
+        /* Open the Icon Studio for this device. Falls back to the full override
+           dialog if the Studio module isn't available. */
+        if (typeof window.dzOpenIconStudio === 'function') {
             window.dzOpenIconStudio({
                 current: src.iconCls || '',
                 title: 'Set icon for ' + ((device && device.Name) || 'device'),
-                onPick: function (cls) {
-                    s.setDeviceOverrideIcon(surface.idx, cls, device && device.Name);
-                    render(surface);
-                }
+                onPick: function (cls) { applyGlyph(surface, device, cls); }
             });
         } else if (s && s.openIconOverride) {
             s.openIconOverride(surface.idx);
@@ -344,11 +502,40 @@
         }
     }
 
+    /* A glyph goes to Domoticz's Icon column where there is one, and to the
+       theme's override blob where there isn't. Only the "on" class is written:
+       the Studio picks one icon, and native reads `off || on`, so one class
+       means one shape in both states — the same thing a Nightglass override
+       has always meant.
+
+       On native the colour is not written with it. DEVICE_MAP still tints the
+       glyph by device type, and a per-device colour remains the settings
+       panel's override editor to set; what does not happen any more is the
+       shape being recorded in two places at once. */
+    function applyGlyph(surface, device, cls) {
+        if (nativeIconStorage()) {
+            /* Icon and CustomImage are alternatives, not layers —
+               dzIconService.resolve() gives Icon precedence, so leaving a stale
+               CustomImage behind would only confuse a later read. */
+            surface.setSelection(0, serializeIcon(cls, null));
+            markDirty(surface);
+        } else {
+            var s = settings();
+            if (s && s.setDeviceOverrideIcon) {
+                s.setDeviceOverrideIcon(surface.idx, cls, device && device.Name);
+            }
+        }
+        render(surface);
+    }
+
     function useDefault(surface) {
         var s = settings();
+        /* Clear every layer in one press rather than peeling them off one at a
+           time: "Use default" should mean the device is back to what Domoticz
+           picks for its type, whichever store the current icon came from. */
         if (s && s.removeDeviceOverride) s.removeDeviceOverride(surface.idx);
-        if (surface.getCustomImage() > 0) {
-            surface.setCustomImage(0);
+        if (surface.getCustomImage() > 0 || parseIcon(surface.getIcon())) {
+            surface.setSelection(0, '');
             markDirty(surface);
         }
         render(surface);
@@ -388,9 +575,15 @@
     function init() {
         mo.observe(document.body, { childList: true, subtree: true });
         [200, 600, 1400].forEach(function (d) { setTimeout(enhance, d); });
+        var $ = jq();
+        /* Closing a Utility dialog without pressing Update abandons the pick.
+           Forget it, or the next open of the same device would show it as
+           though it had been saved. */
+        if ($) $(document).on('dialogclose', function () { _pending = null; });
         try {
             var $rootScope = angular.element(document.body).injector().get('$rootScope');
             $rootScope.$on('$routeChangeSuccess', function () {
+                _pending = null;
                 [200, 700, 1500].forEach(function (d) { setTimeout(enhance, d); });
             });
         } catch (e) {}

--- a/src/js/device-detail.js
+++ b/src/js/device-detail.js
@@ -19,7 +19,7 @@
    CSS supplies the same appearance from scratch.
 
    "Use default" sits in the field rather than inside the Studio: the
-   Studio is shared with the settings panel's override editor, where
+   Studio is shared with the settings panel's device-icon editor, where
    "default" means nothing, and keeping the reset next to the preview
    puts the state and the action that clears it in one place.
 
@@ -85,6 +85,28 @@
             return true;
         }
         return false;
+    }
+
+    /* The latch above can only say "yes" from a route that already loaded
+       dzIconService, which is precisely the two surfaces this module drives.
+       The settings panel's icon editor is a third caller, on a route that
+       never loads it, so a synchronous "no" there would be a false negative.
+       Asking the server for the file settles it independently of routing:
+       dzIconService.js ships in www alongside the binary that has the Icon
+       column, so a 200 IS the column. One request, shared by every caller. */
+    var _probe = null;
+    function probeNativeStorage(cb) {
+        if (_nativeStore) { cb(true); return; }
+        if (!_probe) {
+            _probe = fetch('app/icons/dzIconService.js',
+                           { method: 'HEAD', credentials: 'same-origin' })
+                .then(function (r) { return !!(r && r.ok); })
+                .catch(function () { return false; });
+        }
+        _probe.then(function (ok) {
+            if (ok) _nativeStore = true;
+            cb(ok);
+        });
     }
 
     /* The Icon JSON, exactly as dzIconPicker.serializeIcon() writes it and
@@ -338,7 +360,7 @@
             }
         } else if (ovCls) {
             return {
-                kind: 'override', name: ovCls, origin: 'Nightglass override',
+                kind: 'override', name: ovCls, origin: 'set in Nightglass',
                 iconCls: ovCls, color: (ov && ov.on) || '#4e9af1', isDefault: false
             };
         }
@@ -370,7 +392,7 @@
            theme replaces PNGs, and reads as the current pick here too. */
         if (native && ovCls) {
             return {
-                kind: 'override', name: ovCls, origin: 'Nightglass override (theme-only)',
+                kind: 'override', name: ovCls, origin: 'set in Nightglass (this theme only)',
                 iconCls: ovCls, color: (ov && ov.on) || '#4e9af1', isDefault: false
             };
         }
@@ -536,8 +558,8 @@
 
     function openStudio(surface, device, src) {
         var s = settings();
-        /* Open the Icon Studio for this device. Falls back to the full override
-           dialog if the Studio module isn't available. */
+        /* Open the Icon Studio for this device. Falls back to the settings
+           panel's Device Icons dialog if the Studio module isn't available. */
         if (typeof window.dzOpenIconStudio === 'function') {
             var ci   = surface.getCustomImage();
             var pair = currentIconPair(surface, src);
@@ -586,7 +608,7 @@
        device the user never gave a distinct off icon behaves exactly as before.
 
        Nothing here writes colour. DEVICE_MAP still tints the glyph by device
-       type, and a per-device colour remains the settings panel's override
+       type, and a per-device colour remains the settings panel's device-icon
        editor to set; the shape is not recorded in two places at once. */
     function applyGlyph(surface, device, onCls, offCls) {
         onCls  = String(onCls || '').trim();
@@ -651,7 +673,90 @@
         if (box) box.setAttribute('data-dirty', '1');
     }
 
-    /* The override dialog saves asynchronously; poll briefly so provenance
+    /* ── Writing the Icon column without a surface ─────────────────────
+       Both surfaces above only stage a pick: the page's Save / the dialog's
+       Update issues the setused that stores it. The settings panel's icon
+       editor is not on a device page, so it has no Save to ride on and needs
+       the write itself.
+
+       Domoticz has no icon-only endpoint — the Icon column is written by
+       setused, which leaves most parameters it is not given alone (description,
+       switchtype, options, strparams and the rest all survive being omitted)
+       but has two traps for a partial write, both found by trying it against a
+       real server rather than by reading the handler:
+
+         • `protected` is read with a default of false, so omitting it silently
+           unprotects the device. Send it back unchanged.
+         • `customimage` is only acted on when `name` is sent alongside it.
+           Without a name, customimage=0 is quietly dropped and a stale
+           uploaded image stays behind the new glyph — and then survives a
+           "use default", which is the one thing it must not do. Send the
+           device's own name, which leaves the name itself untouched.
+
+       Published rather than reimplemented next to the caller so the
+       {"t","on","off"} contract and the Icon-vs-CustomImage exclusivity have
+       exactly one home. `device` is a getdevices record — the caller already
+       has one, and reusing it keeps Protected honest without a second read.
+
+       `spec` says what the device should end up carrying:
+         { on, off }        a glyph pair (off optional)
+         { image: <n> }     an uploaded PNG, as DeviceStatus.CustomImage stores it
+         null / {}          neither — back to the device type's own icon
+       The two are alternatives, not layers: dzIconService.resolve() prefers
+       Icon, so setting either clears the other and a clear clears both. That
+       rule lives here so no caller has to remember it. */
+    function writeIcon(device, spec, done) {
+        done = done || function () {};
+        var idx = device && (device.idx !== undefined ? device.idx : device.IDX);
+        if (!/^\d+$/.test(String(idx)) || !nativeIconStorage()) { done(false); return; }
+        /* A record without these is a stub, not a device we know: guessing
+           Protected would unprotect a protected device, and a missing name
+           would silently cost us the CustomImage clear. Read the real one. */
+        if (device.Protected === undefined || !device.Name) {
+            fetchDevice(idx, function (full) {
+                if (!full) { done(false); return; }
+                writeIcon(full, spec, done);
+            });
+            return;
+        }
+        spec = spec || {};
+        var icon  = serializeIcon(spec.on, spec.off);
+        /* A glyph wins if both were somehow given, matching the precedence the
+           server renders with, so what is stored is what will be drawn. */
+        var image = icon ? 0 : (parseInt(spec.image, 10) || 0);
+        var url = 'json.htm?type=command&param=setused&used=true' +
+                  '&idx=' + encodeURIComponent(idx) +
+                  '&icon=' + encodeURIComponent(icon) +
+                  '&customimage=' + image +
+                  /* Unchanged, and only here because customimage needs it. */
+                  '&name=' + encodeURIComponent(device.Name) +
+                  '&protected=' + (device.Protected ? 'true' : 'false');
+        fetch(url, { credentials: 'same-origin' })
+            .then(function (r) { return r.json(); })
+            .then(function (d) {
+                var ok = !!(d && d.status === 'OK');
+                if (ok) {
+                    /* Keep the caller's record (and our own cache, which may be
+                       the same object) agreeing with the server. */
+                    device.Icon = icon;
+                    device.CustomImage = image;
+                }
+                done(ok);
+            })
+            .catch(function () { done(false); });
+    }
+
+    /* The settings panel's device-icon editor edits the same two stores as
+       this module: Domoticz's Icon column for the shape, the theme blob for
+       colour and motion. It gets the store, not a copy of it. */
+    window.dzDeviceIconStore = {
+        isNative:     nativeIconStorage,
+        probeNative:  probeNativeStorage,
+        parse:        parseIcon,
+        write:        writeIcon
+    };
+
+    /* The settings dialog saves asynchronously; poll briefly so provenance
        refreshes without leaving the page. */
     function scheduleRefresh(surface) {
         var n = 0;

--- a/src/js/device-detail.js
+++ b/src/js/device-detail.js
@@ -491,10 +491,22 @@
         /* Open the Icon Studio for this device. Falls back to the full override
            dialog if the Studio module isn't available. */
         if (typeof window.dzOpenIconStudio === 'function') {
+            var ci = surface.getCustomImage();
             window.dzOpenIconStudio({
                 current: src.iconCls || '',
+                /* Only an uploaded image (>= 100) is offered, so only that can
+                   be the current pick; a built-in is not in the grid to mark. */
+                currentImage: ci >= 100 ? ci : 0,
+                /* Uploaded PNGs are the one choice a class string cannot carry,
+                   and CustomImage is where they go — which only exists as a
+                   destination once Domoticz owns the pick. Without native
+                   storage the theme blob is the store, and it holds classes
+                   only, so there is nowhere to put an image and the source
+                   stays hidden rather than offering a dead end. */
+                allowImages: nativeIconStorage(),
                 title: 'Set icon for ' + ((device && device.Name) || 'device'),
-                onPick: function (cls) { applyGlyph(surface, device, cls); }
+                onPick: function (cls) { applyGlyph(surface, device, cls); },
+                onPickImage: function (customImage) { applyImage(surface, customImage); }
             });
         } else if (s && s.openIconOverride) {
             s.openIconOverride(surface.idx);
@@ -525,6 +537,21 @@
                 s.setDeviceOverrideIcon(surface.idx, cls, device && device.Name);
             }
         }
+        render(surface);
+    }
+
+    /* An uploaded image is the mirror image of a glyph: CustomImage carries it
+       and Icon must be cleared, or dzIconService.resolve() would keep returning
+       the glyph it prefers and the pick would appear to do nothing.
+
+       customImage arrives already resolved to the value DeviceStatus.CustomImage
+       stores — the Studio adds back the 100 that getcustomiconset subtracts —
+       so there is no offset left to apply here. */
+    function applyImage(surface, customImage) {
+        customImage = parseInt(customImage, 10) || 0;
+        if (customImage <= 0) return;
+        surface.setSelection(customImage, '');
+        markDirty(surface);
         render(surface);
     }
 

--- a/src/js/device-detail.js
+++ b/src/js/device-detail.js
@@ -399,10 +399,33 @@
         return null;
     }
 
-    function buildPreview(src) {
+    /* ── Animation ────────────────────────────────────────────────────
+       An animation cannot go where the icon goes: Domoticz validates the
+       Icon column to {"t","on","off"} and rejects anything else outright,
+       so motion stays in the theme's own override blob even on a build
+       that owns the icon itself. That also means it saves on the spot,
+       unlike a pick, which waits for the page's Save. */
+
+    function currentAnim(surface) {
+        var s  = settings();
+        var ov = s && s.getDeviceOverride ? s.getDeviceOverride(surface.idx) : null;
+        return (ov && ov.anim) || '';
+    }
+
+    function animLabel(id) {
+        var list = window.dzIconAnimations || [];
+        for (var i = 0; i < list.length; i++) {
+            if (list[i].id === id) return list[i].label;
+        }
+        return '';
+    }
+
+    function buildPreview(src, anim) {
         var wrap = document.createElement('span');
         wrap.className = 'dz-icon-field-preview';
-        wrap.title = src.name + ' — ' + src.origin;
+        var label = animLabel(anim);
+        wrap.title = src.name + ' — ' + src.origin +
+                     (label ? '; ' + label + ' animation' : '');
         if (src.pngSrc) {
             var im = document.createElement('img');
             im.src = src.pngSrc; im.alt = '';
@@ -410,7 +433,12 @@
             return wrap;
         }
         var i = document.createElement('i');
-        i.className = src.iconCls || 'fa-regular fa-square';
+        /* The preview animates too — the field is the one place that shows
+           what this device's icon actually does. */
+        var animCls = (typeof window.dzIconAnimClass === 'function')
+            ? window.dzIconAnimClass(anim) : '';
+        i.className = (src.iconCls || 'fa-regular fa-square') +
+                      (animCls ? ' ' + animCls : '');
         if (src.color) i.style.color = src.color;
         wrap.appendChild(i);
         return wrap;
@@ -446,13 +474,15 @@
                been read; re-render when it lands rather than showing "#101". */
             if (ci >= 100 && !_customSet) fetchCustomSet(function () { render(surface); });
 
+            var anim = currentAnim(surface);
             var sig = [surface.idx, src.kind, src.iconCls || '', src.color || '',
-                       src.pngSrc || '', ci, box.getAttribute('data-dirty') || ''].join('|');
+                       src.pngSrc || '', ci, anim,
+                       box.getAttribute('data-dirty') || ''].join('|');
             if (box.getAttribute('data-sig') === sig) return;
             box.setAttribute('data-sig', sig);
 
             box.innerHTML = '';
-            box.appendChild(buildPreview(src));
+            box.appendChild(buildPreview(src, anim));
 
             box.appendChild(mkBtn('dz-icon-field-btn', 'Change…', function () {
                 openStudio(surface, device, src);
@@ -486,14 +516,33 @@
         return a;
     }
 
+    /* The on/off glyph pair currently in effect for a device, from whichever
+       store holds it. Domoticz's Icon column IS an {on, off} pair; the theme
+       blob carries iconOn/iconOff — so both halves come from one place and the
+       Studio's two slots start on what is really set. */
+    function currentIconPair(surface, src) {
+        if (nativeIconStorage()) {
+            var icon = parseIcon(surface.getIcon());
+            if (icon) return { on: icon.on, off: icon.off || '' };
+            return { on: src.iconCls || '', off: '' };
+        }
+        var s  = settings();
+        var ov = s && s.getDeviceOverride ? s.getDeviceOverride(surface.idx) : null;
+        return {
+            on:  (ov && (ov.iconOn || ov.icon)) || src.iconCls || '',
+            off: (ov && ov.iconOff) || ''
+        };
+    }
+
     function openStudio(surface, device, src) {
         var s = settings();
         /* Open the Icon Studio for this device. Falls back to the full override
            dialog if the Studio module isn't available. */
         if (typeof window.dzOpenIconStudio === 'function') {
-            var ci = surface.getCustomImage();
+            var ci   = surface.getCustomImage();
+            var pair = currentIconPair(surface, src);
             window.dzOpenIconStudio({
-                current: src.iconCls || '',
+                current: pair.on,
                 /* Only an uploaded image (>= 100) is offered, so only that can
                    be the current pick; a built-in is not in the grid to mark. */
                 currentImage: ci >= 100 ? ci : 0,
@@ -504,9 +553,25 @@
                    only, so there is nowhere to put an image and the source
                    stays hidden rather than offering a dead end. */
                 allowImages: nativeIconStorage(),
+                /* Two slots so the off state can differ from the on state, the
+                   way Domoticz's own native picker now offers. An off left
+                   unset falls back to on in every store, so leaving it alone
+                   keeps the old single-icon behaviour. */
+                slots: [
+                    { key: 'on',  label: 'On / active',    cls: pair.on },
+                    { key: 'off', label: 'Off / inactive', cls: pair.off }
+                ],
+                /* One device in view, so an animation has somewhere to
+                   belong — offer the row and preview it on this icon. */
+                animation: currentAnim(surface),
+                animationGlyph: pair.on,
                 title: 'Set icon for ' + ((device && device.Name) || 'device'),
-                onPick: function (cls) { applyGlyph(surface, device, cls); },
-                onPickImage: function (customImage) { applyImage(surface, customImage); }
+                onPickSlot: function (key, cls) {
+                    pair[key] = cls;
+                    applyGlyph(surface, device, pair.on, pair.off);
+                },
+                onPickImage: function (customImage) { applyImage(surface, customImage); },
+                onPickAnimation: function (id) { applyAnim(surface, device, id); }
             });
         } else if (s && s.openIconOverride) {
             s.openIconOverride(surface.idx);
@@ -514,28 +579,41 @@
         }
     }
 
-    /* A glyph goes to Domoticz's Icon column where there is one, and to the
-       theme's override blob where there isn't. Only the "on" class is written:
-       the Studio picks one icon, and native reads `off || on`, so one class
-       means one shape in both states — the same thing a Nightglass override
-       has always meant.
+    /* The on/off glyph pair goes to Domoticz's Icon column where there is one,
+       and to the theme's override blob where there isn't. An off equal to (or
+       absent alongside) on is stored as a single shape — native reads
+       `off || on`, and the blob's applyDeviceOverride does the same — so a
+       device the user never gave a distinct off icon behaves exactly as before.
 
-       On native the colour is not written with it. DEVICE_MAP still tints the
-       glyph by device type, and a per-device colour remains the settings
-       panel's override editor to set; what does not happen any more is the
-       shape being recorded in two places at once. */
-    function applyGlyph(surface, device, cls) {
+       Nothing here writes colour. DEVICE_MAP still tints the glyph by device
+       type, and a per-device colour remains the settings panel's override
+       editor to set; the shape is not recorded in two places at once. */
+    function applyGlyph(surface, device, onCls, offCls) {
+        onCls  = String(onCls || '').trim();
+        offCls = String(offCls || '').trim();
+        if (!onCls) return;                    // an icon needs at least an on state
         if (nativeIconStorage()) {
             /* Icon and CustomImage are alternatives, not layers —
                dzIconService.resolve() gives Icon precedence, so leaving a stale
                CustomImage behind would only confuse a later read. */
-            surface.setSelection(0, serializeIcon(cls, null));
+            surface.setSelection(0, serializeIcon(onCls, offCls || null));
             markDirty(surface);
         } else {
             var s = settings();
-            if (s && s.setDeviceOverrideIcon) {
-                s.setDeviceOverrideIcon(surface.idx, cls, device && device.Name);
+            if (s && s.setDeviceOverrideIcons) {
+                s.setDeviceOverrideIcons(surface.idx, onCls, offCls, device && device.Name);
             }
+        }
+        render(surface);
+    }
+
+    /* The theme blob is the only store for an animation, so this one takes
+       effect immediately rather than waiting for Save — and it is not marked
+       dirty, because there is nothing left for Save to write. */
+    function applyAnim(surface, device, animId) {
+        var s = settings();
+        if (s && s.setDeviceOverrideAnim) {
+            s.setDeviceOverrideAnim(surface.idx, animId, device && device.Name);
         }
         render(surface);
     }

--- a/src/js/icon-studio.js
+++ b/src/js/icon-studio.js
@@ -29,6 +29,7 @@
     var RECENT_KEY = 'dz-icon-recent';
     var RECENT_MAX = 24;
     var RESULT_CAP = 300;
+    var SEARCH_DELAY = 200;          // ms; matches the native Domoticz picker
 
     /* Popular icon-font libraries offered as one-click suggestions in the
        manager (prefilled, NOT auto-enabled). Nightglass downloads + caches
@@ -46,8 +47,64 @@
     /* FA style/utility classes that are not glyphs. */
     var FA_STYLE = /^fa-(solid|regular|brands|light|thin|duotone|sharp|classic|2xs|xs|sm|lg|xl|2xl|[0-9]+x|fw|ul|li|border|pull-left|pull-right|spin|spin-pulse|spin-reverse|pulse|beat|fade|beat-fade|bounce|flip|flip-horizontal|flip-vertical|flip-both|rotate-90|rotate-180|rotate-270|rotate-by|stack|stack-1x|stack-2x|inverse|sr-only|sr-only-focusable|swap-opacity)$/;
 
+    /* Icon classes are only ever letters, digits, spaces, dashes and
+       underscores. Anything else is a typo or an attempt to smuggle markup
+       into the class attribute we build, so it never gets applied or stored. */
+    var SAFE_CLASS_RE = /^[A-Za-z0-9 _-]+$/;
+    function cleanClass(cls) {
+        var v = String(cls == null ? '' : cls).replace(/\s+/g, ' ').trim();
+        return SAFE_CLASS_RE.test(v) ? v : '';
+    }
+
+    /* Rightmost `prefix-name` class token in one selector.
+       Weight-variant sheets declare the glyph on a compound selector whose
+       LEADING token is the variant (`.ph-fill.ph-acorn::before`), so taking
+       the first match would collapse a whole library to a single bogus
+       "ph-fill" entry. */
+    var GLYPH_CLASS_RE = /\.([a-z][a-z0-9]*-[a-z0-9-]+)/gi;
+    function glyphClassOf(selector) {
+        var m, name = null;
+        GLYPH_CLASS_RE.lastIndex = 0;
+        while ((m = GLYPH_CLASS_RE.exec(selector)) !== null) name = m[1];
+        return name;
+    }
+
     /* ── Enumeration (cached) ─────────────────────────────────────── */
     var _cache = null;
+    function collectGlyphs(rules, set) {
+        for (var j = 0; j < rules.length; j++) {
+            var r = rules[j];
+            if (!r) continue;
+            /* @media / @supports / @layer wrap their contents in a grouping
+               rule that has no selectorText of its own; descend or the glyphs
+               inside are never seen. */
+            if (r.cssRules && r.cssRules.length) { collectGlyphs(r.cssRules, set); continue; }
+            if (!r.selectorText || !r.style) continue;
+            var faVar = r.style.getPropertyValue('--fa');
+            var content = r.style.content;
+            var isGlyph = (faVar && faVar !== 'none') ||
+                          (/::?before/.test(r.selectorText) && content &&
+                           content !== 'none' && content !== 'normal' && content !== '""');
+            if (!isGlyph) continue;
+            var sels = r.selectorText.split(',');
+            for (var k = 0; k < sels.length; k++) {
+                var name = glyphClassOf(sels[k]);
+                if (!name) continue;
+                if (name.indexOf('fa-') === 0) {
+                    if (FA_STYLE.test(name)) continue;
+                    set['fa-solid ' + name] = true;
+                } else {
+                    /* Emit the base class alongside the glyph class. Phosphor,
+                       Tabler and Weather Icons hang `font-family` on the base
+                       (`.ph`), so `class="ph-acorn"` alone renders as a
+                       zero-width Times New Roman blank. Libraries that key off
+                       an attribute selector instead (Bootstrap, Remix) don't
+                       need it but are unharmed by it. */
+                    set[name.slice(0, name.indexOf('-')) + ' ' + name] = true;
+                }
+            }
+        }
+    }
     function enumerate() {
         if (_cache) return _cache;
         var set = {};
@@ -56,31 +113,7 @@
             var rules;
             try { rules = sheets[i].cssRules || sheets[i].rules; }
             catch (e) { continue; }               // cross-origin — unreadable
-            if (!rules) continue;
-            for (var j = 0; j < rules.length; j++) {
-                var r = rules[j];
-                if (!r || !r.selectorText || !r.style) continue;
-                var faVar = r.style.getPropertyValue('--fa');
-                var content = r.style.content;
-                var isGlyph = (faVar && faVar !== 'none') ||
-                              (/::?before/.test(r.selectorText) && content &&
-                               content !== 'none' && content !== 'normal' && content !== '""');
-                if (!isGlyph) continue;
-                var sels = r.selectorText.split(',');
-                for (var k = 0; k < sels.length; k++) {
-                    var m = sels[k].match(/\.([a-z][a-z0-9]*-[a-z0-9-]+)/i);
-                    if (!m) continue;
-                    var name = m[1];
-                    if (name.indexOf('fa-') === 0) {
-                        if (FA_STYLE.test(name)) continue;
-                        set['fa-solid ' + name] = true;
-                    } else if (name.indexOf('mdi-') === 0) {
-                        set['mdi ' + name] = true;
-                    } else {
-                        set[name] = true;         // other libs: class == prefix-name
-                    }
-                }
-            }
+            if (rules) collectGlyphs(rules, set);
         }
         _cache = Object.keys(set).sort();
         return _cache;
@@ -156,10 +189,15 @@
             var sel  = chunks[i].slice(0, brace);
             var body = chunks[i].slice(brace + 1);
             if (!/content\s*:/i.test(body) && !/--fa\b/i.test(body)) continue;
-            var mm; selRe.lastIndex = 0;
-            while ((mm = selRe.exec(sel)) !== null) {
-                out[prefix + ' ' + mm[1]] = true;   // e.g. "mdi mdi-home"
-            }
+            /* Rightmost token per selector, as in enumerate(): a weight-variant
+               sheet reads `.ph-fill.ph-acorn:before`, where only the last token
+               is the glyph and the first is the variant. */
+            sel.split(',').forEach(function (one) {
+                var mm, name = null;
+                selRe.lastIndex = 0;
+                while ((mm = selRe.exec(one)) !== null) name = mm[1];
+                if (name) out[prefix + ' ' + name] = true;   // e.g. "mdi mdi-home"
+            });
         }
         return Object.keys(out).sort();
     }
@@ -690,10 +728,24 @@
         return groups;
     }
 
+    /* The glyph is always the last whitespace token; the ones before it are
+       style/base classes. "ph ph-acorn" → "ph-acorn". */
+    function glyphTokenOf(cls) {
+        return String(cls || '').trim().split(/\s+/).pop() || '';
+    }
+
+    /* "ph ph-acorn" → "acorn" */
     function labelOf(cls) {
-        return cls.replace(/^fa-solid\s+fa-/, '').replace(/^fa-\w+\s+fa-/, '')
-                  .replace(/^mdi\s+mdi-/, '').replace(/^[a-z0-9]+[\s-]/, '')
-                  .replace(/-/g, ' ').trim();
+        return glyphTokenOf(cls).replace(/^[a-z0-9]+-/i, '').replace(/-/g, ' ').trim();
+    }
+
+    /* An override stored before base classes were emitted is a bare token
+       ("bi-alarm"); still mark its tile ("bi bi-alarm") as the current pick.
+       Only a bare token may match loosely, so "fa-solid fa-house" and
+       "fa-brands fa-house" stay distinct. */
+    function sameIcon(a, b) {
+        if (!a || !b) return false;
+        return a === b || a === glyphTokenOf(b) || b === glyphTokenOf(a);
     }
 
     function formatAge(ts) {
@@ -717,11 +769,18 @@
     }
 
     /* ── Recent (localStorage) ────────────────────────────────────── */
+    /* Guarded on read as well as write: the list is user-editable storage that
+       gets interpolated into a class attribute. */
     function getRecent() {
-        try { return JSON.parse(localStorage.getItem(RECENT_KEY) || '[]') || []; }
+        try {
+            var list = JSON.parse(localStorage.getItem(RECENT_KEY) || '[]') || [];
+            return list.map(cleanClass).filter(Boolean);
+        }
         catch (e) { return []; }
     }
     function pushRecent(cls) {
+        cls = cleanClass(cls);
+        if (!cls) return;
         try {
             var list = getRecent().filter(function (c) { return c !== cls; });
             list.unshift(cls);
@@ -768,6 +827,7 @@
     /* ── Overlay ──────────────────────────────────────────────────── */
     var _overlay = null;
     var _relaxedDialogs = [];
+    var _escHandler = null;
 
     /* jQuery UI modal dialogs (Domoticz's Utility "edit device" dialogs use
        modal: true) install a document-wide focusin trap. jQuery UI 1.12's
@@ -808,6 +868,10 @@
 
     function close() {
         if (!_overlay) return;
+        if (_escHandler) {
+            document.removeEventListener('keydown', _escHandler, true);
+            _escHandler = null;
+        }
         restoreRelaxedDialogs();
         _overlay.classList.remove('ng-is--open');
         var el = _overlay;
@@ -817,10 +881,18 @@
 
     function openIconStudio(opts) {
         opts = opts || {};
-        if (_overlay) close();
+        if (_overlay) {
+            /* Drop the outgoing overlay now rather than letting it fade: a new
+               dialog is replacing it on screen anyway, and leaving it in the
+               document would duplicate #ng-is-overlay. */
+            var prev = _overlay;
+            close();
+            if (prev.parentNode) prev.remove();
+        }
 
         var libs, all, groups;
-        var chosen    = opts.current || '';
+        /* Sanitised: it is interpolated into the preview's class attribute. */
+        var chosen    = cleanClass(opts.current);
         var scope     = 'all';           // 'all' | 'recent' | libId
         var query     = '';
 
@@ -858,8 +930,8 @@
             '    <button class="ng-is-close" aria-label="Close"><i class="fa-solid fa-xmark"></i></button>' +
             '  </div>' +
             '  <div class="ng-is-body">' +
-            '    <div class="ng-is-rail" id="ng-is-rail"></div>' +
-            '    <div class="ng-is-main" id="ng-is-main"></div>' +
+            '    <div class="ng-is-rail"></div>' +
+            '    <div class="ng-is-main"></div>' +
             '  </div>' +
             '  <div class="ng-is-foot">' +
             '    <div class="ng-is-manual">' +
@@ -867,6 +939,7 @@
             '      <input class="ng-is-manual-input" type="text" placeholder="Or paste any icon class (e.g. mdi mdi-home, fa-brands fa-github)" autocomplete="off">' +
             '      <button class="ng-is-manual-use" type="button">Use</button>' +
             '    </div>' +
+            '    <div class="ng-is-manual-msg" role="alert"></div>' +
             '  </div>' +
             '</div>';
 
@@ -874,24 +947,29 @@
         _overlay = overlay;
         requestAnimationFrame(function () { overlay.classList.add('ng-is--open'); });
 
-        var railEl   = overlay.querySelector('#ng-is-rail');
-        var mainEl   = overlay.querySelector('#ng-is-main');
+        /* Class, not id: these lived under ids nothing else referenced, and a
+           document-level id lookup can land on a still-fading overlay. */
+        var railEl   = overlay.querySelector('.ng-is-rail');
+        var mainEl   = overlay.querySelector('.ng-is-main');
         var searchEl = overlay.querySelector('.ng-is-search');
         var mInput   = overlay.querySelector('.ng-is-manual-input');
         var mPrev    = overlay.querySelector('.ng-is-manual-preview i');
+        var mMsg     = overlay.querySelector('.ng-is-manual-msg');
 
         function apply(cls) {
-            if (!cls) return;
+            cls = cleanClass(cls);
+            if (!cls) return false;
             pushRecent(cls);
             if (typeof opts.onPick === 'function') opts.onPick(cls);
             close();
+            return true;
         }
 
         /* Icon tile */
         function tile(cls) {
             var b = document.createElement('button');
             b.type = 'button';
-            b.className = 'ng-is-tile' + (cls === chosen ? ' ng-is-tile--active' : '');
+            b.className = 'ng-is-tile' + (sameIcon(cls, chosen) ? ' ng-is-tile--active' : '');
             b.title = labelOf(cls);
             b.innerHTML = '<i class="' + cls + '"></i><span>' + labelOf(cls) + '</span>';
             b.addEventListener('click', function () { apply(cls); });
@@ -911,6 +989,59 @@
                 grid.appendChild(more);
             }
             return grid;
+        }
+
+        /* ── Keyboard navigation over the rendered tiles ──────────────
+           Index into whatever the main pane currently shows; -1 = nothing
+           highlighted. renderMain() resets it because the tiles it points
+           at are replaced wholesale. */
+        var hi = -1;
+        function tiles() { return mainEl.querySelectorAll('.ng-is-tile'); }
+
+        /* Up/Down step by a full row, so they need the live column count.
+           .ng-is-grid in settings-panel.css is `repeat(auto-fill, minmax(…))`,
+           i.e. it varies with the dialog width — read the resolved track list
+           back instead of hardcoding a number that would silently drift. */
+        function columnsOf(tileEl) {
+            var grid = tileEl && tileEl.parentNode;
+            if (!grid) return 1;
+            var tracks = (window.getComputedStyle(grid).gridTemplateColumns || '').trim();
+            var n = tracks ? tracks.split(/\s+/).length : 0;
+            return n > 0 ? n : 1;
+        }
+
+        function setHighlight(i, list) {
+            if (hi >= 0 && list[hi]) list[hi].classList.remove('ng-is-tile--hi');
+            hi = i;
+            var el = list[hi];
+            if (!el) return;
+            el.classList.add('ng-is-tile--hi');
+            if (el.scrollIntoView) el.scrollIntoView({ block: 'nearest' });
+        }
+
+        function onGridKeydown(e) {
+            /* The manual-class field and the library form own their own
+               Enter/arrow behaviour. */
+            if (e.target && e.target.closest &&
+                e.target.closest('.ng-is-manual, .ng-is-lib-form')) return;
+
+            var list = tiles();
+            if (e.key === 'Enter') {
+                if (hi >= 0 && list[hi]) { e.preventDefault(); list[hi].click(); }
+                return;
+            }
+            var step;
+            if (e.key === 'ArrowLeft')       step = -1;
+            else if (e.key === 'ArrowRight') step = 1;
+            else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') step = 0;
+            else return;
+            /* Left/Right belong to the caret while the user is typing. */
+            if (step !== 0 && e.target === searchEl) return;
+            if (!list.length) return;
+            e.preventDefault();
+            if (hi < 0) { setHighlight(0, list); return; }
+            if (step === 0) step = (e.key === 'ArrowUp' ? -1 : 1) * columnsOf(list[hi]);
+            setHighlight(Math.max(0, Math.min(list.length - 1, hi + step)), list);
         }
 
         /* ── Left rail ── */
@@ -1115,6 +1246,7 @@
         /* ── Main pane ── */
         function renderMain() {
             mainEl.innerHTML = '';
+            hi = -1;               // the tiles it indexed no longer exist
 
             if (scope === 'manage') { renderManage(); return; }
 
@@ -1155,6 +1287,7 @@
 
                 function showCat(cat) {
                     activeCat = cat;
+                    hi = -1;              // swapping the grid drops the tiles
                     chipBar.querySelectorAll('.ng-is-chip').forEach(function (c) {
                         c.classList.toggle('ng-is-chip--active', c.getAttribute('data-cat') === (cat || ''));
                     });
@@ -1233,19 +1366,62 @@
         }
 
         /* ── Wire ── */
-        searchEl.addEventListener('input', function () { query = this.value.trim(); renderMain(); });
+        /* Every keystroke would otherwise re-filter and re-tile a pool of
+           thousands. Only the re-render is deferred, so the field itself stays
+           responsive. */
+        var searchTimer = null;
+        searchEl.addEventListener('input', function () {
+            var value = this.value.trim();
+            clearTimeout(searchTimer);
+            searchTimer = setTimeout(function () {
+                if (!_overlay) return;            // closed while waiting
+                query = value;
+                renderMain();
+            }, SEARCH_DELAY);
+        });
+
+        function manualFeedback(msg) {
+            mMsg.textContent = msg || '';
+            mInput.classList.toggle('ng-is-invalid', !!msg);
+        }
+        function useManual() {
+            var raw = mInput.value.trim();
+            if (!raw) { manualFeedback('Enter an icon class first, e.g. mdi mdi-home.'); return; }
+            var cls = cleanClass(raw);
+            if (!cls) {
+                manualFeedback('An icon class can only contain letters, numbers, spaces, - and _.');
+                return;
+            }
+            manualFeedback('');
+            apply(cls);
+        }
         mInput.addEventListener('input', function () {
-            mPrev.className = this.value.trim() || 'fa-solid fa-question';
+            var raw = this.value.trim();
+            var cls = cleanClass(raw);
+            mPrev.className = cls || 'fa-solid fa-question';
+            manualFeedback(raw && !cls
+                ? 'An icon class can only contain letters, numbers, spaces, - and _.' : '');
         });
         mInput.addEventListener('keydown', function (e) {
-            if (e.key === 'Enter') { e.preventDefault(); if (this.value.trim()) apply(this.value.trim()); }
+            if (e.key === 'Enter') { e.preventDefault(); useManual(); }
         });
-        overlay.querySelector('.ng-is-manual-use').addEventListener('click', function () {
-            if (mInput.value.trim()) apply(mInput.value.trim());
-        });
+        overlay.querySelector('.ng-is-manual-use').addEventListener('click', useManual);
         overlay.querySelector('.ng-is-close').addEventListener('click', close);
         overlay.addEventListener('click', function (e) { if (e.target === overlay) close(); });
-        overlay.addEventListener('keydown', function (e) { if (e.key === 'Escape') close(); });
+        overlay.addEventListener('keydown', onGridKeydown);
+
+        /* Escape goes on the document in the CAPTURE phase: bound to the
+           overlay it was missed as soon as focus left the dialog, and an open
+           jQuery UI modal underneath would see the key first and close itself
+           instead of us. Cancel only the picker, and drop the listener on
+           close() so it never outlives this instance. */
+        _escHandler = function (e) {
+            if (e.key !== 'Escape') return;
+            e.preventDefault();
+            e.stopPropagation();
+            close();
+        };
+        document.addEventListener('keydown', _escHandler, true);
 
         renderRail();
         renderMain();

--- a/src/js/icon-studio.js
+++ b/src/js/icon-studio.js
@@ -4,23 +4,22 @@
    A large, reusable icon chooser used by the Device Icon Overrides
    editor (and anywhere that needs an icon class). It:
      • enumerates EVERY icon-font glyph the browser has loaded (all of
-       Font Awesome 7 + any extra library the user added), grouped by
-       library with counts;
-     • supports user-added icon libraries (Material Design Icons, etc.)
-       via a settings-managed stylesheet URL + prefix (issue #129). Each
-       library is downloaded once, its fonts inlined, and then stored ON THE
-       DOMOTICZ SERVER (www/assets/ via the `uploadwebasset` API) so every
-       browser loads it locally. Where that isn't possible (non-admin session,
-       or a Domoticz without the endpoint) it falls back to a per-browser
-       IndexedDB copy, and finally to the source URL;
+       Font Awesome 7 + every icon library installed on this Domoticz),
+       grouped by library with counts;
      • offers search, a Recent row, Font Awesome category chips, per-
        library collapsible browsing, and a manual "enter any class"
-       field with live preview (covers cross-origin / CDN libraries the
-       browser won't let us enumerate).
+       field with live preview.
+
+   Icon libraries themselves are Domoticz's business: they are added and
+   removed on Setup → Custom Icons, live in the WebAssets table, and are
+   served from assets/ under a <link> Domoticz injects. This module only
+   reads that registry — it never installs, hosts or caches a library.
+   Because the stylesheets are therefore same-origin, their glyphs come
+   straight out of document.styleSheets and need no fetching at all.
 
    Public API:
      window.dzOpenIconStudio({ current, onPick, title })
-     window.dzInjectIconLibraries(list)   // called by the settings module
+     window.dzMigrateIconLibraries()      // called by the settings module
      window.dzEnumerateIcons()            // cached flat class list
    ══════════════════════════════════════════════════════════════════ */
 (function () {
@@ -30,19 +29,6 @@
     var RECENT_MAX = 24;
     var RESULT_CAP = 300;
     var SEARCH_DELAY = 200;          // ms; matches the native Domoticz picker
-
-    /* Popular icon-font libraries offered as one-click suggestions in the
-       manager (prefilled, NOT auto-enabled). Nightglass downloads + caches
-       them locally in the browser, so the user still only needs a source URL
-       and prefix. */
-    var SUGGESTED_LIBS = [
-        { name: 'Material Design Icons', prefix: 'mdi', cssUrl: 'https://cdn.jsdelivr.net/npm/@mdi/font@7/css/materialdesignicons.min.css' },
-        { name: 'Bootstrap Icons',       prefix: 'bi',  cssUrl: 'https://cdn.jsdelivr.net/npm/bootstrap-icons@1/font/bootstrap-icons.min.css' },
-        { name: 'Phosphor Icons',        prefix: 'ph',  cssUrl: 'https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2/src/regular/style.css' },
-        { name: 'Remix Icon',            prefix: 'ri',  cssUrl: 'https://cdn.jsdelivr.net/npm/remixicon@4/fonts/remixicon.css' },
-        { name: 'Tabler Icons',          prefix: 'ti',  cssUrl: 'https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@2/tabler-icons.min.css' },
-        { name: 'Weather Icons',         prefix: 'wi',  cssUrl: 'https://cdn.jsdelivr.net/npm/weathericons@2.0.10/css/weather-icons.min.css' }
-    ];
 
     /* FA style/utility classes that are not glyphs. */
     var FA_STYLE = /^fa-(solid|regular|brands|light|thin|duotone|sharp|classic|2xs|xs|sm|lg|xl|2xl|[0-9]+x|fw|ul|li|border|pull-left|pull-right|spin|spin-pulse|spin-reverse|pulse|beat|fade|beat-fade|bounce|flip|flip-horizontal|flip-vertical|flip-both|rotate-90|rotate-180|rotate-270|rotate-by|stack|stack-1x|stack-2x|inverse|sr-only|sr-only-focusable|swap-opacity)$/;
@@ -128,105 +114,37 @@
     window.dzEnumerateIcons = enumerate;
 
     /* ── Libraries ────────────────────────────────────────────────── */
-    /* Returns [{ id, name, prefix }] — the implicit Font Awesome library, any
-       user-configured ones, and any library Domoticz itself manages. */
+    /* Returns [{ id, name, prefix }] — the implicit Font Awesome library plus
+       every library installed on this Domoticz. Those are the only two sources:
+       adding a library is done on Domoticz's Custom Icons page, never here. */
     function configuredLibraries() {
-        var libs = [{ id: 'fa', name: 'Font Awesome', prefix: 'fa' }];
-        var byPrefix = {};
-        try {
-            var raw = (window.dzNightglassSettings &&
-                       window.dzNightglassSettings.get('iconLibraries')) || '[]';
-            var arr = typeof raw === 'string' ? JSON.parse(raw) : (raw || []);
-            (arr || []).forEach(function (l) {
-                if (!l || !l.prefix) return;
-                var entry = {
-                    id: l.id || l.prefix, name: l.name || l.prefix,
-                    prefix: l.prefix, cssUrl: l.cssUrl,
-                    /* assetPath = stored on this Domoticz server; must be
-                       carried through so loads/reopens use the local copy
-                       instead of going back out to the source URL. */
-                    assetPath: l.assetPath,
-                    unavailable: !!_nativeGone[l.id || l.prefix]
-                };
-                byPrefix[entry.prefix] = entry;
-                libs.push(entry);
-            });
-        } catch (e) {}
-
-        /* Domoticz's own registry is APPENDED, never substituted. On a prefix
-           collision the Nightglass entry wins because it carries the cssUrl and
-           assetPath a registry row has no equivalent of — but the registry's
-           Title is a real display name, so adopt it when ours is nothing better
-           than the bare prefix. */
-        nativeLibraries().forEach(function (n) {
-            var mine = byPrefix[n.prefix];
-            if (mine) {
-                if (n.title && mine.name === mine.prefix) mine.name = n.title;
-                return;
-            }
-            /* `managed` records provenance for the code, not for the UI: it is
-               what tells the loader this library is Domoticz's to fetch. */
-            libs.push({
-                id: n.id, name: n.name, prefix: n.prefix,
-                cssUrl: n.cssUrl, assetPath: n.assetPath,
-                managed: 'domoticz'
-            });
-        });
-        return libs;
+        return [{ id: 'fa', name: 'Font Awesome', prefix: 'fa' }]
+            .concat(nativeLibraries());
     }
 
-    /* Raw user library list (excludes the implicit Font Awesome entry). */
-    function readLibsRaw() {
-        try {
-            var raw = (window.dzNightglassSettings &&
-                       window.dzNightglassSettings.get('iconLibraries')) || '[]';
-            var a = typeof raw === 'string' ? JSON.parse(raw) : (raw || []);
-            return Array.isArray(a) ? a : [];
-        } catch (e) { return []; }
-    }
-    function saveLibsRaw(arr) {
-        var json = JSON.stringify(arr || []);
-        if (window.dzNightglassSettings) window.dzNightglassSettings.set('iconLibraries', json);
-        if (window.dzInjectIconLibraries) window.dzInjectIconLibraries(json);
-        _cache = null;   // force re-enumeration next time
-    }
+    /* ── Domoticz's icon-library registry ──────────────────────────────
+       Libraries live in the WebAssets table, are added/removed on Setup →
+       Custom Icons, and are listed by the `getwebassets` command.
 
-    /* ── Domoticz's own icon-library registry ──────────────────────────
-       Newer Domoticz manages icon libraries itself: they live in the WebAssets
-       table, are added/removed on Setup → Custom Icons, and are listed by the
-       `getwebassets` command. Without this, adding or removing a library there
-       was invisible to the Studio — new ones never showed up and removed ones
-       lingered as broken entries.
-
-       It is strictly an ADDITIONAL source. Stable Domoticz has none of it, so
-       every read is guarded and a missing or failing endpoint must leave
-       behaviour byte-for-byte as it was: nothing is cleared, no <link> is
-       dropped and no recent is pruned off the back of a failed fetch.
-
-       _nativeLibs stays null until one read actually succeeds, which is also
-       its permanent value on a Domoticz without the endpoint. */
+       Every read is guarded: a Domoticz without the command must leave the
+       Studio showing Font Awesome and nothing else, rather than treating a
+       missing endpoint as "every library was deleted". _nativeLibs therefore
+       stays null until one read actually succeeds, which is also its permanent
+       value on a build without the endpoint. */
     var _nativeLibs = null;
     var _nativeFetch = null;
-    var _nativeGone = {};        // our libs whose uploaded asset has vanished
+    var _nativeAssetNames = {};  // every registry file name, lowercased
     var _onNativeChange = null;  // set while the Studio is open
 
     function nativeLibraries() { return _nativeLibs || []; }
 
-    /* Nightglass uploads its own packaged copies as `iconfont-<prefix>.css`
-       (see assetFileName below) and Domoticz lists those rows too. They are
-       already represented by the iconLibraries entry that owns them, and their
-       stem would derive the bogus prefix "iconfont-mdi", so they are not
-       libraries as far as this merge is concerned. */
+    /* Older Nightglass hosted libraries itself and uploaded them as
+       `iconfont-<prefix>.css`. Anything left over from that is already covered
+       by the real `<prefix>.css` row, and its stem would derive the bogus
+       prefix "iconfontmdi", so it is not a library as far as this is
+       concerned. */
     function isOwnAssetName(name) {
         return /^iconfont-/i.test(String(name || ''));
-    }
-
-    /* `assets/iconfont-mdi.css?v=1756…` → `iconfont-mdi.css`. The cache-busting
-       query is ours alone and registry rows never carry one, so removal
-       detection has to compare on the bare file name. */
-    function assetNameOf(path) {
-        var clean = String(path || '').split('?')[0].split('#')[0];
-        return clean.slice(clean.lastIndexOf('/') + 1).toLowerCase();
     }
 
     function deriveNativeLib(asset) {
@@ -238,20 +156,7 @@
         var prefix = name.replace(/\.css$/i, '').replace(/[^a-z0-9]/gi, '');
         if (!prefix) return null;
         var title = String(asset.Title || '').trim();
-        var path = asset.path || ('assets/' + name);
-        /* cssUrl here is a cache key and a same-origin read path, not a download
-           source — Domoticz owns fetching this library. Folding LastUpdate in
-           makes a refresh on the native page miss the stored class list instead
-           of serving the previous copy's glyphs. */
-        var stamp = String(asset.LastUpdate || '').replace(/[^0-9]/g, '');
-        return {
-            id: prefix,
-            name: title || prefix,
-            prefix: prefix,
-            title: title,
-            assetPath: path,
-            cssUrl: path + (stamp ? '?ts=' + stamp : '')
-        };
+        return { id: prefix, name: title || prefix, prefix: prefix };
     }
 
     function fetchNativeLibraries(force) {
@@ -264,15 +169,16 @@
                    with an error payload. Either way there is no registry, and
                    "no registry" must never be read as "everything was deleted". */
                 if (!d || d.status !== 'OK' || !Array.isArray(d.result)) throw 0;
-                var libs = [], seen = {};
+                var libs = [], seen = {}, names = {};
                 d.result.forEach(function (a) {
+                    if (a && a.name) names[String(a.name).toLowerCase()] = true;
                     var lib = deriveNativeLib(a);
                     if (!lib || seen[lib.prefix]) return;
                     seen[lib.prefix] = true;
                     libs.push(lib);
                 });
                 _nativeLibs = libs;
-                reconcileOwnAssets(d.result);
+                _nativeAssetNames = names;
                 return libs;
             })
             .catch(function () {
@@ -283,52 +189,6 @@
             });
         _nativeFetch = job;
         return job;
-    }
-
-    /* One of our own libraries whose uploaded copy is gone from the registry was
-       removed on the native Custom Icons page. Treat it as gone — but keep the
-       user's iconLibraries entry, since a settings entry still holds the source
-       URL needed to reinstall it. Only ever reached from a SUCCESSFUL read. */
-    function reconcileOwnAssets(rows) {
-        var present = {};
-        rows.forEach(function (a) {
-            if (a && a.name) present[String(a.name).toLowerCase()] = true;
-        });
-        var changed = false;
-        readLibsRaw().forEach(function (l) {
-            if (!l || !l.assetPath) return;
-            var id = l.id || l.prefix;
-            if (present[assetNameOf(l.assetPath)]) {
-                if (_nativeGone[id]) { delete _nativeGone[id]; changed = true; }
-                return;
-            }
-            if (_nativeGone[id]) return;
-            _nativeGone[id] = true;
-            changed = true;
-            forgetVanishedLibrary(l);
-        });
-        if (!changed) return;
-        _cache = null;
-        /* Re-run injection so a library that came BACK gets its <link> again;
-           the ones still flagged are skipped there and swept away. */
-        if (window.dzInjectIconLibraries) window.dzInjectIconLibraries(readLibsRaw());
-    }
-
-    function forgetVanishedLibrary(l) {
-        var id = l.id || l.prefix;
-        var domId = libraryDomId(l);
-        var link = document.getElementById(domId);
-        if (link && link.parentNode) {
-            revokeLibraryBlobUrl(domId);
-            link.parentNode.removeChild(link);
-        }
-        delete _libIcons[id];
-        delete _libPackageLoads[libraryKey(l)];
-        setLibStatus(id, 'missing');
-        /* Both keys: the class list may have been stored under the source URL or
-           under the server path, depending on which route loaded it. */
-        dropLibCache(l.cssUrl);
-        dropLibCache(l.assetPath);
     }
 
     /* Domoticz's Custom Icons page broadcasts after every successful add,
@@ -351,6 +211,17 @@
         } catch (e) { return false; }
     }
 
+    /* Domoticz injects a <link> per asset when the app boots and has no reason
+       to look again mid-session, so nudge its loader — otherwise a library that
+       just migrated renders nothing until the next page load. */
+    function reloadNativeStylesheets() {
+        try {
+            var injector = window.angular &&
+                           window.angular.element(document.body).injector();
+            if (injector) injector.get('iconLibraries').load();
+        } catch (e) {}
+    }
+
     /* ── One-shot migration onto Domoticz's registry ───────────────────
        Nightglass used to install icon libraries itself and remembered them in
        the `iconLibraries` setting. Domoticz owns that job now, and every stored
@@ -364,9 +235,18 @@
     var LEGACY_KEY = 'iconLibraries';
     var _migrationDone = false;
 
+    function legacyLibraries() {
+        try {
+            var raw = window.dzNightglassSettings &&
+                      window.dzNightglassSettings.get(LEGACY_KEY);
+            var arr = typeof raw === 'string' ? JSON.parse(raw || '[]') : (raw || []);
+            return Array.isArray(arr) ? arr : [];
+        } catch (e) { return []; }
+    }
+
     /* `<prefix>.css` is the name Domoticz's own Custom Icons page derives from
        a prefix, so a migrated library is indistinguishable from a hand-added
-       one — including having the prefix read back off the file stem. */
+       one — including having its prefix read back off the file stem. */
     function nativeAssetName(prefix) {
         return String(prefix || '') + '.css';
     }
@@ -391,20 +271,22 @@
     }
 
     /* The theme's own upload for a library it has just handed over. Left in
-       place it would keep its Domoticz-injected <link>, so the same font would
-       be fetched and declared twice for the rest of the install's life. Scoped
-       to our own `iconfont-` naming and only ever reached after that library's
+       place it would keep the <link> Domoticz injects for it, so the same font
+       would be fetched and declared twice for the rest of the install's life.
+       Derived from the prefix rather than the entry's recorded assetPath: that
+       field was only ever written locally, so plenty of installs know the file
+       exists without having a path for it. Only reached once that library's
        migration succeeded. */
-    function dropOwnUpload(assetPath) {
-        var name = assetNameOf(assetPath);
-        if (!/^iconfont-[a-z0-9_-]+\.css$/.test(name)) return;
+    function dropOwnUpload(prefix) {
+        var name = 'iconfont-' + prefix + '.css';
+        if (!_nativeAssetNames[name]) return;
         fetch('json.htm?type=command&param=deletewebasset&name=' + encodeURIComponent(name),
               { credentials: 'same-origin' }).catch(function () {});
     }
 
     function migrateLegacyLibraries() {
         if (_migrationDone) return;
-        var stored = readLibsRaw();
+        var stored = legacyLibraries();
         /* Nothing to migrate — but settings load asynchronously, so this may
            simply be too early to tell. Stay un-done and let the next call
            decide. */
@@ -413,7 +295,7 @@
 
         fetchNativeLibraries(true).then(function () {
             /* No registry on this build: there is nowhere to migrate TO, and
-               the entries have to keep working the way they always did. */
+               the entries have to be left for a Domoticz that has one. */
             if (!_nativeLibs) return;
             var registered = {};
             _nativeLibs.forEach(function (n) { registered[normalizePrefix(n.prefix)] = true; });
@@ -422,22 +304,22 @@
                 var prefix = normalizePrefix(l && l.prefix);
                 /* Already Domoticz's, whether this run put it there or an
                    earlier one did — which is what makes this idempotent. */
-                if (prefix && registered[prefix]) return true;
+                if (prefix && registered[prefix]) { dropOwnUpload(prefix); return true; }
                 /* The server installs from a public http(s) URL only; a
                    relative path or a LAN address is refused. Don't ask, and
                    above all don't discard the only copy of that URL. */
                 if (!prefix || !/^https?:\/\//i.test(String((l && l.cssUrl) || ''))) return false;
                 return installFromUrl(nativeAssetName(prefix), l.cssUrl, l.name || prefix)
                     .then(function (ok) {
-                        if (ok && l.assetPath) dropOwnUpload(l.assetPath);
+                        if (ok) dropOwnUpload(prefix);
                         return ok;
                     });
             })).then(function (moved) {
                 var keep = stored.filter(function (l, i) { return !moved[i]; });
                 if (keep.length === stored.length) return null;
-                /* saveLibsRaw() re-runs the injector, which sweeps the <link>s
-                   of the entries that just left. */
-                saveLibsRaw(keep);
+                if (window.dzNightglassSettings) {
+                    window.dzNightglassSettings.set(LEGACY_KEY, JSON.stringify(keep));
+                }
                 _nativeFetch = null;
                 _cache = null;
                 return fetchNativeLibraries(true).then(function () {
@@ -448,590 +330,6 @@
         });
     }
     window.dzMigrateIconLibraries = migrateLegacyLibraries;
-
-    /* Domoticz injects a <link> per asset when the app boots and has no reason
-       to look again mid-session, so nudge its loader — otherwise a library that
-       just migrated renders nothing until the next page load. */
-    function reloadNativeStylesheets() {
-        try {
-            var injector = window.angular &&
-                           window.angular.element(document.body).injector();
-            if (injector) injector.get('iconLibraries').load();
-        } catch (e) {}
-    }
-
-    /* ── Cross-origin library download + local caching ────────────────
-       Nightglass keeps the user-facing config simple (name + URL + prefix)
-       but downloads the stylesheet and its assets itself, rewrites those
-       asset URLs into embedded data: URLs, stores the result in IndexedDB,
-       and injects a local blob stylesheet on later loads. This avoids making
-       users manually host libraries on the Domoticz server while still
-       allowing a manual refresh/redownload on demand.
-
-       Values in _libIcons: undefined = not loaded, 'loading', 'error', or
-       class[]. */
-    var _libIcons = {};
-    var _libStatus = {};
-    var _libBlobUrls = {};
-    var _libPackageLoads = {};
-
-    /* Parse an icon-font stylesheet for `<prefix>-<name>` glyph classes.
-       Splits into rule blocks and keeps selectors whose body actually declares
-       a glyph (content: or an --fa/-style icon var), so utility classes
-       (sizes, rotations…) are ignored. Handles grouped selectors. */
-    function parseCssForIcons(cssText, prefix) {
-        var out = {};
-        var pfx = prefix.replace(/[^a-z0-9]/gi, '');
-        var selRe = new RegExp('\\.(' + pfx + '-[a-z0-9-]+)', 'gi');
-        var chunks = cssText.split('}');
-        for (var i = 0; i < chunks.length; i++) {
-            var brace = chunks[i].indexOf('{');
-            if (brace < 0) continue;
-            var sel  = chunks[i].slice(0, brace);
-            var body = chunks[i].slice(brace + 1);
-            if (!/content\s*:/i.test(body) && !/--fa\b/i.test(body)) continue;
-            /* Rightmost token per selector, as in enumerate(): a weight-variant
-               sheet reads `.ph-fill.ph-acorn:before`, where only the last token
-               is the glyph and the first is the variant. */
-            sel.split(',').forEach(function (one) {
-                var mm, name = null;
-                selRe.lastIndex = 0;
-                while ((mm = selRe.exec(one)) !== null) name = mm[1];
-                if (name) out[prefix + ' ' + name] = true;   // e.g. "mdi mdi-home"
-            });
-        }
-        return Object.keys(out).sort();
-    }
-
-    /* Two local stores, both keyed by stylesheet URL so a changed/versioned
-       URL misses cleanly:
-         • localStorage (LIB_CACHE_KEY) — the parsed icon-class list, so the
-           Studio grid opens instantly;
-         • IndexedDB (LIB_DB_*) — the downloaded stylesheet with its fonts
-           inlined as data: URLs, so rendering needs no network at all.
-       Neither ever expires on its own: refreshing is an explicit user action,
-       so a stored library never quietly calls out to the source again. */
-    var LIB_CACHE_KEY = 'dz-iconlib-cache';
-    var LIB_DB_NAME = 'dz-nightglass-iconlib-packages';
-    var LIB_DB_STORE = 'packages';
-
-    function readLibCache() {
-        try { return JSON.parse(localStorage.getItem(LIB_CACHE_KEY) || '{}') || {}; }
-        catch (e) { return {}; }
-    }
-    function writeLibCache(url, icons) {
-        if (!url) return;                 // no key = nothing worth storing
-        try {
-            var c = readLibCache();
-            c[url] = { icons: icons, ts: Date.now() };
-            localStorage.setItem(LIB_CACHE_KEY, JSON.stringify(c));
-        } catch (e) { /* quota / disabled — best effort, falls back to refetch */ }
-    }
-    function dropLibCache(url) {
-        if (!url) return;
-        try {
-            var c = readLibCache();
-            if (!Object.prototype.hasOwnProperty.call(c, url)) return;
-            delete c[url];
-            localStorage.setItem(LIB_CACHE_KEY, JSON.stringify(c));
-        } catch (e) {}
-    }
-
-    function setLibStatus(id, state, extra) {
-        var next = { state: state };
-        var prev = _libStatus[id] || {};
-        var k;
-        for (k in prev) {
-            if (Object.prototype.hasOwnProperty.call(prev, k)) next[k] = prev[k];
-        }
-        extra = extra || {};
-        for (k in extra) {
-            if (Object.prototype.hasOwnProperty.call(extra, k)) next[k] = extra[k];
-        }
-        _libStatus[id] = next;
-    }
-
-    function libraryKey(lib) {
-        return String((lib && (lib.id || lib.prefix)) || '') + '|' + String((lib && lib.cssUrl) || '');
-    }
-
-    /* The id of the <link> this library owns. Shared by the injector and the
-       removal path so both address the same element. */
-    function libraryDomId(lib) {
-        var libId = (lib && (lib.id || lib.prefix)) || (lib && lib.cssUrl) || '';
-        return 'ng-iconlib-' + String(libId).replace(/[^\w-]/g, '');
-    }
-
-    function libraryStillConfigured(lib) {
-        var key = libraryKey(lib);
-        var arr = readLibsRaw();
-        for (var i = 0; i < arr.length; i++) {
-            if (libraryKey(arr[i]) === key) return true;
-        }
-        return false;
-    }
-
-    function replaceMarker(text, marker, value) {
-        var at = text.indexOf(marker);
-        if (at < 0) return text;
-        return text.slice(0, at) + value + text.slice(at + marker.length);
-    }
-
-    function blobToDataUrl(blob) {
-        return new Promise(function (resolve, reject) {
-            var reader = new FileReader();
-            reader.onloadend = function () { resolve(reader.result); };
-            reader.onerror = function () { reject(reader.error || 0); };
-            reader.readAsDataURL(blob);
-        });
-    }
-
-    function absolutizeUrl(url, baseUrl) {
-        try { return new URL(url, baseUrl).href; }
-        catch (e) { return url; }
-    }
-
-    function sanitizeCssUrl(url) {
-        return String(url || '').trim().replace(/^['"]|['"]$/g, '');
-    }
-
-    function openLibDb() {
-        return new Promise(function (resolve, reject) {
-            if (!window.indexedDB) { reject(0); return; }
-            var req = window.indexedDB.open(LIB_DB_NAME, 1);
-            req.onupgradeneeded = function () {
-                var db = req.result;
-                if (!db.objectStoreNames.contains(LIB_DB_STORE)) {
-                    db.createObjectStore(LIB_DB_STORE, { keyPath: 'key' });
-                }
-            };
-            req.onsuccess = function () { resolve(req.result); };
-            req.onerror = function () { reject(req.error || 0); };
-        });
-    }
-
-    function readLibPackage(key) {
-        return openLibDb().then(function (db) {
-            return new Promise(function (resolve, reject) {
-                var tx = db.transaction(LIB_DB_STORE, 'readonly');
-                var store = tx.objectStore(LIB_DB_STORE);
-                var req = store.get(key);
-                tx.oncomplete = function () { try { db.close(); } catch (e) {} };
-                tx.onabort = function () { reject(tx.error || 0); };
-                req.onsuccess = function () { resolve(req.result || null); };
-                req.onerror = function () { reject(req.error || 0); };
-            });
-        });
-    }
-
-    function writeLibPackage(entry) {
-        return openLibDb().then(function (db) {
-            return new Promise(function (resolve, reject) {
-                var tx = db.transaction(LIB_DB_STORE, 'readwrite');
-                var store = tx.objectStore(LIB_DB_STORE);
-                tx.oncomplete = function () { try { db.close(); } catch (e) {} resolve(entry); };
-                tx.onabort = function () { reject(tx.error || 0); };
-                var req = store.put(entry);
-                req.onerror = function () { reject(req.error || 0); };
-            });
-        });
-    }
-
-    function deleteLibPackage(key) {
-        return openLibDb().then(function (db) {
-            return new Promise(function (resolve, reject) {
-                var tx = db.transaction(LIB_DB_STORE, 'readwrite');
-                var store = tx.objectStore(LIB_DB_STORE);
-                tx.oncomplete = function () { try { db.close(); } catch (e) {} resolve(); };
-                tx.onabort = function () { reject(tx.error || 0); };
-                var req = store.delete(key);
-                req.onerror = function () { reject(req.error || 0); };
-            });
-        });
-    }
-
-    function fetchCssText(url) {
-        return fetch(url, { credentials: 'omit' })
-            .then(function (r) { if (!r.ok) throw 0; return r.text(); });
-    }
-
-    function localizeCssAssets(cssText, baseUrl, assetCache) {
-        var URL_RE = /url\(\s*(['"]?)([^'")]+)\1\s*\)/gi;
-        var tasks = [];
-        var out = cssText.replace(URL_RE, function (full, quote, raw) {
-            var ref = sanitizeCssUrl(raw);
-            if (!ref || /^data:/i.test(ref) || /^blob:/i.test(ref) || ref.charAt(0) === '#') return full;
-            var abs = absolutizeUrl(ref, baseUrl);
-            if (!assetCache[abs]) {
-                assetCache[abs] = fetch(abs, { credentials: 'omit' })
-                    .then(function (r) { if (!r.ok) throw 0; return r.blob(); })
-                    .then(blobToDataUrl);
-            }
-            var marker = '__NG_ICONLIB_URL_' + tasks.length + '__';
-            tasks.push(assetCache[abs].then(function (dataUrl) {
-                return 'url("' + dataUrl + '")';
-            }).catch(function () { return full; }));
-            return marker;
-        });
-        if (!tasks.length) return Promise.resolve(out);
-        return Promise.all(tasks).then(function (repl) {
-            repl.forEach(function (val, i) {
-                out = replaceMarker(out, '__NG_ICONLIB_URL_' + i + '__', val);
-            });
-            return out;
-        });
-    }
-
-    function fetchAndRewriteCss(url, seen, assetCache) {
-        seen = seen || {};
-        assetCache = assetCache || {};
-        if (seen[url]) return Promise.resolve('');
-        seen[url] = true;
-
-        return fetchCssText(url).then(function (cssText) {
-            var importRe = /@import\s+(?:url\(\s*)?(?:(['"])([^'"]+)\1|([^'"\)\s;]+))\s*\)?[^;]*;/gi;
-            var imports = [];
-            var out = cssText.replace(importRe, function (full, quote, qUrl, bareUrl) {
-                var ref = sanitizeCssUrl(qUrl || bareUrl);
-                if (!ref) return '';
-                var abs = absolutizeUrl(ref, url);
-                var marker = '__NG_ICONLIB_IMPORT_' + imports.length + '__';
-                imports.push(fetchAndRewriteCss(abs, seen, assetCache).catch(function () { return full; }));
-                return marker;
-            });
-            return Promise.all(imports).then(function (chunks) {
-                chunks.forEach(function (chunk, i) {
-                    out = replaceMarker(out, '__NG_ICONLIB_IMPORT_' + i + '__', chunk);
-                });
-                return localizeCssAssets(out, url, assetCache);
-            });
-        });
-    }
-
-    /* ── Server-side hosting (Domoticz `uploadwebasset`) ───────────────
-       Best case: we store the downloaded, self-contained stylesheet in the
-       Domoticz web root (www/assets/<name>) so EVERY browser and device loads
-       it from this server — no CDN, no per-browser download, and because it's
-       same-origin its glyphs also enumerate straight from document.styleSheets
-       (no fetch needed for the picker).
-
-       The store is Domoticz-wide rather than theme-scoped, so the same webfont
-       is shared instead of each theme keeping its own copy, and it survives
-       both theme reinstalls and Domoticz updates.
-
-       Requires an admin session and a Domoticz build that has the endpoint;
-       when either is missing we silently keep the per-browser IndexedDB copy,
-       so nothing breaks on older servers. */
-
-    function utf8ToBase64(str) {
-        var bytes = new TextEncoder().encode(str);
-        var bin = '';
-        var CHUNK = 0x8000;                       // avoid apply() arg limits
-        for (var i = 0; i < bytes.length; i += CHUNK) {
-            bin += String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK));
-        }
-        return btoa(bin);
-    }
-
-    /* `title` is display-only and ignored by Domoticz builds that predate it;
-       sending it means our uploads are labelled with their library name on the
-       native Custom Icons page instead of the bare `iconfont-<prefix>` stem. */
-    function uploadWebAsset(name, content, title) {
-        var body = 'name=' + encodeURIComponent(name) +
-                   '&title=' + encodeURIComponent(title || '') +
-                   '&data=' + encodeURIComponent(utf8ToBase64(content));
-        return fetch('json.htm?type=command&param=uploadwebasset', {
-            method: 'POST',
-            credentials: 'same-origin',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: body
-        }).then(function (r) { return r.json(); }).then(function (d) {
-            if (!d || d.status !== 'OK' || !d.path) throw (d && d.error) || 0;
-            return d.path;
-        });
-    }
-
-    /* The asset store is shared Domoticz-wide, so namespace the filename to
-       make its provenance obvious and avoid clashing with other uploads. */
-    function assetFileName(lib) {
-        return 'iconfont-' + String(lib.prefix || lib.id || 'lib').replace(/[^a-z0-9_-]/gi, '') + '.css';
-    }
-
-    /* Persist the server path onto the library's settings entry so later page
-       loads can point the <link> straight at it. */
-    function setLibraryAssetPath(lib, path) {
-        var arr = readLibsRaw();
-        var changed = false;
-        for (var i = 0; i < arr.length; i++) {
-            if (libraryKey(arr[i]) === libraryKey(lib)) {
-                if (arr[i].assetPath !== path) { arr[i].assetPath = path; changed = true; }
-                break;
-            }
-        }
-        if (changed) saveLibsRaw(arr);
-    }
-
-    /* Best-effort publish; resolves to the path or null (never rejects). */
-    function publishLibraryToServer(lib, cssText) {
-        if (!cssText) return Promise.resolve(null);
-        return uploadWebAsset(assetFileName(lib), cssText, lib.name || lib.prefix)
-            .then(function (path) {
-                if (!libraryStillConfigured(lib)) return null;
-                /* Refreshing overwrites the same filename, so version the URL —
-                   otherwise the browser keeps serving the previous copy. */
-                var versioned = path + '?v=' + Date.now();
-                setLibraryAssetPath(lib, versioned);
-                setLibStatus(lib.id || lib.prefix, 'server', { path: versioned, ts: Date.now() });
-                return versioned;
-            })
-            .catch(function () { return null; });   // no admin / older Domoticz
-    }
-
-    function downloadLibraryPackage(lib) {
-        var id = lib.id || lib.prefix;
-        setLibStatus(id, 'downloading');
-        return fetchAndRewriteCss(lib.cssUrl, {}, {}).then(function (cssText) {
-            var entry = {
-                key: libraryKey(lib),
-                id: id,
-                prefix: lib.prefix,
-                url: lib.cssUrl,
-                cssText: cssText,
-                icons: parseCssForIcons(cssText, lib.prefix),
-                ts: Date.now()
-            };
-            if (!libraryStillConfigured(lib)) throw { removed: true };
-            _libIcons[id] = entry.icons;
-            writeLibCache(lib.cssUrl, entry.icons);
-            setLibStatus(id, 'cached', { ts: entry.ts });
-            return writeLibPackage(entry)
-                .catch(function () { return entry; })
-                .then(function () {
-                    /* Try to hand it to the server too; keeps the local copy
-                       either way so this can never make things worse. */
-                    return publishLibraryToServer(lib, entry.cssText).then(function () { return entry; });
-                });
-        }).catch(function (err) {
-            if (err && err.removed) throw err;
-            setLibStatus(id, 'error');
-            throw err;
-        });
-    }
-
-    function ensureLibraryPackage(lib, opts) {
-        opts = opts || {};
-        if (!lib || !lib.cssUrl) return Promise.reject(0);
-
-        var id = lib.id || lib.prefix;
-        var key = libraryKey(lib);
-        if (_libPackageLoads[key] && !opts.force) return _libPackageLoads[key];
-
-        var job = (opts.force ? deleteLibPackage(key).catch(function () {}) : readLibPackage(key).catch(function () { return null; }))
-            .then(function (entry) {
-                if (entry && !opts.force) {
-                    _libIcons[id] = Array.isArray(entry.icons) ? entry.icons : [];
-                    writeLibCache(lib.cssUrl, _libIcons[id]);
-                    setLibStatus(id, 'cached', { ts: entry.ts || 0 });
-                    /* Deliberately no age-based auto re-download: a locally
-                       stored library must never quietly hit the network again.
-                       Updating is an explicit action (the Refresh button). */
-                    return entry;
-                }
-                return downloadLibraryPackage(lib);
-            });
-
-        _libPackageLoads[key] = job.then(function (entry) {
-            delete _libPackageLoads[key];
-            return entry;
-        }, function (err) {
-            delete _libPackageLoads[key];
-            throw err;
-        });
-        return _libPackageLoads[key];
-    }
-
-    function revokeLibraryBlobUrl(domId) {
-        if (_libBlobUrls[domId]) {
-            try { URL.revokeObjectURL(_libBlobUrls[domId]); } catch (e) {}
-            delete _libBlobUrls[domId];
-        }
-    }
-
-    function setLibraryLinkHref(link, domId, href, originalUrl, isLocal) {
-        link.href = href;
-        link.setAttribute('data-url', originalUrl || '');
-        link.setAttribute('data-local', isLocal ? '1' : '0');
-    }
-
-    /* Claim the <link> for a library WITHOUT giving it an href yet.
-       This is what stops a remote request on every page load: previously the
-       link was pointed at the CDN synchronously and only swapped to the local
-       copy afterwards, so each load still pulled the remote CSS (and the fonts
-       it references). Now applyLibraryStylesheet() points it at the locally
-       cached blob — and only falls back to the source URL if no local copy can
-       be produced. href is removed rather than blanked, because an empty href
-       resolves to the page itself and would fire a pointless request. */
-    function markLibraryLink(link, url) {
-        link.removeAttribute('href');
-        link.setAttribute('data-url', url || '');
-        link.setAttribute('data-local', '0');
-    }
-
-    function applyLibraryStylesheet(link, domId, lib) {
-        ensureLibraryPackage(lib).then(function (entry) {
-            var current = document.getElementById(domId);
-            if (!current || current.getAttribute('data-url') !== lib.cssUrl) return;
-            var blobUrl = URL.createObjectURL(new Blob([entry.cssText || ''], { type: 'text/css' }));
-            revokeLibraryBlobUrl(domId);
-            _libBlobUrls[domId] = blobUrl;
-            setLibraryLinkHref(current, domId, blobUrl, lib.cssUrl, true);
-            _cache = null;
-        }).catch(function () {
-            var current = document.getElementById(domId);
-            if (!current || current.getAttribute('data-url') !== lib.cssUrl) return;
-            if (!libraryStillConfigured(lib)) return;
-            revokeLibraryBlobUrl(domId);
-            setLibStatus(lib.id || lib.prefix, 'remote');
-            setLibraryLinkHref(current, domId, lib.cssUrl, lib.cssUrl, false);
-        });
-    }
-
-    /* Inject/update/remove <link>s for the configured libraries so glyphs
-       render from the local cache when possible, with a source-URL fallback
-       if local download is blocked. */
-    window.dzInjectIconLibraries = function (list) {
-        try {
-            var arr = typeof list === 'string' ? JSON.parse(list) : (list || []);
-            var want = {};
-            (arr || []).forEach(function (l) {
-                if (!l || !l.cssUrl) return;
-                var libId = l.id || l.prefix;
-                /* Its asset was deleted on Domoticz's Custom Icons page, so
-                   re-creating the <link> would only request a 404 and re-flash
-                   the icons. Left out of `want` on purpose: the sweep below then
-                   removes any link still hanging around. Refresh clears this. */
-                if (_nativeGone[libId]) return;
-                var domId = libraryDomId(l);
-                want[domId] = true;
-                var link = document.getElementById(domId);
-                if (link) {
-                    var prevUrl = link.getAttribute('data-url');
-                    /* Already serving the local copy for this exact URL — leave
-                       it alone so re-running (e.g. on settings save) doesn't
-                       drop a working stylesheet and re-flash the icons. */
-                    if (prevUrl === l.cssUrl &&
-                        link.getAttribute('data-local') === '1' &&
-                        link.getAttribute('href')) return;
-                    if (prevUrl && prevUrl !== l.cssUrl) {
-                        revokeLibraryBlobUrl(domId);
-                        if (libId) delete _libIcons[libId];
-                    }
-                } else {
-                    link = document.createElement('link');
-                    link.id = domId;
-                    link.rel = 'stylesheet';
-                    document.head.appendChild(link);
-                }
-                var lib = {
-                    id: libId,
-                    name: l.name || l.prefix,
-                    cssUrl: l.cssUrl,
-                    prefix: l.prefix,
-                    assetPath: l.assetPath
-                };
-
-                /* Best case: the library is hosted on this Domoticz server —
-                   point straight at it. Same-origin, so it costs one ordinary
-                   (browser-cached) request and its glyphs enumerate directly
-                   from document.styleSheets. */
-                if (l.assetPath) {
-                    markLibraryLink(link, l.cssUrl);
-                    link.setAttribute('data-local', '1');
-                    link.onerror = function () {
-                        /* Asset vanished (theme reinstalled/upgraded): forget the
-                           path and fall back to the local/remote flow. */
-                        link.onerror = null;
-                        setLibraryAssetPath(lib, '');
-                        setLibStatus(libId, 'error');
-                        markLibraryLink(link, l.cssUrl);
-                        applyLibraryStylesheet(link, domId, lib);
-                    };
-                    link.href = l.assetPath;
-                    setLibStatus(libId, 'server', { path: l.assetPath });
-                    return;
-                }
-
-                /* Claim the link but leave href unset; the local copy (or a
-                   remote fallback) is applied asynchronously below. */
-                markLibraryLink(link, l.cssUrl);
-                applyLibraryStylesheet(link, domId, lib);
-            });
-            /* Drop links (and cached icons) for removed libraries. */
-            var stale = document.querySelectorAll('link[id^="ng-iconlib-"]');
-            for (var i = 0; i < stale.length; i++) {
-                if (!want[stale[i].id]) {
-                    revokeLibraryBlobUrl(stale[i].id);
-                    stale[i].parentNode.removeChild(stale[i]);
-                }
-            }
-            _cache = null;
-        } catch (e) {}
-    }
-
-    /* Load a library's icon list. cb() fires when state changes.
-       Order: in-memory → localStorage (instant) → IndexedDB/local download. */
-    function loadLibraryIcons(lib, cb, force) {
-        var st = _libIcons[lib.id];
-        if (!force && (st === 'loading' || (st && st !== 'error'))) { cb(); return; }
-        if (!lib.cssUrl && !lib.assetPath) { _libIcons[lib.id] = []; cb(); return; }
-
-        var entry = !force && readLibCache()[lib.cssUrl];
-        if (entry && Array.isArray(entry.icons)) {
-            _libIcons[lib.id] = entry.icons;
-            cb();     // instant from cache; refreshing is an explicit action
-            return;
-        }
-
-        /* Hosted on this server: read the local copy for the icon list. Never
-           reach for the source URL here — that's what Refresh is for. */
-        if (lib.assetPath && !force) {
-            _libIcons[lib.id] = 'loading';
-            cb();
-            fetchCssText(lib.assetPath).then(function (cssText) {
-                var icons = parseCssForIcons(cssText, lib.prefix);
-                _libIcons[lib.id] = icons;
-                writeLibCache(lib.cssUrl, icons);
-                setLibStatus(lib.id, 'server', { path: lib.assetPath });
-                cb();
-            }).catch(function () { _libIcons[lib.id] = 'error'; cb(); });
-            return;
-        }
-
-        _libIcons[lib.id] = 'loading';
-        cb();
-        ensureLibraryPackage(lib, { force: !!force }).then(function (pkg) {
-            _libIcons[lib.id] = Array.isArray(pkg.icons) ? pkg.icons : [];
-            cb();
-        }).catch(function () {
-            _libIcons[lib.id] = 'error';
-            cb();
-        });
-    }
-
-    function removeLibraryCache(lib) {
-        var key = libraryKey(lib);
-        delete _libIcons[lib.id];
-        delete _libStatus[lib.id];
-        delete _libPackageLoads[key];
-        deleteLibPackage(key).catch(function () {});
-        /* Also drop the copy stored on the server, so removing a library
-           doesn't leave an orphaned file in www/assets/. */
-        if (lib.assetPath) {
-            fetch('json.htm?type=command&param=deletewebasset' +
-                  '&name=' + encodeURIComponent(assetFileName(lib)),
-                  { credentials: 'same-origin' }).catch(function () {});
-        }
-    }
 
     /* Which library a class belongs to (by prefix). */
     function libIdOf(cls, libs) {
@@ -1075,29 +373,6 @@
         return a === b || a === glyphTokenOf(b) || b === glyphTokenOf(a);
     }
 
-    function formatAge(ts) {
-        if (!ts) return '';
-        var mins = Math.max(0, Math.floor((Date.now() - ts) / 60000));
-        if (mins < 1) return 'just now';
-        if (mins < 60) return mins + 'm ago';
-        var hours = Math.floor(mins / 60);
-        if (hours < 24) return hours + 'h ago';
-        return Math.floor(hours / 24) + 'd ago';
-    }
-
-    function libraryStatusSummary(lib) {
-        var st = _libStatus[lib.id || lib.prefix] || {};
-        if (st.state === 'downloading') return 'Downloading…';
-        if (st.state === 'missing') {
-            return 'Removed from this server on Domoticz’s Custom Icons page — refresh to reinstall';
-        }
-        if (st.state === 'server') return 'Stored on this server — shared by all devices';
-        if (st.state === 'cached') return 'Stored in this browser' + (st.ts ? ' · updated ' + formatAge(st.ts) : '');
-        if (st.state === 'remote') return 'Using source URL fallback';
-        if (st.state === 'error') return 'Download failed';
-        return 'Waiting to download';
-    }
-
     /* ── Recent (localStorage) ────────────────────────────────────── */
     /* Guarded on read as well as write: the list is user-editable storage that
        gets interpolated into a class attribute. */
@@ -1119,7 +394,7 @@
     }
 
     /* Is this icon class still backed by an available library? Font Awesome is
-       always present; other classes need their library (by prefix) configured. */
+       always present; other classes need their library (by prefix) installed. */
     function isKnownIcon(cls, libs) {
         var token = (cls || '').split(/\s+/)[0];
         if (!token) return false;
@@ -1227,27 +502,20 @@
         var scope     = 'all';           // 'all' | 'recent' | libId
         var query     = '';
 
-        /* Merge same-origin/loaded glyphs (enumerate) with the fetched CDN
-           library icons (_libIcons) into the flat pool + per-library groups. */
         function buildData() {
             libs = configuredLibraries();
-            var valid = {};
-            libs.forEach(function (l) { valid[l.id] = true; });
-            var merged = {}, out = [];
-            enumerate().forEach(function (c) { merged[c] = true; });
-            Object.keys(_libIcons).forEach(function (id) {
-                if (!valid[id]) return;   // library was removed — don't leak its icons
-                if (Array.isArray(_libIcons[id])) _libIcons[id].forEach(function (c) { merged[c] = true; });
-            });
-            Object.keys(merged).sort().forEach(function (c) { out.push(c); });
-            all = out;
+            all = enumerate();
             groups = groupByLibrary(all, libs);
         }
+        /* A library may have been installed or removed since the last open, and
+           its stylesheet is loaded by then either way, so never open on a stale
+           enumeration. */
+        _cache = null;
         buildData();
         /* pruneRecent() is deliberately NOT called here — it runs once the
-           native registry has been consulted (see the bottom of this function),
-           because until then a recent icon from a Domoticz-managed library has
-           no library to be recognised by and would be thrown away. */
+           registry has been consulted (see the bottom of this function),
+           because until then a recent icon from an installed library has no
+           library to be recognised by and would be thrown away. */
 
         var overlay = document.createElement('div');
         overlay.id = 'ng-is-overlay';
@@ -1354,10 +622,8 @@
         }
 
         function onGridKeydown(e) {
-            /* The manual-class field and the library form own their own
-               Enter/arrow behaviour. */
-            if (e.target && e.target.closest &&
-                e.target.closest('.ng-is-manual, .ng-is-lib-form')) return;
+            /* The manual-class field owns its own Enter/arrow behaviour. */
+            if (e.target && e.target.closest && e.target.closest('.ng-is-manual')) return;
 
             var list = tiles();
             if (e.key === 'Enter') {
@@ -1396,206 +662,12 @@
                 b.addEventListener('click', function () { scope = it.id; renderRail(); renderMain(); });
                 railEl.appendChild(b);
             });
-
-            /* Manage libraries (add MDI / your own icon fonts) */
-            var mng = document.createElement('button');
-            mng.type = 'button';
-            mng.className = 'ng-is-rail-manage' + (scope === 'manage' ? ' ng-is-rail-item--active' : '');
-            mng.innerHTML = '<i class="fa-solid fa-plus"></i><span>Add / manage libraries</span>';
-            mng.addEventListener('click', function () { scope = 'manage'; renderRail(); renderMain(); });
-            railEl.appendChild(mng);
-        }
-
-        function refreshData() { buildData(); }
-
-        /* Fetch+parse any not-yet-loaded library, re-rendering as each lands. */
-        function loadLibraries() {
-            configuredLibraries().forEach(function (l) {
-                if (l.id === 'fa') return;
-                /* Domoticz serves its own libraries same-origin and injects the
-                   <link> itself, so their glyphs normally arrive via enumerate()
-                   already; only read the stylesheet when that found none. */
-                if (l.managed === 'domoticz' && groups[l.id] && groups[l.id].icons.length) return;
-                loadLibraryIcons(l, function () {
-                    buildData();
-                    renderRail();
-                    renderMain();
-                });
-            });
-        }
-
-        /* ── Library manager ── */
-        function renderManage() {
-            mainEl.innerHTML = '';
-            var head = document.createElement('div');
-            head.className = 'ng-is-section-title';
-            head.textContent = 'Icon libraries';
-            mainEl.appendChild(head);
-
-            var desc = document.createElement('div');
-            desc.className = 'ng-is-note';
-            desc.innerHTML = 'Add an icon font such as ' +
-                '<a href="https://pictogrammers.com/library/mdi/" target="_blank" rel="noopener">Material Design Icons</a>. ' +
-                'Give its stylesheet URL and class prefix (e.g. <code>mdi</code>) and Nightglass downloads ' +
-                'the stylesheet + fonts once and stores them <strong>on this Domoticz server</strong>, so every ' +
-                'browser loads them locally. If the server can’t store them (not an admin session, or an older ' +
-                'Domoticz), it falls back to a per-browser copy. Use refresh to redownload after upstream changes.';
-            mainEl.appendChild(desc);
-
-            var listWrap = document.createElement('div');
-            listWrap.className = 'ng-is-lib-list';
-            var raw = readLibsRaw();
-            if (!raw.length) {
-                listWrap.innerHTML = '<div class="ng-is-note">No custom libraries yet.</div>';
-            } else {
-                raw.forEach(function (l, i) {
-                    var rowEl = document.createElement('div');
-                    rowEl.className = 'ng-is-lib-row';
-                    if ((_libStatus[l.id || l.prefix] || {}).state === 'downloading') {
-                        rowEl.className += ' ng-is-lib-row--busy';
-                    }
-                    if (_nativeGone[l.id || l.prefix]) {
-                        rowEl.className += ' ng-is-lib-row--missing';
-                    }
-                    rowEl.innerHTML =
-                        '<div class="ng-is-lib-meta"><strong>' + (l.name || l.prefix || '?') + '</strong>' +
-                        '<span>' + (l.prefix ? l.prefix + '-*' : '') + ' · ' + (l.cssUrl || '') + '</span>' +
-                        '<em class="ng-is-lib-status">' + libraryStatusSummary(l) + '</em></div>';
-                    var actions = document.createElement('div');
-                    actions.className = 'ng-is-lib-actions';
-                    var refresh = document.createElement('button');
-                    refresh.type = 'button';
-                    refresh.className = 'ng-is-lib-refresh';
-                    refresh.innerHTML = '<i class="fa-solid fa-rotate-right"></i>';
-                    refresh.title = 'Refresh / redownload library';
-                    refresh.disabled = ((_libStatus[l.id || l.prefix] || {}).state === 'downloading');
-                    refresh.addEventListener('click', function () {
-                        var lib = { id: l.id || l.prefix, name: l.name || l.prefix, cssUrl: l.cssUrl, prefix: l.prefix };
-                        setLibStatus(lib.id, 'downloading');
-                        /* Redownloading re-uploads it, so a library that was
-                           deleted server-side is no longer "gone". */
-                        delete _nativeGone[lib.id];
-                        delete _libIcons[lib.id];
-                        renderManage();
-                        renderRail();
-                        if (scope === lib.id) renderMain();
-                        loadLibraryIcons(lib, function () {
-                            if (window.dzInjectIconLibraries) window.dzInjectIconLibraries(readLibsRaw());
-                            buildData();
-                            renderRail();
-                            renderManage();
-                            if (scope === lib.id) renderMain();
-                        }, true);
-                    });
-                    var rm = document.createElement('button');
-                    rm.type = 'button';
-                    rm.className = 'ng-is-lib-remove';
-                    rm.innerHTML = '<i class="fa-solid fa-trash-can"></i>';
-                    rm.addEventListener('click', function () {
-                        var arr = readLibsRaw();
-                        var removed = arr.splice(i, 1)[0];
-                        saveLibsRaw(arr);
-                        if (removed && removed.prefix) removeLibraryCache({ id: removed.id || removed.prefix, prefix: removed.prefix, cssUrl: removed.cssUrl, assetPath: removed.assetPath });
-                        refreshData();
-                        pruneRecent(libs);          // drop now-invalid recent icons
-                        renderRail();
-                        renderManage();
-                    });
-                    actions.appendChild(refresh);
-                    actions.appendChild(rm);
-                    rowEl.appendChild(actions);
-                    listWrap.appendChild(rowEl);
-                });
-            }
-            mainEl.appendChild(listWrap);
-
-            /* One-click suggestions for popular libraries (prefill only). */
-            var addedPrefixes = {};
-            raw.forEach(function (l) { if (l && l.prefix) addedPrefixes[l.prefix] = true; });
-            /* Hide the suggestion for anything Domoticz already serves —
-               accepting it would just add a second copy under the same prefix. */
-            nativeLibraries().forEach(function (n) { addedPrefixes[n.prefix] = true; });
-            var suggestable = SUGGESTED_LIBS.filter(function (s) { return !addedPrefixes[s.prefix]; });
-            if (suggestable.length) {
-                var sug = document.createElement('div');
-                sug.className = 'ng-is-lib-suggest';
-                var sLbl = document.createElement('div');
-                sLbl.className = 'ng-is-lib-suggest-label';
-                sLbl.textContent = 'Popular libraries — click to prefill, then review & Add:';
-                sug.appendChild(sLbl);
-                var chips = document.createElement('div');
-                chips.className = 'ng-is-lib-suggest-chips';
-                suggestable.forEach(function (s) {
-                    var chip = document.createElement('button');
-                    chip.type = 'button';
-                    chip.className = 'ng-is-lib-suggest-chip';
-                    chip.textContent = s.name;
-                    chip.addEventListener('click', function () {
-                        form.querySelector('.ng-is-lib-name').value   = s.name;
-                        form.querySelector('.ng-is-lib-url').value     = s.cssUrl;
-                        form.querySelector('.ng-is-lib-prefix').value  = s.prefix;
-                        form.querySelector('.ng-is-lib-url').classList.remove('ng-is-invalid');
-                        form.querySelector('.ng-is-lib-prefix').classList.remove('ng-is-invalid');
-                    });
-                    chips.appendChild(chip);
-                });
-                sug.appendChild(chips);
-                mainEl.appendChild(sug);
-            }
-
-            var form = document.createElement('div');
-            form.className = 'ng-is-lib-form';
-            form.innerHTML =
-                '<input class="ng-is-lib-name"   type="text" placeholder="Name (e.g. Material Design Icons)">' +
-                '<input class="ng-is-lib-url"    type="text" placeholder="Stylesheet URL (e.g. templates/materialdesignicons.min.css)">' +
-                '<input class="ng-is-lib-prefix" type="text" placeholder="Class prefix (e.g. mdi)">' +
-                '<button type="button" class="ng-is-lib-add"><i class="fa-solid fa-plus"></i> Add library</button>';
-            mainEl.appendChild(form);
-
-            form.querySelector('.ng-is-lib-add').addEventListener('click', function () {
-                var name   = form.querySelector('.ng-is-lib-name').value.trim();
-                var url    = form.querySelector('.ng-is-lib-url').value.trim();
-                var prefix = form.querySelector('.ng-is-lib-prefix').value.trim().replace(/-.*$/, '').replace(/[^a-z0-9]/gi, '');
-                if (!url || !prefix) {
-                    form.querySelector('.ng-is-lib-url').classList.toggle('ng-is-invalid', !url);
-                    form.querySelector('.ng-is-lib-prefix').classList.toggle('ng-is-invalid', !prefix);
-                    return;
-                }
-                var arr = readLibsRaw();
-                var next = { id: prefix, name: name || prefix, cssUrl: url, prefix: prefix };
-                var existing = -1;
-                arr.forEach(function (item, idx) {
-                    if ((item.id || item.prefix) === prefix) existing = idx;
-                });
-                if (existing >= 0) {
-                    removeLibraryCache({ id: arr[existing].id || arr[existing].prefix, prefix: arr[existing].prefix, cssUrl: arr[existing].cssUrl, assetPath: arr[existing].assetPath });
-                    arr[existing] = next;
-                } else {
-                    arr.push(next);
-                }
-                saveLibsRaw(arr);
-                delete _libIcons[prefix];     // ensure a fresh fetch
-                setLibStatus(prefix, 'downloading');
-                refreshData();
-                scope = prefix;               // jump to the new library (shows loading)
-                renderRail();
-                renderMain();
-                /* Download it locally, inject it, then re-render when the
-                   cached icon list lands. */
-                loadLibraryIcons(next, function () {
-                    if (window.dzInjectIconLibraries) window.dzInjectIconLibraries(readLibsRaw());
-                    buildData(); renderRail(); if (scope === prefix) renderMain();
-                    renderManage();
-                }, true);
-            });
         }
 
         /* ── Main pane ── */
         function renderMain() {
             mainEl.innerHTML = '';
             hi = -1;               // the tiles it indexed no longer exist
-
-            if (scope === 'manage') { renderManage(); return; }
 
             if (query) {
                 var q = query.toLowerCase();
@@ -1668,25 +740,12 @@
             }
 
             if (scope !== 'all') {
-                /* A specific configured library */
-                if (_libIcons[scope] === 'loading') {
-                    mainEl.innerHTML = '<div class="ng-is-note"><i class="fa-solid fa-spinner fa-spin"></i> ' +
-                        'Loading icons…</div>';
-                    return;
-                }
+                /* One installed library */
                 var g = groups[scope];
                 if (!g || !g.icons.length) {
-                    var scoped = null;
-                    libs.forEach(function (l) { if (l.id === scope) scoped = l; });
-                    var reason = (scoped && scoped.unavailable)
-                        ? 'This library was removed from this server on Domoticz’s ' +
-                          'Custom Icons page. Use Refresh under “Add / manage ' +
-                          'libraries” to reinstall it.'
-                        : _libIcons[scope] === 'error'
-                        ? 'Couldn’t download this library into the local cache. ' +
-                          'Nightglass will fall back to the source URL if the browser can load it.'
-                        : 'No icons found in this library’s stylesheet. Paste the exact class below instead.';
-                    mainEl.innerHTML = '<div class="ng-is-note"><i class="fa-solid fa-circle-info"></i> ' + reason + '</div>';
+                    mainEl.innerHTML = '<div class="ng-is-note"><i class="fa-solid fa-circle-info"></i> ' +
+                        'No icons found in this library’s stylesheet. Paste the exact class below instead.' +
+                        '</div>';
                     return;
                 }
                 mainEl.appendChild(gridOf(g.icons, true));
@@ -1778,21 +837,20 @@
 
         renderRail();
         renderMain();
-        loadLibraries();          // fetch+parse CDN/custom libraries in the background
 
-        /* Reconcile with Domoticz's registry on every open, so the Studio also
+        /* Reconcile with the registry on every open, so the Studio also
            self-heals on builds that never broadcast dz-webassets-changed. The
            same handler serves the broadcast while this overlay is on screen.
            fetchNativeLibraries() always resolves: on a Domoticz without the
-           command it yields the empty list, which leaves every step below
-           behaving exactly as it did before the registry existed. */
+           command it yields the empty list, leaving Font Awesome as the only
+           library — which is exactly right there. */
         _onNativeChange = function () {
             if (_overlay !== overlay) return;      // a newer overlay owns the UI
+            _cache = null;        // a library may have just come or gone
             buildData();
             pruneRecent(libs);    // self-heal: drop recents from removed libraries
             renderRail();
             renderMain();
-            loadLibraries();
         };
         fetchNativeLibraries(true).then(_onNativeChange);
 

--- a/src/js/icon-studio.js
+++ b/src/js/icon-studio.js
@@ -351,6 +351,115 @@
         } catch (e) { return false; }
     }
 
+    /* ── One-shot migration onto Domoticz's registry ───────────────────
+       Nightglass used to install icon libraries itself and remembered them in
+       the `iconLibraries` setting. Domoticz owns that job now, and every stored
+       entry already holds what a native install needs — source URL, prefix and
+       display name — so hand them over once and stop remembering them.
+
+       An entry is only dropped once it is definitely safe to forget: that
+       source URL is the sole record of where the library came from, so anything
+       that fails (a session without admin rights, or a URL the server refuses)
+       stays exactly as it is and gets another chance on a later page load. */
+    var LEGACY_KEY = 'iconLibraries';
+    var _migrationDone = false;
+
+    /* `<prefix>.css` is the name Domoticz's own Custom Icons page derives from
+       a prefix, so a migrated library is indistinguishable from a hand-added
+       one — including having the prefix read back off the file stem. */
+    function nativeAssetName(prefix) {
+        return String(prefix || '') + '.css';
+    }
+
+    function normalizePrefix(prefix) {
+        return String(prefix || '').replace(/[^a-z0-9]/gi, '').toLowerCase();
+    }
+
+    /* Resolves true only on a recorded install. Every failure — 403 for a
+       non-admin session, a refused URL, an unreachable server — is one value:
+       "not migrated", which is what keeps the stored entry alive. */
+    function installFromUrl(name, url, title) {
+        return fetch('json.htm?type=command&param=uploadwebasset' +
+                     '&name=' + encodeURIComponent(name) +
+                     '&url=' + encodeURIComponent(url) +
+                     '&title=' + encodeURIComponent(title || ''),
+                     { credentials: 'same-origin' })
+            /* A non-admin session is answered with 403 and no JSON body. */
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (d) { return !!(d && d.status === 'OK'); })
+            .catch(function () { return false; });
+    }
+
+    /* The theme's own upload for a library it has just handed over. Left in
+       place it would keep its Domoticz-injected <link>, so the same font would
+       be fetched and declared twice for the rest of the install's life. Scoped
+       to our own `iconfont-` naming and only ever reached after that library's
+       migration succeeded. */
+    function dropOwnUpload(assetPath) {
+        var name = assetNameOf(assetPath);
+        if (!/^iconfont-[a-z0-9_-]+\.css$/.test(name)) return;
+        fetch('json.htm?type=command&param=deletewebasset&name=' + encodeURIComponent(name),
+              { credentials: 'same-origin' }).catch(function () {});
+    }
+
+    function migrateLegacyLibraries() {
+        if (_migrationDone) return;
+        var stored = readLibsRaw();
+        /* Nothing to migrate — but settings load asynchronously, so this may
+           simply be too early to tell. Stay un-done and let the next call
+           decide. */
+        if (!stored.length) return;
+        _migrationDone = true;
+
+        fetchNativeLibraries(true).then(function () {
+            /* No registry on this build: there is nowhere to migrate TO, and
+               the entries have to keep working the way they always did. */
+            if (!_nativeLibs) return;
+            var registered = {};
+            _nativeLibs.forEach(function (n) { registered[normalizePrefix(n.prefix)] = true; });
+
+            return Promise.all(stored.map(function (l) {
+                var prefix = normalizePrefix(l && l.prefix);
+                /* Already Domoticz's, whether this run put it there or an
+                   earlier one did — which is what makes this idempotent. */
+                if (prefix && registered[prefix]) return true;
+                /* The server installs from a public http(s) URL only; a
+                   relative path or a LAN address is refused. Don't ask, and
+                   above all don't discard the only copy of that URL. */
+                if (!prefix || !/^https?:\/\//i.test(String((l && l.cssUrl) || ''))) return false;
+                return installFromUrl(nativeAssetName(prefix), l.cssUrl, l.name || prefix)
+                    .then(function (ok) {
+                        if (ok && l.assetPath) dropOwnUpload(l.assetPath);
+                        return ok;
+                    });
+            })).then(function (moved) {
+                var keep = stored.filter(function (l, i) { return !moved[i]; });
+                if (keep.length === stored.length) return null;
+                /* saveLibsRaw() re-runs the injector, which sweeps the <link>s
+                   of the entries that just left. */
+                saveLibsRaw(keep);
+                _nativeFetch = null;
+                _cache = null;
+                return fetchNativeLibraries(true).then(function () {
+                    reloadNativeStylesheets();
+                    if (typeof _onNativeChange === 'function') _onNativeChange();
+                });
+            });
+        });
+    }
+    window.dzMigrateIconLibraries = migrateLegacyLibraries;
+
+    /* Domoticz injects a <link> per asset when the app boots and has no reason
+       to look again mid-session, so nudge its loader — otherwise a library that
+       just migrated renders nothing until the next page load. */
+    function reloadNativeStylesheets() {
+        try {
+            var injector = window.angular &&
+                           window.angular.element(document.body).injector();
+            if (injector) injector.get('iconLibraries').load();
+        } catch (e) {}
+    }
+
     /* ── Cross-origin library download + local caching ────────────────
        Nightglass keeps the user-facing config simple (name + URL + prefix)
        but downloads the stylesheet and its assets itself, rewrites those

--- a/src/js/icon-studio.js
+++ b/src/js/icon-studio.js
@@ -128,25 +128,50 @@
     window.dzEnumerateIcons = enumerate;
 
     /* ── Libraries ────────────────────────────────────────────────── */
-    /* Returns [{ id, name, prefix }] — the implicit Font Awesome library
-       plus any user-configured ones. */
+    /* Returns [{ id, name, prefix }] — the implicit Font Awesome library, any
+       user-configured ones, and any library Domoticz itself manages. */
     function configuredLibraries() {
         var libs = [{ id: 'fa', name: 'Font Awesome', prefix: 'fa' }];
+        var byPrefix = {};
         try {
             var raw = (window.dzNightglassSettings &&
                        window.dzNightglassSettings.get('iconLibraries')) || '[]';
             var arr = typeof raw === 'string' ? JSON.parse(raw) : (raw || []);
             (arr || []).forEach(function (l) {
-                if (l && l.prefix) libs.push({
+                if (!l || !l.prefix) return;
+                var entry = {
                     id: l.id || l.prefix, name: l.name || l.prefix,
                     prefix: l.prefix, cssUrl: l.cssUrl,
                     /* assetPath = stored on this Domoticz server; must be
                        carried through so loads/reopens use the local copy
                        instead of going back out to the source URL. */
-                    assetPath: l.assetPath
-                });
+                    assetPath: l.assetPath,
+                    unavailable: !!_nativeGone[l.id || l.prefix]
+                };
+                byPrefix[entry.prefix] = entry;
+                libs.push(entry);
             });
         } catch (e) {}
+
+        /* Domoticz's own registry is APPENDED, never substituted. On a prefix
+           collision the Nightglass entry wins because it carries the cssUrl and
+           assetPath a registry row has no equivalent of — but the registry's
+           Title is a real display name, so adopt it when ours is nothing better
+           than the bare prefix. */
+        nativeLibraries().forEach(function (n) {
+            var mine = byPrefix[n.prefix];
+            if (mine) {
+                if (n.title && mine.name === mine.prefix) mine.name = n.title;
+                return;
+            }
+            /* `managed` records provenance for the code, not for the UI: it is
+               what tells the loader this library is Domoticz's to fetch. */
+            libs.push({
+                id: n.id, name: n.name, prefix: n.prefix,
+                cssUrl: n.cssUrl, assetPath: n.assetPath,
+                managed: 'domoticz'
+            });
+        });
         return libs;
     }
 
@@ -164,6 +189,166 @@
         if (window.dzNightglassSettings) window.dzNightglassSettings.set('iconLibraries', json);
         if (window.dzInjectIconLibraries) window.dzInjectIconLibraries(json);
         _cache = null;   // force re-enumeration next time
+    }
+
+    /* ── Domoticz's own icon-library registry ──────────────────────────
+       Newer Domoticz manages icon libraries itself: they live in the WebAssets
+       table, are added/removed on Setup → Custom Icons, and are listed by the
+       `getwebassets` command. Without this, adding or removing a library there
+       was invisible to the Studio — new ones never showed up and removed ones
+       lingered as broken entries.
+
+       It is strictly an ADDITIONAL source. Stable Domoticz has none of it, so
+       every read is guarded and a missing or failing endpoint must leave
+       behaviour byte-for-byte as it was: nothing is cleared, no <link> is
+       dropped and no recent is pruned off the back of a failed fetch.
+
+       _nativeLibs stays null until one read actually succeeds, which is also
+       its permanent value on a Domoticz without the endpoint. */
+    var _nativeLibs = null;
+    var _nativeFetch = null;
+    var _nativeGone = {};        // our libs whose uploaded asset has vanished
+    var _onNativeChange = null;  // set while the Studio is open
+
+    function nativeLibraries() { return _nativeLibs || []; }
+
+    /* Nightglass uploads its own packaged copies as `iconfont-<prefix>.css`
+       (see assetFileName below) and Domoticz lists those rows too. They are
+       already represented by the iconLibraries entry that owns them, and their
+       stem would derive the bogus prefix "iconfont-mdi", so they are not
+       libraries as far as this merge is concerned. */
+    function isOwnAssetName(name) {
+        return /^iconfont-/i.test(String(name || ''));
+    }
+
+    /* `assets/iconfont-mdi.css?v=1756…` → `iconfont-mdi.css`. The cache-busting
+       query is ours alone and registry rows never carry one, so removal
+       detection has to compare on the bare file name. */
+    function assetNameOf(path) {
+        var clean = String(path || '').split('?')[0].split('#')[0];
+        return clean.slice(clean.lastIndexOf('/') + 1).toLowerCase();
+    }
+
+    function deriveNativeLib(asset) {
+        var name = String((asset && asset.name) || '');
+        if (!/\.css$/i.test(name) || isOwnAssetName(name)) return null;
+        /* Same derivation as Domoticz's own Custom Icons page: the file stem IS
+           the class prefix, because that page builds the name from the prefix
+           the user typed (`<prefix>.css`). */
+        var prefix = name.replace(/\.css$/i, '').replace(/[^a-z0-9]/gi, '');
+        if (!prefix) return null;
+        var title = String(asset.Title || '').trim();
+        var path = asset.path || ('assets/' + name);
+        /* cssUrl here is a cache key and a same-origin read path, not a download
+           source — Domoticz owns fetching this library. Folding LastUpdate in
+           makes a refresh on the native page miss the stored class list instead
+           of serving the previous copy's glyphs. */
+        var stamp = String(asset.LastUpdate || '').replace(/[^0-9]/g, '');
+        return {
+            id: prefix,
+            name: title || prefix,
+            prefix: prefix,
+            title: title,
+            assetPath: path,
+            cssUrl: path + (stamp ? '?ts=' + stamp : '')
+        };
+    }
+
+    function fetchNativeLibraries(force) {
+        if (_nativeFetch && !force) return _nativeFetch;
+        var job = fetch('json.htm?type=command&param=getwebassets',
+                        { credentials: 'same-origin' })
+            .then(function (r) { if (!r.ok) throw 0; return r.json(); })
+            .then(function (d) {
+                /* A Domoticz without the command 404s (thrown above) or answers
+                   with an error payload. Either way there is no registry, and
+                   "no registry" must never be read as "everything was deleted". */
+                if (!d || d.status !== 'OK' || !Array.isArray(d.result)) throw 0;
+                var libs = [], seen = {};
+                d.result.forEach(function (a) {
+                    var lib = deriveNativeLib(a);
+                    if (!lib || seen[lib.prefix]) return;
+                    seen[lib.prefix] = true;
+                    libs.push(lib);
+                });
+                _nativeLibs = libs;
+                reconcileOwnAssets(d.result);
+                return libs;
+            })
+            .catch(function () {
+                /* Retry on the next open rather than caching the failure, and
+                   hand back whatever was last known good. */
+                if (_nativeFetch === job) _nativeFetch = null;
+                return nativeLibraries();
+            });
+        _nativeFetch = job;
+        return job;
+    }
+
+    /* One of our own libraries whose uploaded copy is gone from the registry was
+       removed on the native Custom Icons page. Treat it as gone — but keep the
+       user's iconLibraries entry, since a settings entry still holds the source
+       URL needed to reinstall it. Only ever reached from a SUCCESSFUL read. */
+    function reconcileOwnAssets(rows) {
+        var present = {};
+        rows.forEach(function (a) {
+            if (a && a.name) present[String(a.name).toLowerCase()] = true;
+        });
+        var changed = false;
+        readLibsRaw().forEach(function (l) {
+            if (!l || !l.assetPath) return;
+            var id = l.id || l.prefix;
+            if (present[assetNameOf(l.assetPath)]) {
+                if (_nativeGone[id]) { delete _nativeGone[id]; changed = true; }
+                return;
+            }
+            if (_nativeGone[id]) return;
+            _nativeGone[id] = true;
+            changed = true;
+            forgetVanishedLibrary(l);
+        });
+        if (!changed) return;
+        _cache = null;
+        /* Re-run injection so a library that came BACK gets its <link> again;
+           the ones still flagged are skipped there and swept away. */
+        if (window.dzInjectIconLibraries) window.dzInjectIconLibraries(readLibsRaw());
+    }
+
+    function forgetVanishedLibrary(l) {
+        var id = l.id || l.prefix;
+        var domId = libraryDomId(l);
+        var link = document.getElementById(domId);
+        if (link && link.parentNode) {
+            revokeLibraryBlobUrl(domId);
+            link.parentNode.removeChild(link);
+        }
+        delete _libIcons[id];
+        delete _libPackageLoads[libraryKey(l)];
+        setLibStatus(id, 'missing');
+        /* Both keys: the class list may have been stored under the source URL or
+           under the server path, depending on which route loaded it. */
+        dropLibCache(l.cssUrl);
+        dropLibCache(l.assetPath);
+    }
+
+    /* Domoticz's Custom Icons page broadcasts after every successful add,
+       refresh and delete. Angular, the injector and the event are all optional
+       — on older builds none of the three exists, and the per-open refetch below
+       is what keeps the Studio correct there. */
+    function subscribeToNativeChanges() {
+        try {
+            var injector = window.angular &&
+                           window.angular.element(document.body).injector();
+            if (!injector) return false;
+            injector.get('$rootScope').$on('dz-webassets-changed', function () {
+                _nativeFetch = null;
+                _cache = null;
+                fetchNativeLibraries(true).then(function () {
+                    if (typeof _onNativeChange === 'function') _onNativeChange();
+                });
+            });
+            return true;
+        } catch (e) { return false; }
     }
 
     /* ── Cross-origin library download + local caching ────────────────
@@ -226,11 +411,21 @@
         catch (e) { return {}; }
     }
     function writeLibCache(url, icons) {
+        if (!url) return;                 // no key = nothing worth storing
         try {
             var c = readLibCache();
             c[url] = { icons: icons, ts: Date.now() };
             localStorage.setItem(LIB_CACHE_KEY, JSON.stringify(c));
         } catch (e) { /* quota / disabled — best effort, falls back to refetch */ }
+    }
+    function dropLibCache(url) {
+        if (!url) return;
+        try {
+            var c = readLibCache();
+            if (!Object.prototype.hasOwnProperty.call(c, url)) return;
+            delete c[url];
+            localStorage.setItem(LIB_CACHE_KEY, JSON.stringify(c));
+        } catch (e) {}
     }
 
     function setLibStatus(id, state, extra) {
@@ -249,6 +444,13 @@
 
     function libraryKey(lib) {
         return String((lib && (lib.id || lib.prefix)) || '') + '|' + String((lib && lib.cssUrl) || '');
+    }
+
+    /* The id of the <link> this library owns. Shared by the injector and the
+       removal path so both address the same element. */
+    function libraryDomId(lib) {
+        var libId = (lib && (lib.id || lib.prefix)) || (lib && lib.cssUrl) || '';
+        return 'ng-iconlib-' + String(libId).replace(/[^\w-]/g, '');
     }
 
     function libraryStillConfigured(lib) {
@@ -422,8 +624,12 @@
         return btoa(bin);
     }
 
-    function uploadWebAsset(name, content) {
+    /* `title` is display-only and ignored by Domoticz builds that predate it;
+       sending it means our uploads are labelled with their library name on the
+       native Custom Icons page instead of the bare `iconfont-<prefix>` stem. */
+    function uploadWebAsset(name, content, title) {
         var body = 'name=' + encodeURIComponent(name) +
+                   '&title=' + encodeURIComponent(title || '') +
                    '&data=' + encodeURIComponent(utf8ToBase64(content));
         return fetch('json.htm?type=command&param=uploadwebasset', {
             method: 'POST',
@@ -459,7 +665,7 @@
     /* Best-effort publish; resolves to the path or null (never rejects). */
     function publishLibraryToServer(lib, cssText) {
         if (!cssText) return Promise.resolve(null);
-        return uploadWebAsset(assetFileName(lib), cssText)
+        return uploadWebAsset(assetFileName(lib), cssText, lib.name || lib.prefix)
             .then(function (path) {
                 if (!libraryStillConfigured(lib)) return null;
                 /* Refreshing overwrites the same filename, so version the URL —
@@ -591,7 +797,12 @@
             (arr || []).forEach(function (l) {
                 if (!l || !l.cssUrl) return;
                 var libId = l.id || l.prefix;
-                var domId = 'ng-iconlib-' + String(libId || l.cssUrl).replace(/[^\w-]/g, '');
+                /* Its asset was deleted on Domoticz's Custom Icons page, so
+                   re-creating the <link> would only request a 404 and re-flash
+                   the icons. Left out of `want` on purpose: the sweep below then
+                   removes any link still hanging around. Refresh clears this. */
+                if (_nativeGone[libId]) return;
+                var domId = libraryDomId(l);
                 want[domId] = true;
                 var link = document.getElementById(domId);
                 if (link) {
@@ -768,6 +979,9 @@
     function libraryStatusSummary(lib) {
         var st = _libStatus[lib.id || lib.prefix] || {};
         if (st.state === 'downloading') return 'Downloading…';
+        if (st.state === 'missing') {
+            return 'Removed from this server on Domoticz’s Custom Icons page — refresh to reinstall';
+        }
         if (st.state === 'server') return 'Stored on this server — shared by all devices';
         if (st.state === 'cached') return 'Stored in this browser' + (st.ts ? ' · updated ' + formatAge(st.ts) : '');
         if (st.state === 'remote') return 'Using source URL fallback';
@@ -880,6 +1094,7 @@
             _escHandler = null;
         }
         restoreRelaxedDialogs();
+        _onNativeChange = null;
         _overlay.classList.remove('ng-is--open');
         var el = _overlay;
         _overlay = null;
@@ -920,7 +1135,10 @@
             groups = groupByLibrary(all, libs);
         }
         buildData();
-        pruneRecent(libs);   // self-heal: drop recents from libraries removed elsewhere
+        /* pruneRecent() is deliberately NOT called here — it runs once the
+           native registry has been consulted (see the bottom of this function),
+           because until then a recent icon from a Domoticz-managed library has
+           no library to be recognised by and would be thrown away. */
 
         var overlay = document.createElement('div');
         overlay.id = 'ng-is-overlay';
@@ -1085,6 +1303,10 @@
         function loadLibraries() {
             configuredLibraries().forEach(function (l) {
                 if (l.id === 'fa') return;
+                /* Domoticz serves its own libraries same-origin and injects the
+                   <link> itself, so their glyphs normally arrive via enumerate()
+                   already; only read the stylesheet when that found none. */
+                if (l.managed === 'domoticz' && groups[l.id] && groups[l.id].icons.length) return;
                 loadLibraryIcons(l, function () {
                     buildData();
                     renderRail();
@@ -1123,6 +1345,9 @@
                     if ((_libStatus[l.id || l.prefix] || {}).state === 'downloading') {
                         rowEl.className += ' ng-is-lib-row--busy';
                     }
+                    if (_nativeGone[l.id || l.prefix]) {
+                        rowEl.className += ' ng-is-lib-row--missing';
+                    }
                     rowEl.innerHTML =
                         '<div class="ng-is-lib-meta"><strong>' + (l.name || l.prefix || '?') + '</strong>' +
                         '<span>' + (l.prefix ? l.prefix + '-*' : '') + ' · ' + (l.cssUrl || '') + '</span>' +
@@ -1138,6 +1363,9 @@
                     refresh.addEventListener('click', function () {
                         var lib = { id: l.id || l.prefix, name: l.name || l.prefix, cssUrl: l.cssUrl, prefix: l.prefix };
                         setLibStatus(lib.id, 'downloading');
+                        /* Redownloading re-uploads it, so a library that was
+                           deleted server-side is no longer "gone". */
+                        delete _nativeGone[lib.id];
                         delete _libIcons[lib.id];
                         renderManage();
                         renderRail();
@@ -1175,6 +1403,9 @@
             /* One-click suggestions for popular libraries (prefill only). */
             var addedPrefixes = {};
             raw.forEach(function (l) { if (l && l.prefix) addedPrefixes[l.prefix] = true; });
+            /* Hide the suggestion for anything Domoticz already serves —
+               accepting it would just add a second copy under the same prefix. */
+            nativeLibraries().forEach(function (n) { addedPrefixes[n.prefix] = true; });
             var suggestable = SUGGESTED_LIBS.filter(function (s) { return !addedPrefixes[s.prefix]; });
             if (suggestable.length) {
                 var sug = document.createElement('div');
@@ -1336,7 +1567,13 @@
                 }
                 var g = groups[scope];
                 if (!g || !g.icons.length) {
-                    var reason = _libIcons[scope] === 'error'
+                    var scoped = null;
+                    libs.forEach(function (l) { if (l.id === scope) scoped = l; });
+                    var reason = (scoped && scoped.unavailable)
+                        ? 'This library was removed from this server on Domoticz’s ' +
+                          'Custom Icons page. Use Refresh under “Add / manage ' +
+                          'libraries” to reinstall it.'
+                        : _libIcons[scope] === 'error'
                         ? 'Couldn’t download this library into the local cache. ' +
                           'Nightglass will fall back to the source URL if the browser can load it.'
                         : 'No icons found in this library’s stylesheet. Paste the exact class below instead.';
@@ -1434,6 +1671,22 @@
         renderMain();
         loadLibraries();          // fetch+parse CDN/custom libraries in the background
 
+        /* Reconcile with Domoticz's registry on every open, so the Studio also
+           self-heals on builds that never broadcast dz-webassets-changed. The
+           same handler serves the broadcast while this overlay is on screen.
+           fetchNativeLibraries() always resolves: on a Domoticz without the
+           command it yields the empty list, which leaves every step below
+           behaving exactly as it did before the registry existed. */
+        _onNativeChange = function () {
+            if (_overlay !== overlay) return;      // a newer overlay owns the UI
+            buildData();
+            pruneRecent(libs);    // self-heal: drop recents from removed libraries
+            renderRail();
+            renderMain();
+            loadLibraries();
+        };
+        fetchNativeLibraries(true).then(_onNativeChange);
+
         /* Must happen before we take focus: an open jQuery UI modal would
            otherwise steal it straight back (#230). */
         relaxOpenModalDialogs();
@@ -1441,4 +1694,14 @@
     }
 
     window.dzOpenIconStudio = openIconStudio;
+
+    /* Angular bootstraps after this file runs, so the injector is usually not
+       there yet; retry briefly and then give up for good — on a Domoticz without
+       the feature it will never appear, and the per-open refetch covers it. */
+    if (!subscribeToNativeChanges()) {
+        var tries = 0;
+        var timer = setInterval(function () {
+            if (subscribeToNativeChanges() || ++tries >= 20) clearInterval(timer);
+        }, 500);
+    }
 })();

--- a/src/js/icon-studio.js
+++ b/src/js/icon-studio.js
@@ -22,13 +22,22 @@
    icons. Those are PNGs, not glyphs, so they carry a CustomImage number
    rather than a class and come back through onPickImage.
 
+   Callers that are editing ONE device may likewise opt into the animation
+   row, which is the same opt-in shape: it needs somewhere to store the
+   choice, so it appears only for a caller that passes onPickAnimation.
+   Animation is a second axis rather than part of the pick, so clicking a
+   tile reports it and leaves the dialog open.
+
    Public API:
      window.dzOpenIconStudio({
          current,        // class string of the current pick, if any
          currentImage,   // CustomImage number of the current pick, if any
          allowImages,    // offer the Custom (uploaded image) source
+         animation,      // animation id currently set, '' for none
+         animationGlyph, // glyph to preview the animations on (default: current)
          onPick,         // fn(classString)
          onPickImage,    // fn(customImage, item)
+         onPickAnimation,// fn(animationId) — offers the animation row
          title
      })
      window.dzMigrateIconLibraries()      // called by the settings module
@@ -447,6 +456,28 @@
         return glyphTokenOf(cls).replace(/^[a-z0-9]+-/i, '').replace(/-/g, ' ').trim();
     }
 
+    /* ── Animations ───────────────────────────────────────────────────
+       The catalogue is icons.js's (window.dzIconAnimations); this module
+       only renders it. Both reads are guarded so the row degrades to
+       nothing at all rather than half a row if that module is absent. */
+    function animCatalogue() {
+        return (window.dzIconAnimations || []);
+    }
+    function animClassOf(id) {
+        return (typeof window.dzIconAnimClass === 'function')
+            ? window.dzIconAnimClass(id) : '';
+    }
+    /* '' for anything not in the catalogue — including a stale id from an
+       override written by a later version of the theme. */
+    function animIdOf(value) {
+        var v = String(value == null ? '' : value);
+        var list = animCatalogue();
+        for (var i = 0; i < list.length; i++) {
+            if (list[i].id === v) return v;
+        }
+        return '';
+    }
+
     /* An override stored before base classes were emitted is a bare token
        ("bi-alarm"); still mark its tile ("bi bi-alarm") as the current pick.
        Only a bare token may match loosely, so "fa-solid fa-house" and
@@ -621,6 +652,31 @@
         /* Images need somewhere to go, so the source is only offered to a
            caller that can store one. */
         var allowImg  = !!opts.allowImages && typeof opts.onPickImage === 'function';
+        /* Same rule for the animation row: no store, no row. That also keeps
+           it out of callers with no device to attach it to. */
+        var allowAnim = typeof opts.onPickAnimation === 'function' &&
+                        animCatalogue().length > 0;
+        var animPick  = animIdOf(opts.animation);
+
+        /* On/off (and beyond) target slots.  Domoticz's own native picker
+           gained a distinct off-state icon, and this mirrors it: each slot is
+           { key, label, cls }, the grid assigns to whichever is active, and
+           onPickSlot(key, cls) reports it.  A caller that passes no slots gets
+           the classic single-target picker unchanged. */
+        var slots = (Array.isArray(opts.slots) &&
+                     typeof opts.onPickSlot === 'function')
+            ? opts.slots.map(function (s) {
+                  return { key: s.key, label: s.label, cls: cleanClass(s.cls) };
+              })
+            : null;
+        var activeSlot = 0;
+        if (slots && slots.length) chosen = slots[0].cls || chosen;
+
+        /* With a second axis to set — an off icon, an animation, or both — an
+           icon click refines the choice rather than finishing it, so the dialog
+           stays open and the user closes it with Done / Esc.  Without one it is
+           still pick-and-go. */
+        var keepOpen  = !!(slots && slots.length) || allowAnim;
         var scope     = 'all';           // 'all' | 'recent' | 'custom' | libId
         var query     = '';
 
@@ -654,15 +710,18 @@
             '    </div>' +
             '    <button class="ng-is-close" aria-label="Close"><i class="fa-solid fa-xmark"></i></button>' +
             '  </div>' +
+            (slots ? '  <div class="ng-is-slotbar"></div>' : '') +
             '  <div class="ng-is-body">' +
             '    <div class="ng-is-rail"></div>' +
             '    <div class="ng-is-main"></div>' +
             '  </div>' +
             '  <div class="ng-is-foot">' +
+            (allowAnim ? '    <div class="ng-is-anim"></div>' : '') +
             '    <div class="ng-is-manual">' +
             '      <span class="ng-is-manual-preview"><i class="' + (chosen || 'fa-solid fa-question') + '"></i></span>' +
             '      <input class="ng-is-manual-input" type="text" placeholder="Or paste any icon class (e.g. mdi mdi-home, fa-brands fa-github)" autocomplete="off">' +
             '      <button class="ng-is-manual-use" type="button">Use</button>' +
+            (keepOpen ? '      <button class="ng-is-done" type="button">Done</button>' : '') +
             '    </div>' +
             '    <div class="ng-is-manual-msg" role="alert"></div>' +
             '  </div>' +
@@ -680,12 +739,33 @@
         var mInput   = overlay.querySelector('.ng-is-manual-input');
         var mPrev    = overlay.querySelector('.ng-is-manual-preview i');
         var mMsg     = overlay.querySelector('.ng-is-manual-msg');
+        var slotbarEl = overlay.querySelector('.ng-is-slotbar');
 
         function apply(cls) {
             cls = cleanClass(cls);
             if (!cls) return false;
             pushRecent(cls);
+            if (slots) {
+                /* Assign to the active slot and stay put: the user is likely to
+                   set the other slot next. */
+                slots[activeSlot].cls = cls;
+                chosen = cls;
+                opts.onPickSlot(slots[activeSlot].key, cls);
+                renderSlots();
+                renderMain();          // move the grid's "current" marker
+                if (allowAnim) renderAnimRow();   // preview on the new on-icon
+                if (mPrev) mPrev.className = cls;
+                return true;
+            }
             if (typeof opts.onPick === 'function') opts.onPick(cls);
+            if (keepOpen) {
+                /* Animation-only caller (the override editor): report the icon
+                   but leave the dialog up so the animation row is still there. */
+                chosen = cls;
+                renderMain();
+                if (mPrev) mPrev.className = cls;
+                return true;
+            }
             close();
             return true;
         }
@@ -694,8 +774,46 @@
             if (!allowImg || !item || !(item.value > 0)) return false;
             pushRecent(item);
             opts.onPickImage(item.value, item);
+            /* An uploaded image is a whole-icon choice — there is no separate
+               off PNG — so it finishes the icon axis.  Keep the dialog open
+               only if there is still an animation to set. */
+            if (keepOpen) return true;
             close();
             return true;
+        }
+
+        /* On/off target bar (only when the caller passes slots). */
+        function renderSlots() {
+            if (!slotbarEl) return;
+            slotbarEl.innerHTML = '';
+            var lead = document.createElement('span');
+            lead.className = 'ng-is-slotbar-lead';
+            lead.textContent = 'Editing';
+            slotbarEl.appendChild(lead);
+            slots.forEach(function (s, i) {
+                var b = document.createElement('button');
+                b.type = 'button';
+                b.className = 'ng-is-slot' + (i === activeSlot ? ' ng-is-slot--active' : '');
+                var ic = document.createElement('i');
+                ic.className = s.cls || 'fa-regular fa-square';
+                var lab = document.createElement('span');
+                lab.className = 'ng-is-slot-label';
+                lab.textContent = s.label;
+                var sub = document.createElement('em');
+                sub.className = 'ng-is-slot-cls';
+                sub.textContent = s.cls ? labelOf(s.cls) : 'not set';
+                b.appendChild(ic);
+                b.appendChild(lab);
+                b.appendChild(sub);
+                b.addEventListener('click', function () {
+                    activeSlot = i;
+                    chosen = s.cls;
+                    renderSlots();
+                    renderMain();
+                    if (mPrev) mPrev.className = s.cls || 'fa-solid fa-question';
+                });
+                slotbarEl.appendChild(b);
+            });
         }
 
         /* One tile for both kinds. An entry is a class string (glyph) or an
@@ -794,8 +912,11 @@
         }
 
         function onGridKeydown(e) {
-            /* The manual-class field owns its own Enter/arrow behaviour. */
-            if (e.target && e.target.closest && e.target.closest('.ng-is-manual')) return;
+            /* The footer owns its own Enter/arrow behaviour: the manual-class
+               field types, and an animation tile is a plain focusable button
+               whose native Enter must not be stolen by the grid cursor. */
+            if (e.target && e.target.closest &&
+                e.target.closest('.ng-is-manual, .ng-is-anim')) return;
 
             var list = tiles();
             if (e.key === 'Enter') {
@@ -981,6 +1102,62 @@
             });
         }
 
+        /* ── Animation row ────────────────────────────────────────────
+           A row of tiles, each rendering the icon that is actually selected
+           with one catalogue animation applied — the same .dz-anim-* class
+           the card icon gets, so what the tile does is what the device will
+           do. The choice is made by watching rather than by reading a name,
+           which is why there is no dropdown here. */
+        function renderAnimRow() {
+            var wrap = overlay.querySelector('.ng-is-anim');
+            if (!wrap) return;
+            /* Preview on the icon under discussion — the on/active icon, which
+               is what animates on the card.  `chosen` follows the active slot,
+               and apply() re-renders this row when the icon changes, so the
+               previews always animate the glyph the user just picked. */
+            var glyph = (slots && slots[0].cls) || cleanClass(opts.animationGlyph) ||
+                        chosen || 'fa-solid fa-lightbulb';
+
+            wrap.innerHTML =
+                '<div class="ng-is-anim-head">Animation ' +
+                '<em>plays while the device is on</em></div>' +
+                '<div class="ng-is-anim-strip"></div>';
+            var strip = wrap.querySelector('.ng-is-anim-strip');
+
+            /* "No animation" is the default, so it leads the row. */
+            var entries = [{ id: '', label: 'No animation', hint: 'Holds still' }]
+                .concat(animCatalogue());
+
+            entries.forEach(function (a) {
+                var b = document.createElement('button');
+                b.type = 'button';
+                b.className = 'ng-is-anim-tile' +
+                    (a.id ? '' : ' ng-is-anim-tile--off') +
+                    (a.id === animPick ? ' ng-is-anim-tile--active' : '');
+                b.title = a.hint ? a.label + ' — ' + a.hint : a.label;
+
+                var ic = document.createElement('i');
+                ic.className = glyph + (a.id ? ' ' + animClassOf(a.id) : '');
+                var lbl = document.createElement('span');
+                lbl.textContent = a.label;
+                b.appendChild(ic);
+                b.appendChild(lbl);
+
+                b.addEventListener('click', function () {
+                    animPick = a.id;
+                    strip.querySelectorAll('.ng-is-anim-tile').forEach(function (t) {
+                        t.classList.remove('ng-is-anim-tile--active');
+                    });
+                    b.classList.add('ng-is-anim-tile--active');
+                    /* Reported straight away and the dialog stays open: this is
+                       a second axis, not the pick, and the user may well want to
+                       change the icon in the same visit. */
+                    opts.onPickAnimation(a.id);
+                });
+                strip.appendChild(b);
+            });
+        }
+
         /* ── Wire ── */
         /* Every keystroke would otherwise re-filter and re-tile a pool of
            thousands. Only the re-render is deferred, so the field itself stays
@@ -1022,6 +1199,8 @@
             if (e.key === 'Enter') { e.preventDefault(); useManual(); }
         });
         overlay.querySelector('.ng-is-manual-use').addEventListener('click', useManual);
+        var doneBtn = overlay.querySelector('.ng-is-done');
+        if (doneBtn) doneBtn.addEventListener('click', close);
         overlay.querySelector('.ng-is-close').addEventListener('click', close);
         overlay.addEventListener('click', function (e) { if (e.target === overlay) close(); });
         overlay.addEventListener('keydown', onGridKeydown);
@@ -1041,6 +1220,8 @@
 
         renderRail();
         renderMain();
+        if (slots)     renderSlots();
+        if (allowAnim) renderAnimRow();
 
         /* Reconcile with the registry on every open, so the Studio also
            self-heals on builds that never broadcast dz-webassets-changed. The

--- a/src/js/icon-studio.js
+++ b/src/js/icon-studio.js
@@ -17,8 +17,20 @@
    Because the stylesheets are therefore same-origin, their glyphs come
    straight out of document.styleSheets and need no fetching at all.
 
+   Callers that can store an image (the device / Utility icon field) may
+   also opt into a Custom source listing the user's ZIP-uploaded custom
+   icons. Those are PNGs, not glyphs, so they carry a CustomImage number
+   rather than a class and come back through onPickImage.
+
    Public API:
-     window.dzOpenIconStudio({ current, onPick, title })
+     window.dzOpenIconStudio({
+         current,        // class string of the current pick, if any
+         currentImage,   // CustomImage number of the current pick, if any
+         allowImages,    // offer the Custom (uploaded image) source
+         onPick,         // fn(classString)
+         onPickImage,    // fn(customImage, item)
+         title
+     })
      window.dzMigrateIconLibraries()      // called by the settings module
      window.dzEnumerateIcons()            // cached flat class list
    ══════════════════════════════════════════════════════════════════ */
@@ -331,6 +343,77 @@
     }
     window.dzMigrateIconLibraries = migrateLegacyLibraries;
 
+    /* ── Domoticz's uploaded custom icons ──────────────────────────────
+       The ZIP uploads on Setup → More Options → Custom Icons. They are PNGs,
+       so they are the one thing an icon class cannot express, and the only
+       reason this module talks about images at all.
+
+       Only the uploads are offered — not Domoticz's 38 built-in switch icons.
+       Every one of those now carries an FaClass (verified against
+       custom_light_icons on 2026.3), which is what Domoticz renders for
+       CustomImage 1..99 and what Nightglass substitutes for their PNGs on
+       older builds. So a "Domoticz" source would be a second, worse-labelled
+       route to glyphs the Font Awesome source already lists: picking "Alarm"
+       and picking fa-solid fa-bell produce the identical result. Native
+       offers both because its glyph source is a separate opt-in; here glyphs
+       are the default, so the built-ins are pure duplication. */
+    var _imgSet = null;      // null = never read; [] = read, none uploaded
+    var _imgFetch = null;
+
+    function customImages() { return _imgSet || []; }
+
+    function fetchCustomImages(force) {
+        if (_imgFetch && !force) return _imgFetch;
+        var job = fetch('json.htm?type=command&param=getcustomiconset',
+                        { credentials: 'same-origin' })
+            .then(function (r) { if (!r.ok) throw 0; return r.json(); })
+            .then(function (d) {
+                if (!d || d.status !== 'OK' || !Array.isArray(d.result)) throw 0;
+                var list = [];
+                d.result.forEach(function (it) {
+                    var id = parseInt(it && it.idx, 10);
+                    if (isNaN(id)) return;
+                    var src = String(it.IconFile48On || it.IconFile16 || '');
+                    if (!src) return;
+                    list.push({
+                        kind: 'img',
+                        /* Cmd_GetCustomIconSet (main/WebServerCmds.cpp) emits
+                           only icons whose internal idx is >= 100 — the
+                           CustomImages table, i.e. the uploads — and reports
+                           `icon.idx - 100`. DeviceStatus.CustomImage stores the
+                           internal value, so the 100 that
+                           ReloadCustomSwitchIcons() added has to go back on.
+                           Get this wrong and a pick silently lands on a
+                           different icon, so it is stored resolved, once,
+                           here rather than re-derived at each use site. */
+                        value: id + 100,
+                        src: src,
+                        name: String(it.Title || '').trim() || ('#' + id),
+                        desc: String(it.Description || '').trim()
+                    });
+                });
+                _imgSet = list;
+                return list;
+            })
+            .catch(function () {
+                /* A Domoticz that refuses the command (or a session without
+                   rights) leaves the source absent rather than empty, and gets
+                   another chance on the next open. */
+                if (_imgFetch === job) _imgFetch = null;
+                return customImages();
+            });
+        _imgFetch = job;
+        return job;
+    }
+
+    function findCustomImage(value) {
+        var list = customImages();
+        for (var i = 0; i < list.length; i++) {
+            if (list[i].value === value) return list[i];
+        }
+        return null;
+    }
+
     /* Which library a class belongs to (by prefix). */
     function libIdOf(cls, libs) {
         var token = cls.split(/\s+/)[0];              // e.g. "fa-solid" | "mdi" | "bi"
@@ -373,24 +456,56 @@
         return a === b || a === glyphTokenOf(b) || b === glyphTokenOf(a);
     }
 
-    /* ── Recent (localStorage) ────────────────────────────────────── */
-    /* Guarded on read as well as write: the list is user-editable storage that
+    /* ── Recent (localStorage) ──────────────────────────────────────
+       An entry is either a class string (a glyph) or { kind:'img', value:N }
+       (an uploaded image, N = CustomImage). On disk images are stored as
+       { ci: N }: an older Nightglass runs cleanClass() over every entry, which
+       turns an object into "[object Object]", fails SAFE_CLASS_RE and drops it
+       — so a mixed list degrades to the glyphs it can use instead of rendering
+       a broken tile.
+
+       Guarded on read as well as write: the list is user-editable storage that
        gets interpolated into a class attribute. */
+    function isImgEntry(e) { return !!(e && typeof e === 'object' && e.kind === 'img'); }
+    function entryKey(e)   { return isImgEntry(e) ? 'ci:' + e.value : String(e); }
+
     function getRecent() {
         try {
             var list = JSON.parse(localStorage.getItem(RECENT_KEY) || '[]') || [];
-            return list.map(cleanClass).filter(Boolean);
+            var out = [];
+            list.forEach(function (e) {
+                if (e && typeof e === 'object') {
+                    var ci = parseInt(e.ci, 10);
+                    if (ci > 0) out.push({ kind: 'img', value: ci });
+                    return;
+                }
+                var cls = cleanClass(e);
+                if (cls) out.push(cls);
+            });
+            return out;
         }
         catch (e) { return []; }
     }
-    function pushRecent(cls) {
-        cls = cleanClass(cls);
-        if (!cls) return;
+    function storeRecent(list) {
         try {
-            var list = getRecent().filter(function (c) { return c !== cls; });
-            list.unshift(cls);
-            localStorage.setItem(RECENT_KEY, JSON.stringify(list.slice(0, RECENT_MAX)));
+            localStorage.setItem(RECENT_KEY, JSON.stringify(
+                list.slice(0, RECENT_MAX).map(function (e) {
+                    return isImgEntry(e) ? { ci: e.value } : e;
+                })));
         } catch (e) {}
+    }
+    function pushRecent(entry) {
+        if (isImgEntry(entry)) {
+            if (!(parseInt(entry.value, 10) > 0)) return;
+            entry = { kind: 'img', value: parseInt(entry.value, 10) };
+        } else {
+            entry = cleanClass(entry);
+            if (!entry) return;
+        }
+        var key = entryKey(entry);
+        var list = getRecent().filter(function (e) { return entryKey(e) !== key; });
+        list.unshift(entry);
+        storeRecent(list);
     }
 
     /* Is this icon class still backed by an available library? Font Awesome is
@@ -405,13 +520,16 @@
         return false;
     }
 
-    /* Drop recent icons whose library has been removed, so they don't linger as
-       blank/invalid glyphs. */
+    /* Drop recent icons whose library has been removed, or whose uploaded image
+       has been deleted, so they don't linger as blank tiles. An image is only
+       judged once the set has actually been read: before that, "not in the
+       list" means "list not loaded", not "deleted". */
     function pruneRecent(libs) {
-        try {
-            var kept = getRecent().filter(function (c) { return isKnownIcon(c, libs); });
-            localStorage.setItem(RECENT_KEY, JSON.stringify(kept));
-        } catch (e) {}
+        var kept = getRecent().filter(function (e) {
+            if (isImgEntry(e)) return _imgSet === null || !!findCustomImage(e.value);
+            return isKnownIcon(e, libs);
+        });
+        storeRecent(kept);
     }
 
     /* ── Font Awesome category chips (curated) ────────────────────── */
@@ -496,16 +614,21 @@
             if (prev.parentNode) prev.remove();
         }
 
-        var libs, all, groups;
+        var libs, all, groups, imgs;
         /* Sanitised: it is interpolated into the preview's class attribute. */
         var chosen    = cleanClass(opts.current);
-        var scope     = 'all';           // 'all' | 'recent' | libId
+        var chosenImg = parseInt(opts.currentImage, 10) || 0;
+        /* Images need somewhere to go, so the source is only offered to a
+           caller that can store one. */
+        var allowImg  = !!opts.allowImages && typeof opts.onPickImage === 'function';
+        var scope     = 'all';           // 'all' | 'recent' | 'custom' | libId
         var query     = '';
 
         function buildData() {
             libs = configuredLibraries();
             all = enumerate();
             groups = groupByLibrary(all, libs);
+            imgs = allowImg ? customImages() : [];
         }
         /* A library may have been installed or removed since the last open, and
            its stylesheet is loaded by then either way, so never open on a stale
@@ -567,30 +690,79 @@
             return true;
         }
 
-        /* Icon tile */
-        function tile(cls) {
+        function applyImage(item) {
+            if (!allowImg || !item || !(item.value > 0)) return false;
+            pushRecent(item);
+            opts.onPickImage(item.value, item);
+            close();
+            return true;
+        }
+
+        /* One tile for both kinds. An entry is a class string (glyph) or an
+           uploaded-image record; everything above this point keeps them in the
+           same arrays so search, the cap and the keyboard cursor need no idea
+           which is which. */
+        function tile(entry) {
             var b = document.createElement('button');
             b.type = 'button';
-            b.className = 'ng-is-tile' + (sameIcon(cls, chosen) ? ' ng-is-tile--active' : '');
-            b.title = labelOf(cls);
-            b.innerHTML = '<i class="' + cls + '"></i><span>' + labelOf(cls) + '</span>';
-            b.addEventListener('click', function () { apply(cls); });
+            var isImg = isImgEntry(entry);
+            var active = isImg ? (entry.value === chosenImg) : sameIcon(entry, chosen);
+            b.className = 'ng-is-tile' + (active ? ' ng-is-tile--active' : '');
+
+            if (isImg) {
+                b.classList.add('ng-is-tile--img');
+                b.title = entry.desc ? entry.name + ' — ' + entry.desc : entry.name;
+                var im = document.createElement('img');
+                im.src = entry.src;
+                im.alt = '';
+                var label = document.createElement('span');
+                /* Title and Description come from the server; set as text so a
+                   name with markup in it stays a name. */
+                label.textContent = entry.name;
+                b.appendChild(im);
+                b.appendChild(label);
+                b.addEventListener('click', function () { applyImage(entry); });
+                return b;
+            }
+
+            b.title = labelOf(entry);
+            b.innerHTML = '<i class="' + entry + '"></i><span>' + labelOf(entry) + '</span>';
+            b.addEventListener('click', function () { apply(entry); });
             return b;
         }
 
-        function gridOf(classes, capped) {
+        function gridOf(entries, capped) {
             var grid = document.createElement('div');
             grid.className = 'ng-is-grid';
-            var list = capped ? classes.slice(0, RESULT_CAP) : classes;
-            list.forEach(function (c) { grid.appendChild(tile(c)); });
-            if (capped && classes.length > RESULT_CAP) {
+            var list = capped ? entries.slice(0, RESULT_CAP) : entries;
+            list.forEach(function (e) { grid.appendChild(tile(e)); });
+            if (capped && entries.length > RESULT_CAP) {
                 var more = document.createElement('div');
                 more.className = 'ng-is-note';
-                more.textContent = 'Showing ' + RESULT_CAP + ' of ' + classes.length +
+                more.textContent = 'Showing ' + RESULT_CAP + ' of ' + entries.length +
                                    ' — search to narrow down.';
                 grid.appendChild(more);
             }
             return grid;
+        }
+
+        /* A recent image is stored as just its number; the name and PNG live in
+           the uploaded set, which may not be read yet. Entries the current
+           caller cannot pick are dropped rather than shown as dead tiles. */
+        function recentEntries() {
+            return getRecent().filter(function (e) {
+                return allowImg || !isImgEntry(e);
+            }).map(function (e) {
+                if (!isImgEntry(e)) return e;
+                return findCustomImage(e.value) ||
+                       { kind: 'img', value: e.value, src: '', name: '#' + e.value, desc: '' };
+            });
+        }
+
+        function imageHits(q) {
+            return imgs.filter(function (it) {
+                return !q || (it.name + ' ' + it.desc).toLowerCase().indexOf(q) !== -1;
+            });
         }
 
         /* ── Keyboard navigation over the rendered tiles ──────────────
@@ -647,8 +819,17 @@
         /* ── Left rail ── */
         function renderRail() {
             railEl.innerHTML = '';
-            var items = [{ id: 'all', name: 'All icons', icon: 'fa-layer-group', count: all.length },
-                         { id: 'recent', name: 'Recent', icon: 'fa-clock-rotate-left', count: getRecent().length }];
+            var items = [{ id: 'all', name: 'All icons', icon: 'fa-layer-group',
+                           count: all.length + imgs.length },
+                         { id: 'recent', name: 'Recent', icon: 'fa-clock-rotate-left',
+                           count: recentEntries().length }];
+            /* Only when there is something in it: an empty source in the rail
+               is a dead end, and the note in the main pane cannot be seen
+               without clicking it. */
+            if (imgs.length) {
+                items.push({ id: 'custom', name: 'Custom images', icon: 'fa-upload',
+                             count: imgs.length });
+            }
             libs.forEach(function (l) {
                 items.push({ id: l.id, name: l.name, icon: 'fa-icons',
                              count: (groups[l.id] ? groups[l.id].icons.length : 0) });
@@ -672,6 +853,11 @@
             if (query) {
                 var q = query.toLowerCase();
                 var hits = all.filter(function (c) { return labelOf(c).indexOf(q) !== -1; });
+                /* Images lead. There are a handful of them against thousands of
+                   glyphs, so appending would push them past RESULT_CAP and the
+                   one source the user cannot reach any other way would be the
+                   one that got truncated away. */
+                if (allowImg) hits = imageHits(q).concat(hits);
                 var h = document.createElement('div');
                 h.className = 'ng-is-section-title';
                 h.textContent = hits.length + ' result' + (hits.length === 1 ? '' : 's') + ' for “' + query + '”';
@@ -688,12 +874,23 @@
             }
 
             if (scope === 'recent') {
-                var recent = getRecent();
+                var recent = recentEntries();
                 if (!recent.length) {
                     mainEl.innerHTML = '<div class="ng-is-note">No recent icons yet — the ones you pick will appear here.</div>';
                     return;
                 }
                 mainEl.appendChild(gridOf(recent, false));
+                return;
+            }
+
+            if (scope === 'custom') {
+                if (!imgs.length) {
+                    mainEl.innerHTML = '<div class="ng-is-note"><i class="fa-solid fa-cloud-arrow-up"></i> ' +
+                        'No custom icons uploaded yet. Add them on Setup ▸ More Options ▸ Custom Icons.' +
+                        '</div>';
+                    return;
+                }
+                mainEl.appendChild(gridOf(imgs, false));
                 return;
             }
 
@@ -752,20 +949,18 @@
                 return;
             }
 
-            /* All: collapsible section per library */
-            libs.forEach(function (l) {
-                var g = groups[l.id];
-                var icons = g ? g.icons : [];
+            /* All: collapsible section per source */
+            function section(name, entries) {
                 var sec = document.createElement('div');
                 sec.className = 'ng-is-section';
                 var head = document.createElement('button');
                 head.type = 'button';
                 head.className = 'ng-is-section-head';
-                head.innerHTML = '<i class="fa-solid fa-chevron-down"></i> ' + l.name +
-                                 ' <em>' + icons.length + '</em>';
+                head.innerHTML = '<i class="fa-solid fa-chevron-down"></i> ' + name +
+                                 ' <em>' + entries.length + '</em>';
                 var body = document.createElement('div');
                 body.className = 'ng-is-section-body';
-                body.appendChild(gridOf(icons, true));
+                body.appendChild(gridOf(entries, true));
                 head.addEventListener('click', function () {
                     var open = sec.classList.toggle('ng-is-section--collapsed');
                     head.querySelector('i').className = open ? 'fa-solid fa-chevron-right'
@@ -774,6 +969,15 @@
                 sec.appendChild(head);
                 sec.appendChild(body);
                 mainEl.appendChild(sec);
+            }
+
+            /* Uploaded images first: it is the shortest list and the only one
+               whose contents are the user's own. */
+            if (imgs.length) section('Custom images', imgs);
+
+            libs.forEach(function (l) {
+                var g = groups[l.id];
+                section(l.name, g ? g.icons : []);
             });
         }
 
@@ -853,6 +1057,13 @@
             renderMain();
         };
         fetchNativeLibraries(true).then(_onNativeChange);
+
+        /* Same deal for the uploaded icons: they are added and deleted on
+           Domoticz's Custom Icons page, so re-read them on every open rather
+           than trusting a set fetched at some earlier point in the session.
+           Only for a caller that can store one — nothing else has any use for
+           the request. */
+        if (allowImg) fetchCustomImages(true).then(_onNativeChange);
 
         /* Must happen before we take focus: an open jQuery UI modal would
            otherwise steal it straight back (#230). */

--- a/src/js/icon-studio.js
+++ b/src/js/icon-studio.js
@@ -423,6 +423,16 @@
         return null;
     }
 
+    /* The uploaded-icon list with the +100 already applied, i.e. keyed by the
+       value DeviceStatus.CustomImage stores. Published because a caller that
+       renders a CustomImage it did not just pick (the settings editor's device
+       rows) needs the same resolution the picker uses — re-deriving the offset
+       at a second site is exactly how a pick lands on the wrong icon. */
+    window.dzCustomIcons = function (cb) {
+        fetchCustomImages().then(function (list) { cb(list || []); },
+                                 function ()     { cb([]); });
+    };
+
     /* Which library a class belongs to (by prefix). */
     function libIdOf(cls, libs) {
         var token = cls.split(/\s+/)[0];              // e.g. "fa-solid" | "mdi" | "bi"

--- a/src/js/icon-studio.js
+++ b/src/js/icon-studio.js
@@ -1,8 +1,8 @@
 /* ══════════════════════════════════════════════════════════════════
    ICON STUDIO — Nightglass icon picker overlay
    ──────────────────────────────────────────────────────────────────
-   A large, reusable icon chooser used by the Device Icon Overrides
-   editor (and anywhere that needs an icon class). It:
+   A large, reusable icon chooser used by the Device Icons editor (and
+   anywhere that needs an icon class). It:
      • enumerates EVERY icon-font glyph the browser has loaded (all of
        Font Awesome 7 + every icon library installed on this Domoticz),
        grouped by library with counts;
@@ -759,10 +759,15 @@
             }
             if (typeof opts.onPick === 'function') opts.onPick(cls);
             if (keepOpen) {
-                /* Animation-only caller (the override editor): report the icon
-                   but leave the dialog up so the animation row is still there. */
+                /* Caller that stays open (the Device Icons editor): report the
+                   icon but leave the dialog up so the animation row is still
+                   there. Re-render that row too — the tiles animate the
+                   selected glyph, so leaving them on the previous one made a
+                   pick look like it had not registered. `chosen` is assigned
+                   first because renderAnimRow() reads it. */
                 chosen = cls;
                 renderMain();
+                if (allowAnim) renderAnimRow();
                 if (mPrev) mPrev.className = cls;
                 return true;
             }
@@ -1112,11 +1117,14 @@
             var wrap = overlay.querySelector('.ng-is-anim');
             if (!wrap) return;
             /* Preview on the icon under discussion — the on/active icon, which
-               is what animates on the card.  `chosen` follows the active slot,
-               and apply() re-renders this row when the icon changes, so the
-               previews always animate the glyph the user just picked. */
-            var glyph = (slots && slots[0].cls) || cleanClass(opts.animationGlyph) ||
-                        chosen || 'fa-solid fa-lightbulb';
+               is what animates on the card.  apply() re-renders this row on
+               every pick, so the order here decides which icon the tiles show:
+               `chosen` is the live selection and has to win, because
+               opts.animationGlyph is only the caller's opening hint and goes
+               stale the moment the user picks something else. With slots, slot
+               0 IS the on-icon and outranks both. */
+            var glyph = (slots && slots[0].cls) || chosen ||
+                        cleanClass(opts.animationGlyph) || 'fa-solid fa-lightbulb';
 
             wrap.innerHTML =
                 '<div class="ng-is-anim-head">Animation ' +

--- a/src/js/icon-studio.js
+++ b/src/js/icon-studio.js
@@ -681,6 +681,12 @@
             : null;
         var activeSlot = 0;
         if (slots && slots.length) chosen = slots[0].cls || chosen;
+        /* Icon and CustomImage are alternatives in the store, and Domoticz
+           resolves the glyph first, so a slotted caller handing over both is
+           really saying "glyph". Only that caller can be read this way: the
+           slot-less picker passes the device type's own fallback glyph
+           alongside a real image pick on purpose. */
+        if (slots && slots.length && slots[0].cls) chosenImg = 0;
 
         /* With a second axis to set — an off icon, an animation, or both — an
            icon click refines the choice rather than finishing it, so the dialog
@@ -751,10 +757,25 @@
         var mMsg     = overlay.querySelector('.ng-is-manual-msg');
         var slotbarEl = overlay.querySelector('.ng-is-slotbar');
 
+        /* The record behind the current image pick, or null when the selection
+           is a glyph. Held as a number rather than as the record so it survives
+           the uploaded set being re-read, and resolved here on every render:
+           on open the set is usually still in flight, and a caller can hand us
+           a CustomImage before there is anything to look it up in. */
+        function chosenImage() {
+            if (!chosenImg) return null;
+            return findCustomImage(chosenImg) ||
+                   { kind: 'img', value: chosenImg, src: '', name: '#' + chosenImg, desc: '' };
+        }
+
         function apply(cls) {
             cls = cleanClass(cls);
             if (!cls) return false;
             pushRecent(cls);
+            /* A glyph and an uploaded image are one choice, not two layers —
+               both stores drop the image when a glyph is written — so picking
+               one has to unset the other here as well. */
+            chosenImg = 0;
             if (slots) {
                 /* Assign to the active slot and stay put: the user is likely to
                    set the other slot next. */
@@ -788,13 +809,62 @@
         function applyImage(item) {
             if (!allowImg || !item || !(item.value > 0)) return false;
             pushRecent(item);
+            /* The image becomes THE selection and the glyph one steps aside —
+               same exclusivity apply() enforces the other way round. The slots
+               keep their classes rather than being cleared: they mirror the
+               caller's own copy of the on/off pair, which is what a later glyph
+               pick writes back, so emptying them here would only put the two
+               out of step. chosenImg is what every render reads to decide which
+               kind is set. */
+            chosenImg = item.value;
+            /* Whichever slot was being edited, the next glyph pick is the
+               on-icon: that is the only slot the bar offers while an image is
+               set, and it is where the pair starts again. */
+            activeSlot = 0;
             opts.onPickImage(item.value, item);
             /* An uploaded image is a whole-icon choice — there is no separate
                off PNG — so it finishes the icon axis.  Keep the dialog open
                only if there is still an animation to set. */
-            if (keepOpen) return true;
+            if (keepOpen) {
+                if (slots) renderSlots();
+                renderMain();          // move the grid's "current" marker
+                if (allowAnim) renderAnimRow();
+                /* The footer swatch previews an icon class, which an image has
+                   none of; back to the placeholder rather than leaving the
+                   previous glyph standing as if it were still the pick. */
+                if (mPrev) mPrev.className = 'fa-solid fa-question';
+                return true;
+            }
             close();
             return true;
+        }
+
+        /* What a slot holds, drawn: an uploaded PNG is an <img>, a glyph an
+           <i>, and a slot with neither gets the empty-square placeholder —
+           which is also what an image whose record has not arrived yet shows,
+           rather than a broken <img>. */
+        function slotIcon(cls, img) {
+            if (img && img.src) {
+                var im = document.createElement('img');
+                im.src = img.src;
+                im.alt = '';
+                return im;
+            }
+            var ic = document.createElement('i');
+            ic.className = cls || 'fa-regular fa-square';
+            return ic;
+        }
+
+        function slotText(el, label, sub) {
+            var lab = document.createElement('span');
+            lab.className = 'ng-is-slot-label';
+            lab.textContent = label;
+            var s = document.createElement('em');
+            s.className = 'ng-is-slot-cls';
+            /* Server-supplied for an image (its Title), so text, not markup. */
+            s.textContent = sub;
+            el.appendChild(lab);
+            el.appendChild(s);
         }
 
         /* On/off target bar (only when the caller passes slots). */
@@ -805,21 +875,29 @@
             lead.className = 'ng-is-slotbar-lead';
             lead.textContent = 'Editing';
             slotbarEl.appendChild(lead);
+
+            /* An uploaded image is the whole icon: it ships one PNG, so there
+               is no off state to express and nowhere to store one if there
+               were. While one is picked the bar therefore states the single
+               icon that is set instead of offering an off slot that could not
+               be saved — picking any glyph hands the on/off pair straight
+               back. */
+            var img = chosenImage();
+            if (img) {
+                var one = document.createElement('span');
+                one.className = 'ng-is-slot ng-is-slot--active ng-is-slot--img';
+                one.appendChild(slotIcon('', img));
+                slotText(one, 'Icon', img.name);
+                slotbarEl.appendChild(one);
+                return;
+            }
+
             slots.forEach(function (s, i) {
                 var b = document.createElement('button');
                 b.type = 'button';
                 b.className = 'ng-is-slot' + (i === activeSlot ? ' ng-is-slot--active' : '');
-                var ic = document.createElement('i');
-                ic.className = s.cls || 'fa-regular fa-square';
-                var lab = document.createElement('span');
-                lab.className = 'ng-is-slot-label';
-                lab.textContent = s.label;
-                var sub = document.createElement('em');
-                sub.className = 'ng-is-slot-cls';
-                sub.textContent = s.cls ? labelOf(s.cls) : 'not set';
-                b.appendChild(ic);
-                b.appendChild(lab);
-                b.appendChild(sub);
+                b.appendChild(slotIcon(s.cls, null));
+                slotText(b, s.label, s.cls ? labelOf(s.cls) : 'not set');
                 b.addEventListener('click', function () {
                     activeSlot = i;
                     chosen = s.cls;
@@ -839,7 +917,11 @@
             var b = document.createElement('button');
             b.type = 'button';
             var isImg = isImgEntry(entry);
-            var active = isImg ? (entry.value === chosenImg) : sameIcon(entry, chosen);
+            /* One selection, so at most one marker: a glyph tile only counts as
+               current while no image is picked, or the fallback glyph a caller
+               opens on would sit lit up next to the image actually in use. */
+            var active = isImg ? (entry.value === chosenImg)
+                               : (!chosenImg && sameIcon(entry, chosen));
             b.className = 'ng-is-tile' + (active ? ' ng-is-tile--active' : '');
 
             if (isImg) {
@@ -1135,6 +1217,11 @@
                0 IS the on-icon and outranks both. */
             var glyph = (slots && slots[0].cls) || chosen ||
                         cleanClass(opts.animationGlyph) || 'fa-solid fa-lightbulb';
+            /* …unless the selection is an uploaded PNG, which outranks every
+               glyph above: those are only ever the fallback the caller opened
+               on, and the tiles have to show what the device will actually
+               animate. */
+            var img = chosenImage();
 
             wrap.innerHTML =
                 '<div class="ng-is-anim-head">Animation ' +
@@ -1154,8 +1241,20 @@
                     (a.id === animPick ? ' ng-is-anim-tile--active' : '');
                 b.title = a.hint ? a.label + ' — ' + a.hint : a.label;
 
-                var ic = document.createElement('i');
-                ic.className = glyph + (a.id ? ' ' + animClassOf(a.id) : '');
+                /* Every animation in the catalogue drives transform and opacity
+                   only (section 25 of animations.css), and the classes carry no
+                   element requirement, so an <img> moves under them exactly as
+                   a glyph does. */
+                var ic;
+                if (img && img.src) {
+                    ic = document.createElement('img');
+                    ic.src = img.src;
+                    ic.alt = '';
+                    if (a.id) ic.className = animClassOf(a.id);
+                } else {
+                    ic = document.createElement('i');
+                    ic.className = glyph + (a.id ? ' ' + animClassOf(a.id) : '');
+                }
                 var lbl = document.createElement('span');
                 lbl.textContent = a.label;
                 b.appendChild(ic);
@@ -1254,6 +1353,15 @@
             pruneRecent(libs);    // self-heal: drop recents from removed libraries
             renderRail();
             renderMain();
+            /* The image pick is held as a number, so its name and PNG only
+               exist once the uploaded set has been read — repaint the previews
+               that draw it when that lands. Only then: rebuilding the animation
+               tiles restarts every keyframe list from frame zero, which is a
+               visible stutter to spend on nothing when a glyph is selected. */
+            if (chosenImg) {
+                if (slots) renderSlots();
+                if (allowAnim) renderAnimRow();
+            }
         };
         fetchNativeLibraries(true).then(_onNativeChange);
 

--- a/src/js/icon-studio.js
+++ b/src/js/icon-studio.js
@@ -82,7 +82,14 @@
             if (!r.selectorText || !r.style) continue;
             var faVar = r.style.getPropertyValue('--fa');
             var content = r.style.content;
+            /* Not every set is a font. Iconoir and friends ship no @font-face and
+               draw each icon as an SVG mask, so they declare mask-image and never
+               a codepoint; requiring content would enumerate nothing for them.
+               Utility classes declare neither, which is what this really excludes. */
+            var mask = r.style.getPropertyValue('mask-image') ||
+                       r.style.getPropertyValue('-webkit-mask-image');
             var isGlyph = (faVar && faVar !== 'none') ||
+                          (mask && mask !== 'none') ||
                           (/::?before/.test(r.selectorText) && content &&
                            content !== 'none' && content !== 'normal' && content !== '""');
             if (!isGlyph) continue;

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -730,10 +730,66 @@
     /* ── Per-device icon overrides ─────────────────────────────────
        Keyed by device IDX string.
        Schema: { iconOn, iconOff?, iconOpen?, iconClose?, iconStop?,
-                 on, off, keepColor?, name }
+                 on, off, keepColor?, anim?, name }
        Legacy field 'icon' is treated as iconOn for backward compat.
        Populated by the settings module via window._dzSetDeviceIconOverrides. */
     var DEVICE_ICON_OVERRIDES = {};
+
+    /* ── Icon animations ───────────────────────────────────────────
+       The animations themselves are section 25 of animations.css; all this
+       side owns is which one an icon carries.  Named for the job rather
+       than for the motion, because the choice is made per device.
+
+       Why this lives in the theme's override blob and not on the device:
+       Domoticz's own Icon column is server-validated to {"t","on","off"}
+       and capped at 512 chars (NormaliseDeviceIcon()), so an extra key
+       would come straight back as "Invalid icon".  Icon identity is the
+       device's; colour and motion are presentation and stay ours. */
+    var ICON_ANIMATIONS = [
+        { id: 'spin',    label: 'Spin',    hint: 'Fans, motors, pumps' },
+        { id: 'breathe', label: 'Breathe', hint: 'Motion, presence, heart rate' },
+        { id: 'flicker', label: 'Flicker', hint: 'Flame, candle, fireplace' },
+        { id: 'ring',    label: 'Ring',    hint: 'Bells, sirens, alarms' },
+        { id: 'bounce',  label: 'Bounce',  hint: 'Doorbells, notifications' },
+        { id: 'glow',    label: 'Glow',    hint: 'Lights, lamps, strips' },
+        { id: 'blink',   label: 'Blink',   hint: 'Recording, faults' },
+        { id: 'swing',   label: 'Swing',   hint: 'Doors, gates, blinds' },
+        { id: 'drift',   label: 'Drift',   hint: 'Wind, water, air quality' }
+    ];
+    var ANIM_PREFIX = 'dz-anim-';
+    var ANIM_KNOWN = {};
+    ICON_ANIMATIONS.forEach(function (a) { ANIM_KNOWN[a.id] = true; });
+
+    /* The catalogue is read by the Icon Studio (tiles + previews), the
+       settings panel and the device icon field, so it is published once
+       here rather than transcribed into each of them. */
+    window.dzIconAnimations = ICON_ANIMATIONS;
+
+    /* Whitelisted, never interpolated: the value comes out of
+       user-editable settings storage and ends up in a class attribute. */
+    window.dzIconAnimClass = function (id) {
+        return ANIM_KNOWN[id] ? ANIM_PREFIX + id : '';
+    };
+
+    function animClassFor(devIdx) {
+        var ov = devIdx ? DEVICE_ICON_OVERRIDES[devIdx] : null;
+        return (ov && ANIM_KNOWN[ov.anim]) ? ANIM_PREFIX + ov.anim : '';
+    }
+
+    /* Apply the device's chosen animation class to an icon element.
+       Writes only on a change: decorateNativeGlyph() runs on every burst
+       pass, and re-adding the class would restart the keyframes from frame
+       zero each time — visible as a stutter every few hundred ms. */
+    function applyIconAnim(el, devIdx) {
+        var want = animClassFor(devIdx);
+        var cur  = '';
+        for (var i = 0; i < el.classList.length; i++) {
+            if (el.classList[i].indexOf(ANIM_PREFIX) === 0) { cur = el.classList[i]; break; }
+        }
+        if (cur === want) return;
+        if (cur)  el.classList.remove(cur);
+        if (want) el.classList.add(want);
+    }
 
     /* Bumped whenever the map above changes.  Read by the native-glyph
        colour cache further down, which keys off the device rather than off
@@ -814,9 +870,11 @@
        Schedules a replacement burst so already-rendered icons update. */
     window._dzSetDeviceIconOverrides = function (overrides) {
         DEVICE_ICON_OVERRIDES = overrides || {};
-        /* Invalidate the native-glyph colour cache: an override added,
+        /* Invalidate the native-glyph resolution cache: an override added,
            changed or removed at runtime must re-resolve on the next pass
-           even though the glyph's own identity did not change. */
+           even though the glyph's own identity did not change.  Covers a
+           changed animation as well as a changed colour — the entry holds
+           the device idx both are read from. */
         _nativeColorGen++;
         /* Re-apply to already-rendered device icons right away so overrides
            added, changed, or removed at runtime take effect immediately —
@@ -959,6 +1017,12 @@
             if (resolved.color) icon.style.color = resolved.color;
             var rot = WIND_ROTATION[resolved.dir];
             if (rot !== null) icon.style.transform = 'rotate(' + rot + 'deg)';
+            /* Wind icons never went through the override block above, so they
+               carry no IDX tag yet — and Drift is the animation they are most
+               likely to be given.  Pure DOM, no scope walk. */
+            var windIdx = deviceIdxFromDom(img);
+            if (windIdx) img.setAttribute('data-dz-dev-idx', windIdx);
+            applyIconAnim(icon, windIdx);
         } else if (resolved.type === 'device') {
             icon.className = resolved.cls;
             if (resolved.color) icon.style.color = resolved.color;
@@ -966,6 +1030,11 @@
             if (resolved.colorOn)  icon.setAttribute('data-dz-color-on',  resolved.colorOn);
             if (resolved.colorOff) icon.setAttribute('data-dz-color-off', resolved.colorOff);
             icon.setAttribute('data-dz-state', resolved.color === resolved.colorOn ? 'on' : 'off');
+            /* Chosen animation.  Read from the attribute rather than the local:
+               an icon whose src carries no override still gets tagged above,
+               and a device with an animation but no icon override never enters
+               that branch at all. */
+            applyIconAnim(icon, img.getAttribute('data-dz-dev-idx') || '');
             /* Optimistic toggle: immediately swap color on click so the user
                sees instant visual feedback before Angular/API round-trip.
                Only fires for devices whose click actually sends a binary
@@ -1065,6 +1134,9 @@
                 icon.setAttribute('data-dz-color-on',  ovSpec.colorOn);
                 icon.setAttribute('data-dz-color-off', ovSpec.colorOff);
                 icon.setAttribute('data-dz-state', ovSpec.color === ovSpec.colorOn ? 'on' : 'off');
+                /* className was just rewritten, which dropped the animation
+                   class with it — put it back. */
+                applyIconAnim(icon, devIdx);
                 img.setAttribute('data-dz-src', curSrc);
                 return;
             }
@@ -1090,6 +1162,7 @@
             var rot = WIND_ROTATION[resolved.dir];
             icon.style.transform = (rot !== undefined && rot !== null)
                 ? 'rotate(' + rot + 'deg)' : '';
+            applyIconAnim(icon, img.getAttribute('data-dz-dev-idx') || '');
         } else if (resolved.type === 'device') {
             icon.className = resolved.cls;
             icon.style.color = resolved.color || '';
@@ -1098,6 +1171,7 @@
             if (resolved.colorOn)  icon.setAttribute('data-dz-color-on',  resolved.colorOn);
             if (resolved.colorOff) icon.setAttribute('data-dz-color-off', resolved.colorOff);
             icon.setAttribute('data-dz-state', resolved.color === resolved.colorOn ? 'on' : 'off');
+            applyIconAnim(icon, devIdx || '');
         } else {
             icon.className = resolved.cls + ' ' + getSizeClass(img, curSrc);
             icon.style.color = resolved.color || '';
@@ -1191,6 +1265,7 @@
                 prevIcon.style.color = newResolved.color || '';
                 var rot = WIND_ROTATION[newResolved.dir];
                 prevIcon.style.transform = rot !== null ? 'rotate(' + rot + 'deg)' : '';
+                applyIconAnim(prevIcon, rImg.getAttribute('data-dz-dev-idx') || '');
             } else if (newResolved.type === 'device') {
                 /* Prefer per-device override if one is configured */
                 var p2DevIdx = rImg.getAttribute('data-dz-dev-idx');
@@ -1201,6 +1276,7 @@
                 if (p2Final.colorOn)  prevIcon.setAttribute('data-dz-color-on',  p2Final.colorOn);
                 if (p2Final.colorOff) prevIcon.setAttribute('data-dz-color-off', p2Final.colorOff);
                 prevIcon.setAttribute('data-dz-state', p2Final.color === p2Final.colorOn ? 'on' : 'off');
+                applyIconAnim(prevIcon, p2DevIdx || '');
             }
 
             rImg.setAttribute('data-dz-src', curSrc);
@@ -1627,7 +1703,7 @@
        There is no <img> left to replace, so replaceImage() never runs and
        the two hooks it used to apply — the dz-fa-device class and the
        data-dz-state attribute — are never applied.  Everything keyed on
-       them is silently orphaned: the nine icon animations in
+       them is silently orphaned: the icon-animation gate in
        animations.css, the sizing/hover/fa-stop rules in layout.css, the
        wind rotation, and the state-change flash observer in
        card-features.js.
@@ -1679,15 +1755,12 @@
        reports neither, because it has no on/off state.
 
        When there is no state class we leave data-dz-state ABSENT rather
-       than guessing.  data-dz-state drives the animations, and every rule
-       that consumes it — all nine in animations.css plus the
-       animation-suppression rule search.js injects — requires the exact
-       value "on"; nothing keys on "off" or on the attribute merely being
-       present.  So an absent attribute is inert, whereas a fabricated
-       "on" would spin / flicker / shake every sensor whose glyph happens
-       to be a fan, flame or bell, forever, and a fabricated "off" would
-       trip the state-change flash the first time the device reports a real
-       state.  Absent it is. */
+       than guessing.  Absent is the useful value: the animation gate stops
+       an icon that reports "off", and a sensor that reports nothing keeps
+       whatever animation the user picked for it — which is the only reason
+       it would have one.  A fabricated "off" would instead cancel that
+       animation outright and trip the state-change flash in
+       card-features.js the first time the device reports a real state. */
     function nativeGlyphState(glyph) {
         if (glyph.classList.contains('dz-icon--on'))  return 'on';
         if (glyph.classList.contains('dz-icon--off')) return 'off';
@@ -1792,14 +1865,17 @@
     var nativeColorCache = new WeakMap();
 
     /* Identity signature: the device idx plus the icon classes, ignoring
-       the volatile ones (native's state classes and our own hooks). */
+       the volatile ones (native's state classes and our own hooks — the
+       animation class among them, or adding it would invalidate the entry
+       we just wrote it from). */
     function nativeColorSig(glyph, devIdx) {
         var sig = _nativeColorGen + '|' + devIdx + '|';
         var cl  = glyph.classList;
         for (var i = 0; i < cl.length; i++) {
             var c = cl[i];
             if (c === 'dz-icon-glyph' || c === 'dz-fa-device' ||
-                c === 'dz-wind' || c.indexOf('dz-icon--') === 0) continue;
+                c === 'dz-wind' || c.indexOf('dz-icon--') === 0 ||
+                c.indexOf(ANIM_PREFIX) === 0) continue;
             sig += c + ' ';
         }
         return sig;
@@ -1814,7 +1890,8 @@
 
         if (!entry || entry.sig !== sig) {
             var spec = resolveNativeSpec(glyph, devIdx);
-            entry = { sig: sig, on: spec.on, off: spec.off, wind: spec.wind, applied: null };
+            entry = { sig: sig, idx: devIdx, on: spec.on, off: spec.off,
+                      wind: spec.wind, applied: null };
             nativeColorCache.set(glyph, entry);
         }
         return entry;
@@ -1893,6 +1970,10 @@
         var entry = nativeEntryFor(glyph);
         applyNativeColor(glyph, entry, state);
         if (entry.wind) applyNativeWind(glyph);
+        /* Native owns the glyph, Nightglass owns its motion.  The gate in
+           animations.css keeps an off device still, so this is applied
+           regardless of state. */
+        applyIconAnim(glyph, entry.idx);
 
         var cur = glyph.getAttribute('data-dz-state');
         /* Write only on a genuine change.  Every data-dz-state mutation
@@ -1907,6 +1988,7 @@
 
     function undecorateNativeGlyph(glyph) {
         glyph.classList.remove('dz-fa-device', 'dz-wind');
+        applyIconAnim(glyph, '');
         glyph.removeAttribute('data-dz-state');
         glyph.style.color = '';
         glyph.style.transform = '';

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -735,6 +735,11 @@
        Populated by the settings module via window._dzSetDeviceIconOverrides. */
     var DEVICE_ICON_OVERRIDES = {};
 
+    /* Bumped whenever the map above changes.  Read by the native-glyph
+       colour cache further down, which keys off the device rather than off
+       an image src and so has nothing else to invalidate on. */
+    var _nativeColorGen = 0;
+
     /* Returns an overridden resolved spec for a given device IDX + src,
        or null when no override is configured for that device.             */
     function applyDeviceOverride(devIdx, src, fallbackResolved) {
@@ -809,6 +814,10 @@
        Schedules a replacement burst so already-rendered icons update. */
     window._dzSetDeviceIconOverrides = function (overrides) {
         DEVICE_ICON_OVERRIDES = overrides || {};
+        /* Invalidate the native-glyph colour cache: an override added,
+           changed or removed at runtime must re-resolve on the next pass
+           even though the glyph's own identity did not change. */
+        _nativeColorGen++;
         /* Re-apply to already-rendered device icons right away so overrides
            added, changed, or removed at runtime take effect immediately —
            without waiting for a device state change or a page refresh.  A plain
@@ -1685,6 +1694,146 @@
         return null;
     }
 
+    /* ── Colour layer ──────────────────────────────────────────────
+       Native paints every device glyph the same blue (#43A4D3) with a
+       grey off-state; it has no per-device-type colour.  DEVICE_MAP stays
+       the colour source, but there is no PNG filename left to key it
+       with, so key it off the device record instead — mirroring the
+       precedence dzIconService.resolve() uses to pick the glyph itself:
+       a built-in CustomImage wins over TypeImg.  Keying off the same
+       fields as the glyph means the colour always agrees with the shape
+       that is actually on screen.
+
+       device.Icon — the per-device pick in Domoticz's own icon picker —
+       carries no type information, so those devices fall through to
+       CustomImage / TypeImg for their colour: the user chose the shape,
+       Nightglass still supplies the type colour.
+
+       DEVICE_MAP's icon field is unused here; native owns icon identity. */
+
+    /* TypeImg values that differ from the DEVICE_MAP key.  Mirrors
+       dzIconService's TYPE_ALIASES, so a device whose glyph Domoticz
+       resolved through an alias gets the colour of that same entry. */
+    var TYPEIMG_ALIASES = {
+        'hardware':      'gauge',
+        'hum':           'humidity',
+        'temphum':       'temp',
+        'temphumbaroew': 'temp',
+        'zwavemelding':  'alarm',
+        'elec':          'electricityusage',
+        'lightbulb':     'light',
+        'temperature':   'temp',
+        'temp + rain':   'temp',
+        'setpoint':      'temp',
+        'bbq':           'temp',
+        'evohome':       'heating',
+        'weather':       'sun',
+        'general':       'gauge',
+        'utility':       'gauge',
+        'siren':         'alarm',
+        'pushoff':       'push',
+        'override_mini': 'adjust'
+    };
+
+    function deviceMapSpecFor(device) {
+        if (!device) return null;
+        /* CustomImage 1..99 is Domoticz's built-in icon library and
+           device.Image carries its name ('Fan', 'Alarm', 'WallSocket'),
+           which is exactly the DEVICE_MAP key.  100+ are user-uploaded
+           icon sets and carry no device-type meaning. */
+        var ci = parseInt(device.CustomImage, 10);
+        if (ci > 0 && ci < 100 && device.Image) {
+            var imgKey = String(device.Image).toLowerCase();
+            if (DEVICE_MAP[imgKey]) return DEVICE_MAP[imgKey];
+        }
+        var ti = String(device.TypeImg || '').toLowerCase();
+        if (!ti) return null;
+        return DEVICE_MAP[ti] || DEVICE_MAP[TYPEIMG_ALIASES[ti]] || null;
+    }
+
+    /* Resolve the on/off colour pair for a native glyph.  Either side may
+       come back empty, which means "do not colour" — DEVICE_MAP stores
+       null for entries that must keep the stock colour ('onoff',
+       'remote', 'security', and the off-state of read-only sensors), and
+       under native the stock colour is Domoticz's own, which is already
+       right for those. */
+    function resolveNativeSpec(glyph, devIdx) {
+        var device = getDeviceFromIcon(glyph);
+        var spec   = deviceMapSpecFor(device);
+        var on     = spec ? spec.on  : null;
+        var off    = spec ? spec.off : null;
+
+        /* A per-device colour the user set in Nightglass must win over
+           DEVICE_MAP.  keepColor means "override the shape only, keep the
+           resolver's dynamic colour"; native owns the shape, so it
+           degrades to "leave the colour alone". */
+        var idx = devIdx || (device && String(device.idx || device.IDX || '')) || '';
+        var ov  = idx ? DEVICE_ICON_OVERRIDES[idx] : null;
+        if (ov && !ov.keepColor) {
+            if (ov.on)  on  = ov.on;
+            if (ov.off) off = ov.off;
+        }
+
+        return { on: on, off: off };
+    }
+
+    /* Resolving the device costs an Angular scope walk, and a burst runs
+       several passes, so cache the result per element and recompute only
+       when the glyph's identity changes (different device in the slot, or
+       Domoticz re-resolved the icon).  WeakMap so entries go away with
+       the element. */
+    var nativeColorCache = new WeakMap();
+
+    /* Identity signature: the device idx plus the icon classes, ignoring
+       the volatile ones (native's state classes and our own hooks). */
+    function nativeColorSig(glyph, devIdx) {
+        var sig = _nativeColorGen + '|' + devIdx + '|';
+        var cl  = glyph.classList;
+        for (var i = 0; i < cl.length; i++) {
+            var c = cl[i];
+            if (c === 'dz-icon-glyph' || c === 'dz-fa-device' ||
+                c === 'dz-wind' || c.indexOf('dz-icon--') === 0) continue;
+            sig += c + ' ';
+        }
+        return sig;
+    }
+
+    function nativeEntryFor(glyph) {
+        /* deviceIdxFromDom is pure DOM (card id / td#name[data-idx]), so
+           it is cheap enough to run on every pass as the cache key. */
+        var devIdx = deviceIdxFromDom(glyph);
+        var entry  = nativeColorCache.get(glyph);
+        var sig    = nativeColorSig(glyph, devIdx);
+
+        if (!entry || entry.sig !== sig) {
+            var spec = resolveNativeSpec(glyph, devIdx);
+            entry = { sig: sig, on: spec.on, off: spec.off, applied: null };
+            nativeColorCache.set(glyph, entry);
+        }
+        return entry;
+    }
+
+    function applyNativeColor(glyph, entry, state) {
+        /* A state-less glyph (read-only sensor) takes the on colour: that
+           is what the PNG era did for the same devices, whose filenames
+           carried no _On/_Off suffix either. */
+        var want = (state === 'off') ? entry.off : entry.on;
+
+        /* Write only when our own target changed.  card-features.js also
+           writes inline colour on these elements (temperature accent, bar
+           ranges) and runs later in the same burst pass — re-asserting our
+           colour every pass would fight it for no reason. */
+        if (want) {
+            if (entry.applied !== want) {
+                glyph.style.color = want;
+                entry.applied = want;
+            }
+        } else if (entry.applied) {
+            glyph.style.color = '';
+            entry.applied = null;
+        }
+    }
+
     function decorateNativeGlyph(glyph) {
         /* Idempotent: Nightglass's own <i>s never carry dz-icon-glyph, so
            this can never re-process an icon we created ourselves, and
@@ -1694,7 +1843,10 @@
         }
 
         var state = nativeGlyphState(glyph);
-        var cur   = glyph.getAttribute('data-dz-state');
+        var entry = nativeEntryFor(glyph);
+        applyNativeColor(glyph, entry, state);
+
+        var cur = glyph.getAttribute('data-dz-state');
         /* Write only on a genuine change.  Every data-dz-state mutation
            wakes the flash observer in card-features.js, so a blind
            setAttribute on each burst pass would strobe every card. */
@@ -1710,6 +1862,9 @@
         glyph.removeAttribute('data-dz-state');
         glyph.style.color = '';
         glyph.style.transform = '';
+        /* Drop the cached colour too, or a later re-enable would see its
+           own value as already applied and never re-paint. */
+        nativeColorCache.delete(glyph);
     }
 
     /* dzDeviceIcon renders an <img> fallback while dzIconService is still

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -1607,6 +1607,156 @@
         return null;
     };
 
+    /* ── Native Font Awesome rendering adapter ─────────────────────
+       Newer Domoticz resolves device icons itself and renders them as
+       glyphs through its own <dz-device-icon> component:
+
+         <dz-device-icon class="dz-icon-48">
+             <i class="dz-icon-glyph fa-solid fa-fan dz-icon--on"></i>
+         </dz-device-icon>
+
+       There is no <img> left to replace, so replaceImage() never runs and
+       the two hooks it used to apply — the dz-fa-device class and the
+       data-dz-state attribute — are never applied.  Everything keyed on
+       them is silently orphaned: the nine icon animations in
+       animations.css, the sizing/hover/fa-stop rules in layout.css, the
+       wind rotation, and the state-change flash observer in
+       card-features.js.
+
+       Rather than duplicate Domoticz's icon resolution we decorate its
+       own glyph with those two hooks, which makes every existing selector
+       match again without touching a single line of CSS.
+
+       Stable Domoticz emits no <dz-device-icon> at all, so this block
+       short-circuits on its first querySelector and behaviour there is
+       unchanged.                                                        */
+
+    /* Only widget icons put dz-icon-48 / dz-icon-40 on the host element.
+       Chrome — row action buttons, table type indicators, favourite stars —
+       uses .dz-chrome-icon or .dz-icon-glyph.dz-icon-16, and the scene
+       on/off buttons carry .dz-icon-glyph on the <td> itself.  Matching
+       only an <i> inside a 48/40 host keeps table buttons and stars out of
+       the animation and sizing rules. */
+    var NATIVE_GLYPH_SEL = '.dz-icon-48 > i.dz-icon-glyph, .dz-icon-40 > i.dz-icon-glyph';
+
+    /* True once native glyph rendering has been observed.  Re-evaluated on
+       every burst pass rather than latched at load: the SPA only mounts
+       <dz-device-icon> on pages that show device widgets, and a cold start
+       may land on Setup or the Dynamic Dashboard first. */
+    var _nativeSeen = false;
+
+    /* The "Device Icons" setting means "let Nightglass restyle device
+       icons".  With it off, search.js injects
+         i.dz-fa-device, i.dz-wind { display: none !important }
+       and un-hides the original PNGs.  Under native rendering there is no
+       PNG to fall back to, so an undecorated glyph *is* the off state —
+       hence we must not add dz-fa-device at all while the setting is off,
+       or the card would go blank.  A live toggle takes effect on the next
+       burst (route change, device update, or tab refocus). */
+    function nativeDecorEnabled() {
+        try {
+            var s = window.dzNightglassSettings;
+            if (s && typeof s.get === 'function') {
+                var v = s.get('deviceIcons');
+                if (v !== undefined && v !== null) return !!v;
+            }
+        } catch (e) { /* settings module not loaded yet */ }
+        return true; /* shipped default */
+    }
+
+    /* Read the state that dzDeviceIcon published.  It only emits
+       dz-icon--on / dz-icon--off when its isActive binding resolves to a
+       boolean; a read-only sensor (temperature, wind, UV, rain, counter…)
+       reports neither, because it has no on/off state.
+
+       When there is no state class we leave data-dz-state ABSENT rather
+       than guessing.  data-dz-state drives the animations, and every rule
+       that consumes it — all nine in animations.css plus the
+       animation-suppression rule search.js injects — requires the exact
+       value "on"; nothing keys on "off" or on the attribute merely being
+       present.  So an absent attribute is inert, whereas a fabricated
+       "on" would spin / flicker / shake every sensor whose glyph happens
+       to be a fan, flame or bell, forever, and a fabricated "off" would
+       trip the state-change flash the first time the device reports a real
+       state.  Absent it is. */
+    function nativeGlyphState(glyph) {
+        if (glyph.classList.contains('dz-icon--on'))  return 'on';
+        if (glyph.classList.contains('dz-icon--off')) return 'off';
+        return null;
+    }
+
+    function decorateNativeGlyph(glyph) {
+        /* Idempotent: Nightglass's own <i>s never carry dz-icon-glyph, so
+           this can never re-process an icon we created ourselves, and
+           re-running over an already-decorated glyph is a no-op. */
+        if (!glyph.classList.contains('dz-fa-device')) {
+            glyph.classList.add('dz-fa-device');
+        }
+
+        var state = nativeGlyphState(glyph);
+        var cur   = glyph.getAttribute('data-dz-state');
+        /* Write only on a genuine change.  Every data-dz-state mutation
+           wakes the flash observer in card-features.js, so a blind
+           setAttribute on each burst pass would strobe every card. */
+        if (state === null) {
+            if (cur !== null) glyph.removeAttribute('data-dz-state');
+        } else if (cur !== state) {
+            glyph.setAttribute('data-dz-state', state);
+        }
+    }
+
+    function undecorateNativeGlyph(glyph) {
+        glyph.classList.remove('dz-fa-device', 'dz-wind');
+        glyph.removeAttribute('data-dz-state');
+        glyph.style.color = '';
+        glyph.style.transform = '';
+    }
+
+    /* dzDeviceIcon renders an <img> fallback while dzIconService is still
+       fetching the built-in icon table, then swaps it for the glyph.  Our
+       MutationObserver replaces that transient <img> with an <i>, and
+       cleanupOrphan() deliberately leaves stray <i>s in the DOM (Pass 2
+       normally re-adopts them once the <img> reappears).  Here the <img> is
+       gone for good, so the shim survives as a permanent duplicate beside
+       the native glyph — two icons on one card.  Drop it.
+
+       Hosts that still contain an <img> are the useGlyph="false" path
+       (alert level, temperature range, wind direction PNGs), where the
+       <img> is the real icon and our replacement is the point. */
+    function dropStaleNativeShims() {
+        var shims = document.querySelectorAll(
+            'dz-device-icon > i.dz-fa-device:not(.dz-icon-glyph)');
+        for (var i = 0; i < shims.length; i++) {
+            var host = shims[i].parentNode;
+            if (host && !host.querySelector('img')) host.removeChild(shims[i]);
+        }
+    }
+
+    function processNativeGlyphs() {
+        var glyphs = document.querySelectorAll(NATIVE_GLYPH_SEL);
+        if (!glyphs.length) {
+            /* Cheapest possible exit on a Domoticz without native glyph
+               rendering, and on native pages that show no device widgets. */
+            return;
+        }
+        _nativeSeen = true;
+        dropStaleNativeShims();
+
+        var enabled = nativeDecorEnabled();
+        for (var i = 0; i < glyphs.length; i++) {
+            if (enabled) decorateNativeGlyph(glyphs[i]);
+            else         undecorateNativeGlyph(glyphs[i]);
+        }
+    }
+
+    /* Registered as an extra processor so it runs inside the existing
+       icon-replacement burst — same batch, no second MutationObserver.
+       Bursts already fire on route change, $viewContentLoaded,
+       device_update / scene_update, DataTables draws and tab refocus,
+       which covers every path that can mount or restate a glyph. */
+    window._dzExtraProcessors = window._dzExtraProcessors || [];
+    window._dzExtraProcessors.push(processNativeGlyphs);
+
     /* ── Floorplan popup: immediate icon replacement + theme patch ───
        Device.popupRedraw recreates the popup SVG content each time it
        is shown, including new <image> elements for the device icon.

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -801,7 +801,15 @@
     function applyDeviceOverride(devIdx, src, fallbackResolved) {
         if (!devIdx || !DEVICE_ICON_OVERRIDES[devIdx]) return null;
         var ov = DEVICE_ICON_OVERRIDES[devIdx];
-        if (!ov.iconOn && !ov.iconOpen && !ov.icon) return null;
+        /* An entry with colours but no shape is the normal case on a Domoticz
+           that owns the icon itself: the theme stores only colour and motion
+           there. It still has to tint the icon the resolver picked, so it can
+           no longer be dismissed as an empty entry. keepColor means "keep the
+           resolver's dynamic colour", which with no shape to change is
+           genuinely nothing to do. */
+        var hasShape = !!(ov.iconOn || ov.iconOpen || ov.icon || ov.iconStop);
+        var hasColor = !!(ov.on || ov.off) && !ov.keepColor;
+        if (!hasShape && !hasColor) return null;
 
         var parsedSrc = parseDeviceSrc(src);
         var base      = parsedSrc ? parsedSrc.base : null;
@@ -838,7 +846,19 @@
                 ? (ov.iconOn  || ov.icon)
                 : (ov.iconOff || ov.iconOn || ov.icon);
         }
-        if (!iconCls) return null;
+        if (!iconCls) {
+            /* Colour only: keep the shape the resolver picked (and its type —
+               blindsstop is an 'icon', not a device state) and just re-tint. */
+            if (!hasColor || !fallbackResolved) return null;
+            return {
+                type:     fallbackResolved.type || 'device',
+                cls:      fallbackResolved.cls,
+                color:    isOn ? (ov.on || fallbackResolved.colorOn)
+                               : (ov.off || fallbackResolved.colorOff),
+                colorOn:  ov.on  || fallbackResolved.colorOn,
+                colorOff: ov.off || fallbackResolved.colorOff
+            };
+        }
 
         var fbOn  = (fallbackResolved && fallbackResolved.colorOn)  || '#4e9af1';
         var fbOff = (fallbackResolved && fallbackResolved.colorOff) || '#555770';

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -1111,7 +1111,21 @@
         img.classList.add('dz-icon-replaced');
         iconMap.set(img, icon);
         img.parentNode.insertBefore(icon, img);
+        hideNativeNavGlyph(img);
         return true;
+    }
+
+    /* Domoticz's own "Icon style" setting puts a glyph of its own after each navbar
+       image and shows it instead of the image when the style is set to glyphs. The
+       theme already replaced that image, so both would render and the navbar would
+       show every icon twice. The theme owns the navbar look here, so its glyph is
+       hidden rather than removed — Angular re-renders these menus, and a removed
+       node would just come back. */
+    function hideNativeNavGlyph(img) {
+        var next = img.nextElementSibling;
+        if (next && next.tagName === 'I' && next.classList.contains('dz-nav-glyph')) {
+            next.classList.add('dz-nav-glyph-hidden');
+        }
     }
 
     /* -- Process unprocessed images (used by Pass 1 & recovery) -- */

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -1774,7 +1774,14 @@
             if (ov.off) off = ov.off;
         }
 
-        return { on: on, off: off };
+        return {
+            on:   on,
+            off:  off,
+            /* Same test dzUtilityWidget.isValueDrivenIcon() uses to decide
+               a reading is encoded in the icon rather than a device state. */
+            wind: !!(device && device.Direction !== undefined &&
+                     device.Direction !== null && device.Direction !== '')
+        };
     }
 
     /* Resolving the device costs an Angular scope walk, and a burst runs
@@ -1807,7 +1814,7 @@
 
         if (!entry || entry.sig !== sig) {
             var spec = resolveNativeSpec(glyph, devIdx);
-            entry = { sig: sig, on: spec.on, off: spec.off, applied: null };
+            entry = { sig: sig, on: spec.on, off: spec.off, wind: spec.wind, applied: null };
             nativeColorCache.set(glyph, entry);
         }
         return entry;
@@ -1834,6 +1841,46 @@
         }
     }
 
+    /* ── Wind direction ────────────────────────────────────────────
+       The rotation used to come from the compass letters in the PNG
+       filename (images/WindNNE.png → WIND_ROTATION).  Native resolves the
+       icon from the device, so there is no filename; take the direction
+       from the device record instead.  weather_widget.html binds
+       item.Direction — the true direction in degrees — alongside
+       item.DirectionStr, the (possibly localised) compass abbreviation.
+       Degrees are exact and need no compass table, so prefer them and
+       keep WIND_ROTATION/WIND_ALIASES as the fallback for feeds that only
+       publish the abbreviation.
+
+       Native draws fa-wind here, not the fa-arrow-up the PNG era
+       substituted, and Nightglass must not override Domoticz's icon
+       choice — so the rotation orients a windsock instead of pointing an
+       arrow.  Utility-page wind widgets are unaffected: they render with
+       use-glyph="false", i.e. still as a WindNNE.png <img>, which the
+       existing replacement path handles unchanged. */
+    function nativeWindRotation(device) {
+        if (!device) return null;
+        var deg = parseFloat(device.Direction);
+        if (!isNaN(deg)) return ((deg % 360) + 360) % 360;
+        var str = String(device.DirectionStr || '').toUpperCase();
+        if (!str) return null;
+        var rot = WIND_ROTATION[WIND_ALIASES[str] || str];
+        return (rot === undefined) ? null : rot;
+    }
+
+    function applyNativeWind(glyph) {
+        /* The reading changes without the glyph's identity changing, so
+           this cannot be cached with the colour — re-read the device.
+           Only wind devices get here, so it stays a handful of walks. */
+        var rot = nativeWindRotation(getDeviceFromIcon(glyph));
+        /* Direction unreachable: degrade cleanly — no rotation, no log. */
+        if (rot === null) return;
+
+        if (!glyph.classList.contains('dz-wind')) glyph.classList.add('dz-wind');
+        var tf = 'rotate(' + rot + 'deg)';
+        if (glyph.style.transform !== tf) glyph.style.transform = tf;
+    }
+
     function decorateNativeGlyph(glyph) {
         /* Idempotent: Nightglass's own <i>s never carry dz-icon-glyph, so
            this can never re-process an icon we created ourselves, and
@@ -1845,6 +1892,7 @@
         var state = nativeGlyphState(glyph);
         var entry = nativeEntryFor(glyph);
         applyNativeColor(glyph, entry, state);
+        if (entry.wind) applyNativeWind(glyph);
 
         var cur = glyph.getAttribute('data-dz-state');
         /* Write only on a genuine change.  Every data-dz-state mutation

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -2152,3 +2152,42 @@
         setTimeout(patchFloorplanPopup, 300);
     }
 })();
+
+/* ── Domoticz "Icon style" setting ────────────────────────────────
+   Domoticz can render its own interface with classic images or with Font
+   Awesome glyphs (Settings > Icon style, classic by default). Nightglass is
+   built on the glyphs throughout — per-device colours, the animation
+   catalogue and the navbar replacement all key off them — so the theme pins
+   the running config to glyphs and hides the control rather than offering a
+   choice half of the theme cannot render.
+
+   Only the in-memory config is forced; the stored preference is left alone,
+   so uninstalling the theme gives the user back whatever they had. */
+(function () {
+    'use strict';
+
+    function forceGlyphStyle() {
+        try {
+            var body = window.angular && angular.element(document.body);
+            var injector = body && body.injector && body.injector();
+            if (injector) {
+                var cfg = injector.get('$rootScope').config;
+                if (cfg && cfg.IconStyle != 1) cfg.IconStyle = 1;
+            }
+        } catch (e) { /* Angular not up yet; the next burst retries */ }
+
+        if (window.$ && $.myglobals) $.myglobals.iconGlyphs = true;
+        document.documentElement.classList.add('dz-icons-glyph');
+
+        var sel = document.getElementById('comboiconstyle');
+        if (sel) {
+            /* Hide the whole row, not just the select, so its label goes too. */
+            var row = sel.closest && sel.closest('tr');
+            if (row) row.style.display = 'none';
+        }
+    }
+
+    forceGlyphStyle();
+    window._dzExtraProcessors = window._dzExtraProcessors || [];
+    window._dzExtraProcessors.push(forceGlyphStyle);
+})();

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -880,7 +880,7 @@
             if (err === 'too_large') {
                 errorToast('var(--dz-danger, #e05555)', 'Settings too large',
                     'The settings blob exceeds the 16 KB server limit. ' +
-                    'Try removing device icon overrides or user presets.');
+                    'Try removing device icon styling or user presets.');
                 return;
             }
 
@@ -1011,10 +1011,11 @@
        set ones cuts a typical entry from ~230 to ~90 chars, the single
        biggest contributor to ThemeSettings bloat (issue #203). */
     /* Domoticz's own per-device Icon column, as dzIconPicker serialises it:
-       { "t":<prefix>, "on":<class>[, "off":<class>] }. Read-only here — the
-       override editor shows it as the effective default so a device the user
-       set natively (e.g. a ventilator given mdi-fan-remove on the device page)
-       reads as that icon rather than the theme's type default. */
+       { "t":<prefix>, "on":<class>[, "off":<class>] }. Read here so the icon
+       editor opens on the shape actually in effect — a device the user gave an
+       icon (a ventilator set to mdi-fan-remove on its device page) reads as
+       that icon rather than as the theme's type default. Writing it goes
+       through dzDeviceIconStore, which owns the serialisation. */
     function parseNativeDeviceIcon(v) {
         if (!v) return null;
         var p = v;
@@ -1922,25 +1923,22 @@
             '</div>' +
             '</div>' +
 
-            (function () {
-                var ovRaw = (s.deviceIconOverrides || '{}');
-                var ovCount = 0;
-                try { ovCount = Object.keys(typeof ovRaw === 'string' ? JSON.parse(ovRaw) : ovRaw).length; } catch (e) {}
-                var badge = ovCount > 0
-                    ? ' <span class="ng-override-badge">' + ovCount + '</span>'
-                    : '';
-                return '<div class="ng-settings-section">' +
-                    '<div class="ng-section-header"><i class="fa-solid fa-icons"></i> Device Icon Overrides</div>' +
-                    '<div class="ng-setting-row ng-setting-row--action">' +
-                    '  <div class="ng-setting-info">' +
-                    '    <span class="ng-setting-label">Per-Device Icons' + badge + '</span>' +
-                    '    <span class="ng-setting-desc">Assign any Font Awesome icon &amp; custom on/off colors to individual devices</span>' +
-                    '  </div>' +
-                    '  <button type="button" class="ng-action-chip" id="ng-override-manage-btn">' +
-                    '    <i class="fa-solid fa-wand-magic-sparkles"></i> Manage</button>' +
-                    '</div>' +
-                    '</div>';
-            })() +
+            /* No count here. The number of entries in the theme's blob is not
+               the number of devices with a custom icon — on a Domoticz that
+               owns the icon, the blob holds only colour and animation — so a
+               badge would invite exactly the wrong reading. The dialog's own
+               footer counts what is actually customised. */
+            '<div class="ng-settings-section">' +
+            '<div class="ng-section-header"><i class="fa-solid fa-icons"></i> Device Icons</div>' +
+            '<div class="ng-setting-row ng-setting-row--action">' +
+            '  <div class="ng-setting-info">' +
+            '    <span class="ng-setting-label">Per-Device Icons</span>' +
+            '    <span class="ng-setting-desc">Pick an icon for a device, then give it on/off colors and an animation</span>' +
+            '  </div>' +
+            '  <button type="button" class="ng-action-chip" id="ng-override-manage-btn">' +
+            '    <i class="fa-solid fa-wand-magic-sparkles"></i> Manage</button>' +
+            '</div>' +
+            '</div>' +
 
             /* Right column: Color panels (together) */
             '<div class="ng-settings-section ng-settings-section--colors">' +
@@ -2491,9 +2489,23 @@
             });
     }
 
-    /* ── Device Icon Override Dialog ──────────────────────────────── */
+    /* ── Device Icons Dialog ──────────────────────────────────────────
+       One row per device, and per device two stores behind it:
 
-    /* Classify a device into an icon/color model for the override editor.
+         • the SHAPE is Domoticz's, in the DeviceStatus.Icon column, on a
+           build that has one — the server renders it, so the choice outlives
+           the theme. Written here through dzDeviceIconStore (device-detail.js),
+           the same contract the device page's icon field uses. On a build
+           without the column the shape falls back to the theme blob, which is
+           where it has always lived.
+         • COLOUR and ANIMATION are the theme's, in deviceIconOverrides.
+           Domoticz validates the Icon column to {"t","on","off"} and has no
+           field for either, so they cannot go on the device.
+
+       The storage key is still called deviceIconOverrides: renaming it would
+       orphan every existing user's settings. Only the wording moved on. */
+
+    /* Classify a device into an icon/color model for the editor.
        Returns one of:
          'binary'    standard switch — 1 icon, on/off colors
          'selector'  selector switch — 1 icon, active/inactive colors
@@ -2578,14 +2590,41 @@
         var existing = document.getElementById('ng-ov-overlay');
         if (existing) existing.remove();
 
-        // Parse current overrides
+        // Parse the theme's stored colour / animation entries
         var currentOv = {};
         try {
             var raw = (window.dzNightglassSettings && window.dzNightglassSettings.get('deviceIconOverrides')) || '{}';
             currentOv = typeof raw === 'string' ? JSON.parse(raw) : (raw || {});
         } catch (e) {}
 
-        // Popular quick-override suggestions
+        /* Where a shape gets stored. Resolved before the rows render, because
+           it decides both what a row's icon control writes and what the row's
+           starting icon is. */
+        var iconStore    = window.dzDeviceIconStore || null;
+        var nativeShapes = false;
+
+        /* Icon edits staged for Domoticz's own storage, keyed by idx:
+           { on, off } for a glyph pair, { image: n } for an uploaded PNG, or
+           null to clear. Staged rather than written on the spot so the dialog
+           stays one transaction — Save flushes these with the theme blob,
+           Cancel drops both. The shape of an entry is dzDeviceIconStore.write's
+           `spec`, so Save hands them over untranslated. */
+        var pendingNative = {};
+
+        /* Uploaded icons, resolved to the value CustomImage stores. Only needed
+           where Domoticz can hold one; null until fetched, [] if unavailable. */
+        var customIcons = null;
+
+        function imageInfo(ci) {
+            ci = parseInt(ci, 10) || 0;
+            if (!ci || !customIcons) return null;
+            for (var i = 0; i < customIcons.length; i++) {
+                if (customIcons[i].value === ci) return customIcons[i];
+            }
+            return null;
+        }
+
+        // Popular quick-icon suggestions
         var POPULAR_OVERRIDES = [
             { label: 'WiFi Router',     icon: 'fa-solid fa-wifi',              on: '#4caf7d', off: '#555770' },
             { label: 'Network Switch',  icon: 'fa-solid fa-network-wired',     on: '#4e9af1', off: '#555770' },
@@ -2610,8 +2649,8 @@
         ];
 
 
-        // Mutable copy of current overrides — copy every stored field so the
-        // sidebar and row editors reflect the saved state when the dialog reopens.
+        // Mutable copy of the theme entries — copy every stored field so the
+        // row editors reflect the saved state when the dialog reopens.
         var pending = {};
         Object.keys(currentOv).forEach(function (k) {
             var s = currentOv[k];
@@ -2634,18 +2673,19 @@
         overlay.id = 'ng-ov-overlay';
         overlay.className = 'ng-bl-overlay';
         overlay.innerHTML =
-            '<div class="ng-bl-dialog ng-ov-dialog" role="dialog" aria-label="Device Icon Overrides">' +
+            '<div class="ng-bl-dialog ng-ov-dialog" role="dialog" aria-label="Device Icons">' +
             '  <div class="ng-bl-header">' +
             '    <div class="ng-bl-title">' +
             '      <i class="fa-solid fa-icons"></i>' +
-            '      <span>Device Icon Overrides</span>' +
+            '      <span>Device Icons</span>' +
             '    </div>' +
             '    <button class="ng-bl-close" aria-label="Close"><i class="fa-solid fa-xmark"></i></button>' +
             '  </div>' +
             '  <div class="ng-ov-body">' +
             '    <div class="ng-ov-main">' +
+            '      <div class="ng-ov-store-note" id="ng-ov-store-note"></div>' +
             '      <div class="ng-ov-popular">' +
-            '        <div class="ng-ov-popular-label"><i class="fa-solid fa-wand-magic-sparkles"></i> Quick Presets — click to assign to a device</div>' +
+            '        <div class="ng-ov-popular-label"><i class="fa-solid fa-wand-magic-sparkles"></i> Quick Presets — click one, then click a device</div>' +
             '        <div class="ng-ov-chips" id="ng-ov-chips"></div>' +
             '      </div>' +
             '      <div class="ng-bl-search-wrap">' +
@@ -2656,21 +2696,12 @@
             '        <div class="ng-bl-loading"><i class="fa-solid fa-spinner fa-spin"></i> Loading devices…</div>' +
             '      </div>' +
             '    </div>' +
-            '    <div class="ng-ov-sidebar" id="ng-ov-sidebar">' +
-            '      <div class="ng-ov-sidebar-header">' +
-            '        <i class="fa-solid fa-list-check"></i> Active' +
-            '        <span class="ng-ov-sidebar-count" id="ng-ov-sidebar-count">0</span>' +
-            '      </div>' +
-            '      <div class="ng-ov-sidebar-list" id="ng-ov-sidebar-list">' +
-            '        <div class="ng-ov-sidebar-empty">No overrides yet</div>' +
-            '      </div>' +
-            '    </div>' +
             '  </div>' +
             '  <div class="ng-bl-footer">' +
             '    <span class="ng-bl-count" id="ng-ov-count"></span>' +
             '    <div class="ng-bl-footer-btns">' +
             '      <button class="ng-bl-btn ng-bl-btn--cancel">Cancel</button>' +
-            '      <button class="ng-bl-btn ng-bl-btn--save">Save Overrides</button>' +
+            '      <button class="ng-bl-btn ng-bl-btn--save">Save</button>' +
             '    </div>' +
             '  </div>' +
             '</div>';
@@ -2678,110 +2709,127 @@
         document.body.appendChild(overlay);
         requestAnimationFrame(function () { overlay.classList.add('ng-bl-overlay--open'); });
 
-        var listEl         = overlay.querySelector('#ng-ov-list');
-        var searchEl       = overlay.querySelector('#ng-ov-search');
-        var countEl        = overlay.querySelector('#ng-ov-count');
-        var chipsEl        = overlay.querySelector('#ng-ov-chips');
-        var sidebarListEl  = overlay.querySelector('#ng-ov-sidebar-list');
-        var sidebarCountEl = overlay.querySelector('#ng-ov-sidebar-count');
+        var listEl   = overlay.querySelector('#ng-ov-list');
+        var searchEl = overlay.querySelector('#ng-ov-search');
+        var countEl  = overlay.querySelector('#ng-ov-count');
+        var chipsEl  = overlay.querySelector('#ng-ov-chips');
+        var noteEl   = overlay.querySelector('#ng-ov-store-note');
 
         function close() {
             overlay.classList.remove('ng-bl-overlay--open');
             setTimeout(function () { overlay.remove(); }, 260);
         }
 
-        function renderSidebar() {
-            var keys = Object.keys(pending);
-            if (sidebarCountEl) sidebarCountEl.textContent = keys.length;
-            if (!sidebarListEl) return;
-            if (!keys.length) {
-                sidebarListEl.innerHTML = '<div class="ng-ov-sidebar-empty">No overrides yet</div>';
-                return;
+        /* getdevices records by idx. Both the marker painter (which needs the
+           Icon column) and the shape writer (which needs Protected) read it,
+           and it is the same record the rows were built from. */
+        var devByIdx = {};
+
+        /* The shape in effect for a device — null when it is still on the icon
+           its type gives it. Native first: where Domoticz has the Icon column
+           it renders that shape itself, so it is what is actually on screen. A
+           shape in the theme blob is the fallback — the only store on a build
+           without the column, and still what the theme's PNG replacement draws
+           for a device Domoticz has no icon for. Same precedence as the device
+           page's icon field. Which of the two it came from is deliberately not
+           reported: nothing on the row distinguishes them. */
+        function shapeOf(idxStr) {
+            if (nativeShapes) {
+                var staged = pendingNative.hasOwnProperty(idxStr);
+                var s = staged ? pendingNative[idxStr]
+                               : parseNativeDeviceIcon((devByIdx[idxStr] || {}).Icon);
+                if (s && s.on) return { on: s.on, off: s.off || '' };
+                /* An uploaded PNG is the other half of the same native storage,
+                   so it counts as a shape here even though it has no class. */
+                var ci = staged ? (s && s.image)
+                                : (devByIdx[idxStr] || {}).CustomImage;
+                ci = parseInt(ci, 10) || 0;
+                if (ci >= 100) return { image: ci };
+                /* A staged entry is the whole truth for this device: an explicit
+                   clear must not fall through to the blob's legacy shape. */
+                if (staged) return null;
             }
-            sidebarListEl.innerHTML = '';
-            keys.forEach(function (idxStr) {
-                var ov   = pending[idxStr];
-                var name = ov.name || ('IDX ' + idxStr);
-                var on   = ov.on  || '#4e9af1';
-                var off  = ov.off || '#555770';
-
-                var item = document.createElement('div');
-                item.className = 'ng-ov-si';
-                item.dataset.idx = idxStr;
-                item.title = 'Jump to ' + name +
-                             (ov.anim ? ' — animation: ' + ov.anim : '');
-
-                var icon = document.createElement('i');
-                icon.className = (ov.iconOn || ov.iconOpen || ov.icon || 'fa-solid fa-circle-question') + ' ng-ov-si-icon';
-                icon.style.color = on;
-
-                var info = document.createElement('div');
-                info.className = 'ng-ov-si-info';
-
-                var nameEl = document.createElement('span');
-                nameEl.className = 'ng-ov-si-name';
-                nameEl.textContent = name;
-
-                var dots = document.createElement('span');
-                dots.className = 'ng-ov-si-dots';
-                dots.innerHTML =
-                    '<span class="ng-ov-si-dot" style="background:' + on  + '" title="On: ' + on + '"></span>' +
-                    '<span class="ng-ov-si-dot" style="background:' + off + '" title="Off: ' + off + '"></span>';
-
-                info.appendChild(nameEl);
-                info.appendChild(dots);
-
-                var removeBtn = document.createElement('button');
-                removeBtn.type = 'button';
-                removeBtn.className = 'ng-ov-si-remove';
-                removeBtn.title = 'Remove override';
-                removeBtn.innerHTML = '<i class="fa-solid fa-xmark"></i>';
-                removeBtn.addEventListener('click', function (e) {
-                    e.stopPropagation();
-                    delete pending[idxStr];
-                    /* Reset the corresponding device row if visible */
-                    var row = listEl.querySelector('[data-idx="' + idxStr + '"]');
-                    if (row) {
-                        row.classList.remove('ng-ov-row--active');
-                        var rowFa   = row.querySelector('.ng-ov-row-fa');
-                        var editBtn = row.querySelector('.ng-ov-edit-btn');
-                        var editor  = row.querySelector('.ng-ov-editor');
-                        if (rowFa)   { rowFa.className = (row.dataset.defIcon || 'fa-solid fa-circle-question') + ' ng-ov-row-fa'; rowFa.style.color = row.dataset.defColor || '#555770'; rowFa.style.opacity = '.55'; }
-                        if (editBtn) { editBtn.innerHTML = '<i class="fa-solid fa-plus"></i>'; }
-                        if (editor)  { editor.style.display = 'none'; }
-                    }
-                    updateCount();
-                });
-
-                item.appendChild(icon);
-                item.appendChild(info);
-                item.appendChild(removeBtn);
-
-                /* Click to jump to + briefly highlight the device row */
-                item.addEventListener('click', function () {
-                    var target = listEl.querySelector('[data-idx="' + idxStr + '"]');
-                    if (!target) return;
-                    /* Clear search so the row is visible */
-                    if (searchEl && searchEl.value) { searchEl.value = ''; filterList(''); }
-                    target.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-                    target.classList.add('ng-ov-row--flash');
-                    setTimeout(function () { target.classList.remove('ng-ov-row--flash'); }, 900);
-                });
-
-                sidebarListEl.appendChild(item);
-            });
+            var ov  = pending[idxStr];
+            var cls = ov && (ov.iconOn || ov.iconOpen || ov.icon);
+            if (cls) return { on: cls, off: (ov.iconOff || '') };
+            return null;
         }
 
+        /* Whether clearing a device would have anything to erase on the device
+           itself — an icon, or an uploaded image the icon would have replaced. */
+        function deviceCarriesIcon(idxStr) {
+            var rec = devByIdx[idxStr] || {};
+            return !!parseNativeDeviceIcon(rec.Icon) ||
+                   (parseInt(rec.CustomImage, 10) || 0) > 0;
+        }
+
+        /* One list, no shadow list: a device carrying customisation is marked on
+           its own row instead of being duplicated into a sidebar, so there is
+           one place to look and one place to edit.
+
+           The marks show the theme styling — the two colours and the animation.
+           Deliberately nothing about WHICH store holds the icon: on the builds
+           this targets the icon is always the device's, so a chip saying so
+           would read identically on every row and earn none of its width. The
+           line above the list says it once instead. */
+        function paintRowMarks(row) {
+            var idxStr = String(row.dataset.idx || '');
+            var marks  = row.querySelector('.ng-ov-row-marks');
+            if (!marks) return;
+            var ov    = pending[idxStr] || null;
+            var shape = shapeOf(idxStr);
+            var html  = '';
+
+            if (ov && (ov.on || ov.off)) {
+                var on  = ov.on  || '#4e9af1';
+                var off = ov.off || '#555770';
+                html += '<span class="ng-ov-mark-dots" title="Nightglass colours — on ' +
+                        on + ', off ' + off + '">' +
+                        '<span class="ng-ov-mark-dot" style="background:' + on  + '"></span>' +
+                        '<span class="ng-ov-mark-dot" style="background:' + off + '"></span>' +
+                        '</span>';
+            }
+            var animName = ov ? animLabel(ov.anim) : '';
+            if (animName) {
+                html += '<span class="ng-ov-mark ng-ov-mark--anim" title="' + animName +
+                        ' animation — Nightglass styling">' +
+                        '<i class="fa-solid fa-wand-magic-sparkles"></i>' + animName + '</span>';
+            }
+
+            marks.innerHTML = html;
+            /* Highlight on anything customised, including an icon with no theme
+               styling beside it — the marks can be empty while the row is still
+               not on its defaults. */
+            row.classList.toggle('ng-ov-row--active', !!(shape || ov));
+        }
+
+        /* Counts marked rows, i.e. both stores — the footer is about what the
+           user will see on their cards, not about one blob's size. */
         function updateCount() {
-            if (countEl) {
-                var n = Object.keys(pending).length;
-                countEl.textContent = n === 0 ? 'No overrides set' : n + ' override' + (n === 1 ? '' : 's');
+            if (!countEl) return;
+            var keys = Object.keys(devByIdx);
+            var n = 0;
+            for (var i = 0; i < keys.length; i++) {
+                if (pending[keys[i]] || shapeOf(keys[i])) n++;
             }
-            renderSidebar();
+            countEl.textContent = n === 0
+                ? 'No devices customised'
+                : n + ' of ' + keys.length + ' devices customised';
         }
 
-        /* Populate sidebar immediately for any pre-existing overrides */
-        renderSidebar();
+        /* One short line about the split, and only where it is true: on a build
+           whose devices hold their own icon, the shape the user picks here is
+           not the theme's and will not leave with it. */
+        function paintStoreNote() {
+            if (!noteEl) return;
+            noteEl.innerHTML = nativeShapes
+                ? '<i class="fa-solid fa-circle-info"></i> The icon is saved on the ' +
+                  'device and stays if you switch themes. Colour and animation are ' +
+                  'Nightglass styling and only apply here.'
+                : '<i class="fa-solid fa-circle-info"></i> This Domoticz cannot store ' +
+                  'an icon per device, so the icon, colour and animation are all ' +
+                  'Nightglass styling and only apply here.';
+        }
 
         function filterList(q) {
             q = (q || '').toLowerCase();
@@ -2814,8 +2862,14 @@
         /* `anim` is optional: { get, set }. Passing it hands the Studio the
            animation row as well, so it is given to the picker that edits the
            device's primary (on / open) icon and to no other — an animation
-           belongs to the device, not to one of its icon slots. */
-        function buildIconPicker(initialCls, onSelect, anim) {
+           belongs to the device, not to one of its icon slots.
+
+           `img` is optional too: { get, set }, the device's CustomImage. Passing
+           it opens the Studio's Custom source, which is only worth offering
+           where an uploaded PNG has somewhere to go — Domoticz's CustomImage
+           column. It rides on the same picker as the glyph because to the user
+           they are one choice: what this device looks like. */
+        function buildIconPicker(initialCls, onSelect, anim, img) {
             var wrap = document.createElement('div');
             wrap.className = 'ng-ov-picker';
 
@@ -2824,14 +2878,35 @@
             var row = document.createElement('div');
             row.className = 'ng-ov-picker-current';
 
+            /* Two previews, one shown at a time: a class cannot render a PNG
+               and an <img> cannot carry an icon font. */
             var prev = document.createElement('i');
-            prev.className = current || 'fa-solid fa-question';
+            var prevImg = document.createElement('img');
+            prevImg.className = 'ng-ov-picker-img';
+            prevImg.alt = '';
             row.appendChild(prev);
+            row.appendChild(prevImg);
 
             var lbl = document.createElement('span');
             lbl.className = 'ng-ov-picker-label';
-            lbl.textContent = pickerLabel(current);
             row.appendChild(lbl);
+
+            /* Draws whichever of the two the device is actually carrying. */
+            function paintCurrent() {
+                var info = img ? imageInfo(img.get()) : null;
+                if (info) {
+                    prev.style.display = 'none';
+                    prevImg.style.display = '';
+                    prevImg.src = info.src;
+                    lbl.textContent = info.name;
+                    return;
+                }
+                prevImg.style.display = 'none';
+                prev.style.display = '';
+                prev.className = current || 'fa-solid fa-question';
+                lbl.textContent = pickerLabel(current);
+            }
+            paintCurrent();
 
             /* Says what is set without having to open the Studio; empty
                collapses out of the layout (CSS :empty). */
@@ -2865,12 +2940,22 @@
                     /* Preview the animations on the icon this row is editing,
                        not on the Studio's own placeholder. */
                     animationGlyph: current,
+                    allowImages: !!img,
+                    currentImage: img ? img.get() : 0,
                     onPick: function (cls) {
                         current = cls;
-                        prev.className = cls;
-                        lbl.textContent = pickerLabel(cls);
+                        /* A glyph replaces an image, so drop the image first or
+                           paintCurrent would keep drawing the old PNG. */
+                        if (img) img.set(0);
+                        paintCurrent();
                         onSelect(cls);
                     },
+                    onPickImage: img ? function (customImage) {
+                        /* Already the value CustomImage stores — the Studio put
+                           back the 100 that getcustomiconset takes off. */
+                        img.set(customImage);
+                        paintCurrent();
+                    } : undefined,
                     onPickAnimation: anim ? function (id) {
                         anim.set(id);
                         paintAnim();
@@ -2888,64 +2973,84 @@
             var idxStr = String(d.idx);
             var ov     = pending[idxStr];
             var model  = getDeviceColorModel(d);
-            var hasOv  = !!(ov && (ov.iconOn || ov.iconOpen || ov.icon));
 
-            /* ── Resolve defaults via the icon replacement module ─────────── */
+            /* ── The device type's own icon, from the replacement module ─────
+               Kept intact as `theme*`: it is what "Use default" returns to,
+               and folding a chosen shape over it would leave nothing to reset
+               back down to. */
             var dzIcon     = typeof window._dzIconForDevice === 'function' ? window._dzIconForDevice : null;
-            var defSpecOn  = dzIcon ? dzIcon(d) : null;
-            var defIconOn  = (defSpecOn && defSpecOn.icon)  || 'fa-solid fa-circle-question';
-            var defColorOn = (defSpecOn && defSpecOn.color) || '#4e9af1';
-            var defColorOff = '#555770';
-            var defIconOpen  = defIconOn;
-            var defIconClose = defIconOn;
-
-            /* Prefer Domoticz's own per-device icon where the device carries
-               one: on a build with the Icon column, that shape is what is
-               actually rendered, so the row's default has to be it rather than
-               the theme's type guess. Colour is unaffected — the Icon column
-               carries none, so the theme still supplies it. */
-            var nativeIcon = parseNativeDeviceIcon(d.Icon);
-            if (nativeIcon) {
-                defIconOn    = nativeIcon.on;
-                defIconOpen  = nativeIcon.on;
-                defIconClose = nativeIcon.off || nativeIcon.on;
-            }
+            /* An uploaded image (>= 100) is not a device type — it is artwork —
+               so it must not decide what "the type's own icon" resolves to, or
+               a device carrying one reports a question mark as its default and
+               shows that the moment it is cleared. Image goes with CustomImage:
+               the server derives one from the other, so for an upload it holds
+               the artwork's name, which is not a DEVICE_MAP key either.
+               Built-in images (1..99) do carry type meaning and stay. */
+            var defSrc     = ((parseInt(d.CustomImage, 10) || 0) >= 100)
+                ? Object.assign({}, d, { CustomImage: 0, Image: '' }) : d;
+            var defSpecOn  = dzIcon ? dzIcon(defSrc) : null;
+            var themeIconOn  = (defSpecOn && defSpecOn.icon)  || 'fa-solid fa-circle-question';
+            var defColorOn   = (defSpecOn && defSpecOn.color) || '#4e9af1';
+            var defColorOff  = '#555770';
+            var themeIconOpen  = themeIconOn;
+            var themeIconClose = themeIconOn;
 
             if (model === 'blinds-2' || model === 'blinds-3') {
                 var sOp = dzIcon ? dzIcon({ TypeImg: (d.TypeImg || '') + 'open', Status: 'On'  }) : null;
                 var sCl = dzIcon ? dzIcon({ TypeImg:  d.TypeImg  || 'blinds',   Status: 'Off' }) : null;
-                defIconOpen  = (sOp && sOp.icon)  || 'fa-solid fa-chevron-up';
-                defIconClose = (sCl && sCl.icon)  || 'fa-solid fa-chevron-down';
-                defColorOn   = (sOp && sOp.color) || defColorOn;
+                themeIconOpen  = (sOp && sOp.icon)  || 'fa-solid fa-chevron-up';
+                themeIconClose = (sCl && sCl.icon)  || 'fa-solid fa-chevron-down';
+                defColorOn     = (sOp && sOp.color) || defColorOn;
             }
 
-            /* ── Current values: override or defaults ─────────────────────── */
-            var curIconOn    = hasOv ? (ov.iconOn    || ov.icon || defIconOn)                 : defIconOn;
-            var curIconOff   = hasOv ? (ov.iconOff   || ov.iconOn || ov.icon || defIconOn)    : defIconOn;
-            var curIconOpen  = hasOv ? (ov.iconOpen  || ov.iconOn || ov.icon || defIconOpen)  : defIconOpen;
-            var curIconClose = hasOv ? (ov.iconClose || ov.iconOn || ov.icon || defIconClose) : defIconClose;
-            var curIconStop  = hasOv ? (ov.iconStop  || 'fa-solid fa-stop')                   : 'fa-solid fa-stop';
-            var curOn        = hasOv ? (ov.on  || defColorOn)  : defColorOn;
-            var curOff       = hasOv ? (ov.off || defColorOff) : defColorOff;
+            /* ── Starting values ────────────────────────────────────────────
+               Shape from whichever store owns it (shapeOf), colour, animation
+               and the Stop icon always from the theme entry. */
+            var shape = shapeOf(idxStr);
+            var curIconOn    = shape ? shape.on                : themeIconOn;
+            var curIconOff   = shape ? (shape.off || shape.on) : themeIconOn;
+            var curIconOpen  = shape ? shape.on                : themeIconOpen;
+            var curIconClose = shape ? (shape.off || shape.on) : themeIconClose;
+            /* An uploaded PNG carries no class, so the glyph slots stay on the
+               type default: open the glyph picker on a device showing an image
+               and it starts where the device would fall back to. */
+            if (shape && shape.image) {
+                curIconOn = themeIconOn;         curIconOff   = themeIconOn;
+                curIconOpen = themeIconOpen;     curIconClose = themeIconClose;
+            }
+            var curIconStop  = (ov && ov.iconStop) || 'fa-solid fa-stop';
+            var curOn        = (ov && ov.on)  || defColorOn;
+            var curOff       = (ov && ov.off) || defColorOff;
             var keepColor    = ov ? !!(ov.keepColor) : (model === 'sensor');
-            /* Read off the entry rather than off hasOv: an animation is
-               stored on its own and does not need an icon override to exist. */
+            /* Read off the entry rather than off a shape: colour and animation
+               are stored on their own and need no icon to exist. */
             var curAnim      = (ov && ov.anim) || '';
+
+            /* Marked = the device carries something, from either store. Drives
+               the row's highlight, the edit button and the dimmed preview. */
+            var hasOv = !!(shape || ov);
 
             /* ── Row element ──────────────────────────────────────────────── */
             var row = document.createElement('div');
             row.className        = 'ng-ov-row' + (hasOv ? ' ng-ov-row--active' : '');
             row.dataset.idx      = idxStr;
             row.dataset.name     = d.Name || '';
-            row.dataset.defIcon  = defIconOn;
-            row.dataset.defColor = defColorOn;
 
             /* ── Summary line ─────────────────────────────────────────────── */
             var summary = document.createElement('div');
             summary.className = 'ng-ov-row-summary';
             var isBlinds = (model === 'blinds-2' || model === 'blinds-3');
 
-            var iconHtml = isBlinds
+            /* An uploaded PNG replaces the whole icon — there is no per-state
+               half of it — so it shows as one image even on a multi-icon row. */
+            var imgShape = shape && shape.image ? imageInfo(shape.image) : null;
+            var iconHtml =
+                (shape && shape.image)
+                ? '<span class="ng-ov-row-icon">' +
+                  '<img class="ng-ov-row-img" alt="" src="' +
+                  ((imgShape && imgShape.src) || '') + '">' +
+                  '</span>'
+                : isBlinds
                 ? '<span class="ng-ov-row-icon ng-ov-row-icon--multi">' +
                   '<i class="' + curIconOpen  + ' ng-ov-row-fa ng-ov-row-fa--open"  style="color:' + curOn  + ';' + (hasOv ? '' : 'opacity:.55') + '"></i>' +
                   '<i class="' + curIconClose + ' ng-ov-row-fa ng-ov-row-fa--close" style="color:' + curOff + ';' + (hasOv ? '' : 'opacity:.55') + '"></i>' +
@@ -2975,10 +3080,16 @@
                     (d.Type ? ' &middot; ' + d.Type : '') + swLabel + modelBadge + groupTag +
                 '  </span>' +
                 '</span>' +
-                '<button class="ng-ov-edit-btn" type="button" title="' + (hasOv ? 'Edit override' : 'Add override') + '">' +
-                '  <i class="fa-solid ' + (hasOv ? 'fa-pen-to-square' : 'fa-plus') + '"></i>' +
+                /* Filled by paintRowMarks — the theme styling this device carries. */
+                '<span class="ng-ov-row-marks"></span>' +
+                /* Always "edit", never "add": every device already shows an
+                   icon, its type default if nothing else, so there is no state
+                   in which the user is creating one rather than changing it. */
+                '<button class="ng-ov-edit-btn" type="button" title="Edit this device’s icon">' +
+                '  <i class="fa-solid fa-pen-to-square"></i>' +
                 '</button>';
             row.appendChild(summary);
+            paintRowMarks(row);
 
             /* ── Inline editor ────────────────────────────────────────────── */
             var editor = document.createElement('div');
@@ -3186,7 +3297,11 @@
                     note.textContent = noteText;
                     wrap.appendChild(note);
                 }
-                wrap.appendChild(buildIconPicker(initialCls, onSelectFn, anim));
+                /* `img` rides along with `anim`: both belong to the device as a
+                   whole rather than to one slot, so they go to the same single
+                   picker section — the one editing the primary icon. */
+                wrap.appendChild(buildIconPicker(initialCls, onSelectFn, anim,
+                                                 anim ? imgAccess : null));
                 return wrap;
             }
 
@@ -3199,60 +3314,157 @@
                 repaint: function () {}      // replaced by buildIconPicker
             };
 
+            /* The device's uploaded PNG, or 0. Only offered where Domoticz can
+               store one; the theme blob holds classes, so on a build without
+               the CustomImage destination there is nowhere to put an image and
+               the Studio's Custom source stays hidden rather than dead. */
+            var imgAccess = !nativeShapes ? null : {
+                get: function () {
+                    var s = shapeOf(idxStr);
+                    return (s && s.image) || 0;
+                },
+                set: function (ci) {
+                    ci = parseInt(ci, 10) || 0;
+                    if (ci >= 100) pendingNative[idxStr] = { image: ci };
+                    else if (pendingNative[idxStr] && pendingNative[idxStr].image) {
+                        /* Cleared by a glyph pick, which stages itself next. */
+                        delete pendingNative[idxStr];
+                    }
+                    repaintRowIcon();
+                    paintRowMarks(row);
+                    updateCount();
+                }
+            };
+
+            /* Redraw the row's leading icon from whatever the device now carries.
+               A glyph and a PNG are different elements, and an image is
+               whole-icon even on a two-icon row, so this rebuilds the slot
+               rather than patching whatever happens to be in it. Only when the
+               kind changed — repainting an unchanged glyph would restart any
+               CSS animation on it. */
+            function repaintRowIcon() {
+                var slot = summary.querySelector('.ng-ov-row-icon');
+                if (!slot) return;
+                var s     = shapeOf(idxStr);
+                var info  = s && s.image ? imageInfo(s.image) : null;
+                var hadImg = !!slot.querySelector('img');
+                if (info) {
+                    if (hadImg && slot.querySelector('img').src.indexOf(info.src) !== -1) return;
+                    slot.classList.remove('ng-ov-row-icon--multi');
+                    slot.innerHTML = '<img class="ng-ov-row-img" alt="" src="' + info.src + '">';
+                    return;
+                }
+                if (!hadImg) return;
+                if (isBlinds) {
+                    slot.classList.add('ng-ov-row-icon--multi');
+                    slot.innerHTML =
+                        '<i class="' + curIconOpen  + ' ng-ov-row-fa ng-ov-row-fa--open"  style="color:' + curOn  + '"></i>' +
+                        '<i class="' + curIconClose + ' ng-ov-row-fa ng-ov-row-fa--close" style="color:' + curOff + '"></i>';
+                } else {
+                    slot.innerHTML = '<i class="' + curIconOn + ' ng-ov-row-fa" style="color:' + curOn + '"></i>';
+                }
+            }
+
             /* Sync the summary's single primary icon */
             function updateSummaryPrimary() {
+                repaintRowIcon();
                 var fa = summary.querySelector('.ng-ov-row-fa');
                 if (fa) { fa.className = curIconOn + ' ng-ov-row-fa'; fa.style.color = curOn; fa.style.opacity = ''; }
             }
 
             /* Sync the summary's blinds open + close icons */
             function updateSummaryBlinds() {
+                repaintRowIcon();
                 var fo = summary.querySelector('.ng-ov-row-fa--open');
                 var fc = summary.querySelector('.ng-ov-row-fa--close');
                 if (fo) { fo.className = curIconOpen  + ' ng-ov-row-fa ng-ov-row-fa--open';  fo.style.color = curOn;  fo.style.opacity = ''; }
                 if (fc) { fc.className = curIconClose + ' ng-ov-row-fa ng-ov-row-fa--close'; fc.style.color = curOff; fc.style.opacity = ''; }
             }
 
-            /* Remove button with model-aware reset callback */
-            function buildRemoveBtn(onRemove) {
+            /* "Use default" clears BOTH layers, the way the device page's icon
+               field does: the shape on the device (staged as an explicit clear
+               so Save erases the Icon column and any uploaded image with it)
+               and the theme's colour / animation entry. Peeling off one and
+               leaving the other is what made the old two-store split confusing.
+               `onReset` restores this model's own preview. */
+            function buildResetBtn(onReset) {
                 var btn = document.createElement('button');
                 btn.type      = 'button';
                 btn.className = 'ng-ov-remove-btn';
-                btn.innerHTML = '<i class="fa-solid fa-trash-can"></i> Remove';
+                btn.innerHTML = '<i class="fa-solid fa-rotate-left"></i> Use default';
+                btn.title     = 'Back to the icon Domoticz picks for this device type';
                 btn.addEventListener('click', function () {
                     delete pending[idxStr];
-                    row.classList.remove('ng-ov-row--active');
-                    var eb = summary.querySelector('.ng-ov-edit-btn');
-                    if (eb) eb.innerHTML = '<i class="fa-solid fa-plus"></i>';
+                    if (nativeShapes && deviceCarriesIcon(idxStr)) {
+                        pendingNative[idxStr] = null;
+                    } else {
+                        /* Nothing on the device to erase — drop any staged pick
+                           rather than queue a write that changes nothing. */
+                        delete pendingNative[idxStr];
+                    }
                     editor.style.display = 'none';
-                    onRemove();
+                    onReset();
+                    repaintRowIcon();
+                    paintRowMarks(row);
                     updateCount();
                 });
                 return btn;
             }
 
-            /* Persist pending entry + mark row active */
+            /* A shape edit goes to whichever store owns shapes on this build.
+               On native that is Domoticz's Icon column — staged for Save, and
+               the theme entry is left untouched, so a device that only got a
+               new icon does not gain a theme entry it has no use for. */
+            function stageShape() {
+                if (!nativeShapes) { commitOverride(); return; }
+                /* The Icon column is a single on/off pair, so the models with
+                   more slots fold onto it: lock/contact map straight over,
+                   blinds' Open/Close become on/off. Everything else has one
+                   shape and leaves off unset — native reads `off || on`. */
+                var on, off;
+                if (model === 'blinds-2' || model === 'blinds-3') {
+                    on = curIconOpen; off = curIconClose;
+                } else if (model === 'lock' || model === 'contact') {
+                    on = curIconOn;   off = curIconOff;
+                } else {
+                    on = curIconOn;   off = '';
+                }
+                pendingNative[idxStr] = { on: on, off: (off && off !== on) ? off : '' };
+                /* After staging, never before: the row's icon is drawn from
+                   shapeOf(), so repainting first would still see the icon this
+                   pick replaces — an uploaded PNG most visibly. */
+                repaintRowIcon();
+                paintRowMarks(row);
+                updateCount();
+            }
+
+            /* Persist the theme entry: colour, animation, keepColor — and the
+               shape only where the theme is still its store. Writing a shape
+               into the blob on a native build would record it twice, and the
+               blob's copy is the one that never renders. */
             function commitOverride() {
                 var obj = { name: d.Name || '', on: curOn, off: curOff };
-                if (model === 'blinds-2' || model === 'blinds-3') {
-                    obj.iconOpen  = curIconOpen;
-                    obj.iconClose = curIconClose;
-                    obj.iconOn    = curIconOpen;   /* sidebar display fallback */
-                    if (model === 'blinds-3') obj.iconStop = curIconStop;
-                } else if (model === 'lock' || model === 'contact') {
-                    obj.iconOn  = curIconOn;
-                    obj.iconOff = curIconOff;
-                } else if (model === 'sensor') {
-                    obj.iconOn    = curIconOn;
-                    obj.keepColor = keepColor;
-                } else {
-                    obj.iconOn = curIconOn;
+                if (!nativeShapes) {
+                    if (model === 'blinds-2' || model === 'blinds-3') {
+                        obj.iconOpen  = curIconOpen;
+                        obj.iconClose = curIconClose;
+                        obj.iconOn    = curIconOpen;   /* single-icon fallback */
+                        if (model === 'blinds-3') obj.iconStop = curIconStop;
+                    } else if (model === 'lock' || model === 'contact') {
+                        obj.iconOn  = curIconOn;
+                        obj.iconOff = curIconOff;
+                    } else {
+                        obj.iconOn = curIconOn;
+                    }
+                } else if (model === 'blinds-3' && curIconStop !== 'fa-solid fa-stop') {
+                    /* The one shape with nowhere native to go: an on/off pair
+                       has no third state, so the Stop icon stays the theme's. */
+                    obj.iconStop = curIconStop;
                 }
+                if (model === 'sensor') obj.keepColor = keepColor;
                 if (curAnim) obj.anim = curAnim;
                 pending[idxStr] = obj;
-                row.classList.add('ng-ov-row--active');
-                var eb = summary.querySelector('.ng-ov-edit-btn');
-                if (eb) eb.innerHTML = '<i class="fa-solid fa-pen-to-square"></i>';
+                paintRowMarks(row);
                 updateCount();
             }
 
@@ -3274,11 +3486,16 @@
                         curIconOpen = cls;
                         updateSlotIcon(slotOpen, curIconOpen, curOn);
                         updateSummaryBlinds();
-                        commitOverride();
+                        stageShape();
                     }, animAccess));
                 if (model === 'blinds-3') {
                     editor.appendChild(makePickerSection('Stop button icon',
-                        'Middle icon — click to stop movement', curIconStop, function (cls) {
+                        nativeShapes
+                            /* Domoticz's icon is an on/off pair with no third
+                               state, so this one cannot go on the device. */
+                            ? 'Middle icon — Nightglass only, Domoticz has no third icon'
+                            : 'Middle icon — click to stop movement',
+                        curIconStop, function (cls) {
                             curIconStop = cls;
                             updateSlotIcon(slotStop, curIconStop, '#b0b3c6');
                             commitOverride();
@@ -3289,7 +3506,7 @@
                         curIconClose = cls;
                         updateSlotIcon(slotClose, curIconClose, curOff);
                         updateSummaryBlinds();
-                        commitOverride();
+                        stageShape();
                     }));
 
                 colorRow.appendChild(makeOvColorPicker('Open color', curOn, function (v) {
@@ -3298,8 +3515,9 @@
                 colorRow.appendChild(makeOvColorPicker('Close color', curOff, function (v) {
                     curOff = v; updateSlotIcon(slotClose, curIconClose, curOff); updateSummaryBlinds(); commitOverride();
                 }));
-                colorRow.appendChild(buildRemoveBtn(function () {
-                    curIconOpen = defIconOpen; curIconClose = defIconClose; curIconStop = 'fa-solid fa-stop';
+                colorRow.appendChild(buildResetBtn(function () {
+                    curIconOpen = themeIconOpen; curIconClose = themeIconClose;
+                    curIconStop = 'fa-solid fa-stop';
                     curOn = defColorOn; curOff = defColorOff;
                     curAnim = ''; animAccess.repaint();
                     updateSummaryBlinds();
@@ -3326,7 +3544,7 @@
                         curIconOn = cls;
                         updateSlotIcon(slotSensor, curIconOn, keepColor ? defColorOn : curOn);
                         updateSummaryPrimary();
-                        commitOverride();
+                        stageShape();
                     }, animAccess));
 
                 var keepWrap = document.createElement('div');
@@ -3352,11 +3570,11 @@
                     if (!keepColor) updateSlotIcon(slotSensor, curIconOn, v);
                     commitOverride();
                 }));
-                colorRow.appendChild(buildRemoveBtn(function () {
-                    curIconOn = defIconOn; curOn = defColorOn; keepColor = true;
+                colorRow.appendChild(buildResetBtn(function () {
+                    curIconOn = themeIconOn; curOn = defColorOn; keepColor = true;
                     curAnim = ''; animAccess.repaint();
                     var fa = summary.querySelector('.ng-ov-row-fa');
-                    if (fa) { fa.className = defIconOn + ' ng-ov-row-fa'; fa.style.color = defColorOn; fa.style.opacity = '.55'; }
+                    if (fa) { fa.className = themeIconOn + ' ng-ov-row-fa'; fa.style.color = defColorOn; fa.style.opacity = '.55'; }
                 }));
                 editor.appendChild(colorRow);
 
@@ -3375,12 +3593,12 @@
                     curIconOn = cls;
                     updateSlotIcon(slotActive, curIconOn, curOn);
                     updateSummaryPrimary();
-                    commitOverride();
+                    stageShape();
                 }, animAccess));
                 editor.appendChild(makePickerSection(inactiveLabel + ' icon', null, curIconOff, function (cls) {
                     curIconOff = cls;
                     updateSlotIcon(slotInactive, curIconOff, curOff);
-                    commitOverride();
+                    stageShape();
                 }));
 
                 colorRow.appendChild(makeOvColorPicker(activeLabel + ' color', curOn, function (v) {
@@ -3389,11 +3607,11 @@
                 colorRow.appendChild(makeOvColorPicker(inactiveLabel + ' color', curOff, function (v) {
                     curOff = v; updateSlotIcon(slotInactive, curIconOff, curOff); commitOverride();
                 }));
-                colorRow.appendChild(buildRemoveBtn(function () {
-                    curIconOn = defIconOn; curIconOff = defIconOn; curOn = defColorOn; curOff = defColorOff;
+                colorRow.appendChild(buildResetBtn(function () {
+                    curIconOn = themeIconOn; curIconOff = themeIconOn; curOn = defColorOn; curOff = defColorOff;
                     curAnim = ''; animAccess.repaint();
                     var fa = summary.querySelector('.ng-ov-row-fa');
-                    if (fa) { fa.className = defIconOn + ' ng-ov-row-fa'; fa.style.color = defColorOn; fa.style.opacity = '.55'; }
+                    if (fa) { fa.className = themeIconOn + ' ng-ov-row-fa'; fa.style.color = defColorOn; fa.style.opacity = '.55'; }
                 }));
                 editor.appendChild(colorRow);
 
@@ -3415,7 +3633,7 @@
                     curIconOn = cls;
                     updateSlotIcon(slotMain, curIconOn, curOn);
                     updateSummaryPrimary();
-                    commitOverride();
+                    stageShape();
                 }, animAccess));
 
                 colorRow.appendChild(makeOvColorPicker(labelOn, curOn, function (v) {
@@ -3424,11 +3642,11 @@
                 colorRow.appendChild(makeOvColorPicker(labelOff, curOff, function (v) {
                     curOff = v; commitOverride();
                 }));
-                colorRow.appendChild(buildRemoveBtn(function () {
-                    curIconOn = defIconOn; curOn = defColorOn; curOff = defColorOff;
+                colorRow.appendChild(buildResetBtn(function () {
+                    curIconOn = themeIconOn; curOn = defColorOn; curOff = defColorOff;
                     curAnim = ''; animAccess.repaint();
                     var fa = summary.querySelector('.ng-ov-row-fa');
-                    if (fa) { fa.className = defIconOn + ' ng-ov-row-fa'; fa.style.color = defColorOn; fa.style.opacity = '.55'; }
+                    if (fa) { fa.className = themeIconOn + ' ng-ov-row-fa'; fa.style.color = defColorOn; fa.style.opacity = '.55'; }
                 }));
                 editor.appendChild(colorRow);
             }
@@ -3472,11 +3690,12 @@
                 return;
             }
             listEl.innerHTML = '';
+            devices.forEach(function (d) { devByIdx[String(d.idx)] = d; });
 
-            // Sort: devices with existing overrides first
+            // Sort: already-customised devices first, from either store
             var sorted = devices.slice().sort(function (a, b) {
-                var aHas = !!(pending[String(a.idx)]);
-                var bHas = !!(pending[String(b.idx)]);
+                var aHas = !!(pending[String(a.idx)] || shapeOf(String(a.idx)));
+                var bHas = !!(pending[String(b.idx)] || shapeOf(String(b.idx)));
                 if (aHas && !bHas) return -1;
                 if (!aHas && bHas) return 1;
                 return (a.Name || '').localeCompare(b.Name || '');
@@ -3539,13 +3758,28 @@
             listEl.querySelectorAll('.ng-ov-confirm-bar').forEach(function (b) { b.remove(); });
         }
 
-        /* Apply the pending preset to a device row */
+        /* Apply the pending preset to a device row.
+
+           A preset is a shape plus a colour pair, so it splits cleanly down the
+           same seam as everything else: the icon to whichever store owns shapes
+           here, the two colours always to the theme. Nothing about a preset is
+           lost in the split — there is no preset field without a home. */
         function applyPresetToRow(idxStr) {
             var pp = _pendingPreset;
-            pending[idxStr] = { iconOn: pp.icon, on: pp.on, off: pp.off, name: pending[idxStr] && pending[idxStr].name || pp.label };
+            var was = pending[idxStr];
+            var ent = { on: pp.on, off: pp.off, name: (was && was.name) || pp.label };
+            /* Keep an animation the device already had: a preset says nothing
+               about motion, so it has no business clearing one. */
+            if (was && was.anim) ent.anim = was.anim;
+            if (nativeShapes) {
+                pendingNative[idxStr] = { on: pp.icon, off: '' };
+            } else {
+                ent.iconOn = pp.icon;
+            }
+            pending[idxStr] = ent;
+
             var row = listEl.querySelector('[data-idx="' + idxStr + '"]');
             if (row) {
-                row.classList.add('ng-ov-row--active');
                 /* Update all FA icons in the summary — blinds rows have open + close icons,
                    so querySelectorAll is needed instead of just querySelector for the first. */
                 row.querySelectorAll('.ng-ov-row-fa').forEach(function (fa) {
@@ -3555,8 +3789,7 @@
                     fa.style.color   = fa.classList.contains('ng-ov-row-fa--close') ? pp.off : pp.on;
                     fa.style.opacity = '';
                 });
-                var editBtn = row.querySelector('.ng-ov-edit-btn');
-                if (editBtn) editBtn.innerHTML = '<i class="fa-solid fa-pen-to-square"></i>';
+                paintRowMarks(row);
             }
             updateCount();
             exitSelectMode();
@@ -3594,24 +3827,55 @@
         });
         if (searchEl) searchEl.addEventListener('input', function () { filterList(this.value); });
 
+        /* Save writes both stores. The staged shapes go to Domoticz first: they
+           are the half that can fail (a rejected class, a permission), and a
+           failure there must not be hidden behind an already-saved theme blob.
+           The blob is written either way — colour and animation are ours and
+           have nothing to do with whether setused went through. */
         overlay.querySelector('.ng-bl-btn--save').addEventListener('click', function () {
-            if (window.dzNightglassSettings) {
-                window.dzNightglassSettings.set('deviceIconOverrides', JSON.stringify(pending));
+            var staged = Object.keys(pendingNative);
+            var failed = 0;
+            var left   = staged.length;
+
+            function finish() {
+                if (window.dzNightglassSettings) {
+                    window.dzNightglassSettings.set('deviceIconOverrides', JSON.stringify(pending));
+                }
+                if (failed && typeof window.ngShowToast === 'function') {
+                    window.ngShowToast({
+                        type: 'error', icon: 'fa-triangle-exclamation', color: 'var(--dz-danger)',
+                        title: 'Icon not saved',
+                        body: 'Domoticz refused the icon for ' + failed + ' device' +
+                              (failed === 1 ? '' : 's') + '. Colour and animation were saved.'
+                    });
+                }
+                close();
+                // Refresh settings panel badge
+                var wrap = document.getElementById('ng-theme-settings-wrap');
+                if (wrap) {
+                    var presetsBody = wrap.querySelector('#ngPresetsBody');
+                    var presetsOpen = presetsBody && presetsBody.style.display !== 'none';
+                    wrap.innerHTML = buildPanel({ presetsOpen: presetsOpen });
+                    bindEvents(wrap);
+                    loadPresets(wrap);
+                }
             }
-            close();
-            // Refresh settings panel badge
-            var wrap = document.getElementById('ng-theme-settings-wrap');
-            if (wrap) {
-                var presetsBody = wrap.querySelector('#ngPresetsBody');
-                var presetsOpen = presetsBody && presetsBody.style.display !== 'none';
-                wrap.innerHTML = buildPanel({ presetsOpen: presetsOpen });
-                bindEvents(wrap);
-                loadPresets(wrap);
-            }
+
+            if (!left || !iconStore || typeof iconStore.write !== 'function') { finish(); return; }
+            staged.forEach(function (idxStr) {
+                /* A staged entry already IS the store's spec — { on, off } for a
+                   glyph, { image } for an upload, null to clear. */
+                iconStore.write(devByIdx[idxStr] || { idx: idxStr },
+                                pendingNative[idxStr], function (ok) {
+                    if (!ok) failed++;
+                    if (--left === 0) finish();
+                });
+            });
         });
 
         /* Fetch devices — window.__ngDemoDevices can be set by demo pages as a fallback */
-        fetch('/json.htm?type=command&param=getdevices&filter=all&used=true&order=Name', { credentials: 'same-origin' })
+        function loadDevices() {
+          fetch('/json.htm?type=command&param=getdevices&filter=all&used=true&order=Name', { credentials: 'same-origin' })
             .then(function (r) { return r.json(); })
             .then(function (data) { renderDevices(data.result || []); })
             .catch(function () {
@@ -3631,6 +3895,33 @@
                     '</div>';
                 updateCount();
             });
+        }
+
+        /* Settle the store question before anything renders — it decides what
+           each row's icon control writes and what its starting icon is. */
+        if (iconStore && typeof iconStore.probeNative === 'function') {
+            iconStore.probeNative(function (ok) {
+                nativeShapes = ok;
+                paintStoreNote();
+                /* Uploaded icons only matter where Domoticz can store one, and
+                   the rows need them to draw a device that already has one — so
+                   this waits for the list rather than rendering "#101" first.
+                   dzCustomIcons owns the +100, so no offset arrives here. */
+                if (ok && typeof window.dzCustomIcons === 'function') {
+                    window.dzCustomIcons(function (list) {
+                        customIcons = list;
+                        loadDevices();
+                    });
+                    return;
+                }
+                loadDevices();
+            });
+        } else {
+            /* The device-icon module is a separate file: without it there is no
+               way to reach the Icon column from here, so the blob is the store. */
+            paintStoreNote();
+            loadDevices();
+        }
     }
 
     function bindEvents(container) {
@@ -3722,7 +4013,7 @@
             blBtn.addEventListener('click', openBlacklistDialog);
         }
 
-        // Device icon override manage button
+        // Device Icons dialog button
         var ovBtn = container.querySelector('#ng-override-manage-btn');
         if (ovBtn) {
             /* Wrap so the click Event isn't passed as presetIdx (issue #225). */
@@ -4197,7 +4488,8 @@
     }
 
     // Expose for external use
-    /* Parse the stored override map (best-effort). */
+    /* Parse the stored per-device styling map (best-effort). Still keyed
+       'deviceIconOverrides' in storage — see the Device Icons dialog. */
     function readOverrideMap() {
         try {
             var raw = (window.dzNightglassSettings && window.dzNightglassSettings.get('deviceIconOverrides')) || '{}';
@@ -4214,15 +4506,15 @@
                 saveSetting(key, DEFAULTS[key]);
             });
         },
-        /* Open the Device Icon Overrides dialog, optionally focused on one
-           device (used by the device-detail page). */
+        /* Open the Device Icons dialog, optionally focused on one device
+           (used by the device-detail page). */
         openIconOverride: function (idx) { openDeviceIconOverrideDialog(idx); },
-        /* Return the override entry for a device IDX, or null. */
+        /* Return the stored styling entry for a device IDX, or null. */
         getDeviceOverride: function (idx) {
             var m = readOverrideMap();
             return m[String(idx)] || null;
         },
-        /* Remove a device's override and re-apply icons immediately. */
+        /* Drop a device's styling entry and re-apply icons immediately. */
         removeDeviceOverride: function (idx) {
             var m = readOverrideMap();
             if (!m[String(idx)]) return false;
@@ -4233,11 +4525,11 @@
             }
             return true;
         },
-        /* Set the on (and optionally off) icon of a device's override,
-           preserving any existing colours and animation. Used by the
-           device-detail / utility box so an Icon Studio pick applies directly
-           without the full override dialog. An empty off clears the stored
-           off, falling back to the on shape — the single-icon default. */
+        /* Set the on (and optionally off) icon in the theme's own entry,
+           preserving any existing colours and animation. The fallback store
+           for a shape: used by the device-detail / utility box on a Domoticz
+           without the Icon column. An empty off clears the stored off,
+           falling back to the on shape — the single-icon default. */
         setDeviceOverrideIcons: function (idx, onCls, offCls, deviceName) {
             if (!idx || !onCls) return false;
             var m  = readOverrideMap();

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -602,10 +602,11 @@
 
         deviceIconOverrides: '{}',
 
-        /* Extra icon-font libraries the user added (issue #129) — JSON array of
-           { id, name, cssUrl, prefix }. Nightglass downloads + caches them
-           locally in the browser so users only need the source URL + prefix. */
-        iconLibraries:      '[]',
+        /* No iconLibraries key: extra icon fonts are Domoticz's own feature now
+           (Setup → Custom Icons). Any value left over from when the theme
+           managed them is still read straight out of storage by the one-shot
+           migration in icon-studio.js — a key absent from DEFAULTS survives
+           both (de)serialize paths untouched. */
 
         userPresets:        '[]',   /* user-saved color presets — JSON array */
 
@@ -1719,11 +1720,6 @@
             } catch (e) {
                 window._dzSetDeviceIconOverrides({});
             }
-        }
-
-        // Load any user-added icon libraries so their glyphs render + enumerate.
-        if (typeof window.dzInjectIconLibraries === 'function') {
-            window.dzInjectIconLibraries(_settings.iconLibraries || '[]');
         }
 
         // Hand libraries the theme used to host over to Domoticz's own icon

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -1725,6 +1725,13 @@
         if (typeof window.dzInjectIconLibraries === 'function') {
             window.dzInjectIconLibraries(_settings.iconLibraries || '[]');
         }
+
+        // Hand libraries the theme used to host over to Domoticz's own icon
+        // library registry, which manages them from now on. Runs once, and only
+        // when there is something to move.
+        if (typeof window.dzMigrateIconLibraries === 'function') {
+            window.dzMigrateIconLibraries();
+        }
     }
 
     /* ── Build the settings panel HTML ─────────────────────────── */

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -1006,14 +1006,32 @@
     /* ── Settings persistence ─────────────────────────────────────── */
 
     /* Strip empty/default fields from each device-icon override.  A stored
-       entry can carry up to 10 fields (icon, iconOn/Off/Open/Close/Stop,
-       keepColor, on, off, name) but most are blank — keeping only the set
-       ones cuts a typical entry from ~230 to ~90 chars, the single biggest
-       contributor to ThemeSettings bloat (issue #203). */
+       entry can carry up to 11 fields (icon, iconOn/Off/Open/Close/Stop,
+       keepColor, on, off, anim, name) but most are blank — keeping only the
+       set ones cuts a typical entry from ~230 to ~90 chars, the single
+       biggest contributor to ThemeSettings bloat (issue #203). */
+    /* Domoticz's own per-device Icon column, as dzIconPicker serialises it:
+       { "t":<prefix>, "on":<class>[, "off":<class>] }. Read-only here — the
+       override editor shows it as the effective default so a device the user
+       set natively (e.g. a ventilator given mdi-fan-remove on the device page)
+       reads as that icon rather than the theme's type default. */
+    function parseNativeDeviceIcon(v) {
+        if (!v) return null;
+        var p = v;
+        if (typeof v === 'string') { try { p = JSON.parse(v); } catch (e) { return null; } }
+        if (!p || typeof p !== 'object' || typeof p.on !== 'string') return null;
+        var on = p.on.replace(/\s+/g, ' ').trim();
+        if (!on) return null;
+        return { on: on, off: (typeof p.off === 'string' ? p.off.trim() : '') };
+    }
+
     function pruneOverrides(ov) {
         if (!ov || typeof ov !== 'object') return {};
+        /* 'anim' is an id, so an unset animation is '' and drops out here
+           along with every other blank field — no animation is the default
+           and costs nothing to store. */
         var KEEP = ['icon', 'iconOn', 'iconOff', 'iconOpen', 'iconClose',
-                    'iconStop', 'on', 'off', 'name'];
+                    'iconStop', 'on', 'off', 'anim', 'name'];
         var out = {};
         Object.keys(ov).forEach(function (idx) {
             var s = ov[idx] || {};
@@ -1276,14 +1294,17 @@
             devIconStyle.remove();
         }
 
-        // Animate device icons (spinning fans, flickering flames, etc.)
+        // Animate device icons — master switch over the per-device choices
         var animStyle = document.getElementById('dz-ng-anim-icon-style');
         if (!_settings.animateDeviceIcons || !_settings.deviceIcons) {
             if (!animStyle) {
                 animStyle = document.createElement('style');
                 animStyle.id = 'dz-ng-anim-icon-style';
+                /* Not gated on data-dz-state: a read-only sensor publishes no
+                   state and would otherwise keep animating with the switch
+                   off.  Device icons carry no other animation to lose. */
                 animStyle.textContent =
-                    'i.dz-fa-device[data-dz-state="on"] { animation: none !important; }';
+                    'i.dz-fa-device { animation: none !important; }';
                 document.head.appendChild(animStyle);
             }
         } else if (animStyle) {
@@ -1840,7 +1861,7 @@
             '<div class="ng-settings-section">' +
             '<div class="ng-section-header"><i class="fa-solid fa-cube"></i> Device &amp; Card Icons</div>' +
             toggle('deviceIcons', 'Device Icons', 'Replace 48px PNG device icons with Font Awesome on cards') +
-            toggle('animateDeviceIcons', 'Animate Device Icons', 'Spin fans, flicker flames, pulse presence sensors when active') +
+            toggle('animateDeviceIcons', 'Animate Device Icons', 'Play the animation each device was given in the Icon Studio — spin, glow, flicker and six more') +
             toggle('favStarIcons', 'Favorite Star Icons', 'Replace PNG stars with Font Awesome star icons') +
             toggle('trendArrowIcons', 'Trend Arrow Icons', 'Replace PNG trend arrows with Font Awesome arrows') +
             toggle('actionIcons', 'Action Icons', 'Replace PNG action icons (delete, rename, add) in data tables') +
@@ -2604,6 +2625,7 @@
                 keepColor: s.keepColor,
                 on:        s.on,
                 off:       s.off,
+                anim:      s.anim,
                 name:      s.name || ''
             };
         });
@@ -2686,7 +2708,8 @@
                 var item = document.createElement('div');
                 item.className = 'ng-ov-si';
                 item.dataset.idx = idxStr;
-                item.title = 'Jump to ' + name;
+                item.title = 'Jump to ' + name +
+                             (ov.anim ? ' — animation: ' + ov.anim : '');
 
                 var icon = document.createElement('i');
                 icon.className = (ov.iconOn || ov.iconOpen || ov.icon || 'fa-solid fa-circle-question') + ' ng-ov-si-icon';
@@ -2779,7 +2802,20 @@
             return token.replace(/^[a-z0-9]+-/i, '').replace(/-/g, ' ').trim() || 'No icon';
         }
 
-        function buildIconPicker(initialCls, onSelect) {
+        /* Display name of an animation id, from icons.js's catalogue. */
+        function animLabel(id) {
+            var list = window.dzIconAnimations || [];
+            for (var i = 0; i < list.length; i++) {
+                if (list[i].id === id) return list[i].label;
+            }
+            return '';
+        }
+
+        /* `anim` is optional: { get, set }. Passing it hands the Studio the
+           animation row as well, so it is given to the picker that edits the
+           device's primary (on / open) icon and to no other — an animation
+           belongs to the device, not to one of its icon slots. */
+        function buildIconPicker(initialCls, onSelect, anim) {
             var wrap = document.createElement('div');
             wrap.className = 'ng-ov-picker';
 
@@ -2797,21 +2833,48 @@
             lbl.textContent = pickerLabel(current);
             row.appendChild(lbl);
 
+            /* Says what is set without having to open the Studio; empty
+               collapses out of the layout (CSS :empty). */
+            var animChip = null;
+            if (anim) {
+                animChip = document.createElement('span');
+                animChip.className = 'ng-ov-picker-anim';
+                row.appendChild(animChip);
+            }
+            function paintAnim() {
+                if (!animChip) return;
+                var label = animLabel(anim.get());
+                animChip.innerHTML = label
+                    ? '<i class="fa-solid fa-wand-magic-sparkles"></i>' + label : '';
+            }
+            /* Lets the row's Remove button clear the chip this drew. */
+            if (anim) anim.repaint = paintAnim;
+            paintAnim();
+
             var btn = document.createElement('button');
             btn.type = 'button';
             btn.className = 'ng-ov-picker-change';
-            btn.innerHTML = '<i class="fa-solid fa-icons"></i> Change icon…';
+            btn.innerHTML = '<i class="fa-solid fa-icons"></i> ' +
+                            (anim ? 'Change icon or animation…' : 'Change icon…');
             btn.addEventListener('click', function () {
                 if (typeof window.dzOpenIconStudio !== 'function') return;
                 window.dzOpenIconStudio({
                     current: current,
-                    title: 'Choose an icon',
+                    title: anim ? 'Choose an icon and animation' : 'Choose an icon',
+                    animation: anim ? anim.get() : '',
+                    /* Preview the animations on the icon this row is editing,
+                       not on the Studio's own placeholder. */
+                    animationGlyph: current,
                     onPick: function (cls) {
                         current = cls;
                         prev.className = cls;
                         lbl.textContent = pickerLabel(cls);
                         onSelect(cls);
-                    }
+                    },
+                    onPickAnimation: anim ? function (id) {
+                        anim.set(id);
+                        paintAnim();
+                    } : undefined
                 });
             });
             row.appendChild(btn);
@@ -2836,6 +2899,18 @@
             var defIconOpen  = defIconOn;
             var defIconClose = defIconOn;
 
+            /* Prefer Domoticz's own per-device icon where the device carries
+               one: on a build with the Icon column, that shape is what is
+               actually rendered, so the row's default has to be it rather than
+               the theme's type guess. Colour is unaffected — the Icon column
+               carries none, so the theme still supplies it. */
+            var nativeIcon = parseNativeDeviceIcon(d.Icon);
+            if (nativeIcon) {
+                defIconOn    = nativeIcon.on;
+                defIconOpen  = nativeIcon.on;
+                defIconClose = nativeIcon.off || nativeIcon.on;
+            }
+
             if (model === 'blinds-2' || model === 'blinds-3') {
                 var sOp = dzIcon ? dzIcon({ TypeImg: (d.TypeImg || '') + 'open', Status: 'On'  }) : null;
                 var sCl = dzIcon ? dzIcon({ TypeImg:  d.TypeImg  || 'blinds',   Status: 'Off' }) : null;
@@ -2853,6 +2928,9 @@
             var curOn        = hasOv ? (ov.on  || defColorOn)  : defColorOn;
             var curOff       = hasOv ? (ov.off || defColorOff) : defColorOff;
             var keepColor    = ov ? !!(ov.keepColor) : (model === 'sensor');
+            /* Read off the entry rather than off hasOv: an animation is
+               stored on its own and does not need an icon override to exist. */
+            var curAnim      = (ov && ov.anim) || '';
 
             /* ── Row element ──────────────────────────────────────────────── */
             var row = document.createElement('div');
@@ -3090,8 +3168,10 @@
                 if (ic) { ic.className = iconCls + ' ng-ov-preview-icon'; ic.style.color = color; }
             }
 
-            /* Labeled wrapper around an icon picker grid */
-            function makePickerSection(labelText, noteText, initialCls, onSelectFn) {
+            /* Labeled wrapper around an icon picker grid. `anim` is passed
+               through to buildIconPicker — see there for why only one
+               section per row gets it. */
+            function makePickerSection(labelText, noteText, initialCls, onSelectFn, anim) {
                 var wrap = document.createElement('div');
                 wrap.className = 'ng-ov-picker-section';
                 if (labelText) {
@@ -3106,9 +3186,18 @@
                     note.textContent = noteText;
                     wrap.appendChild(note);
                 }
-                wrap.appendChild(buildIconPicker(initialCls, onSelectFn));
+                wrap.appendChild(buildIconPicker(initialCls, onSelectFn, anim));
                 return wrap;
             }
+
+            /* The row's animation accessor, handed to exactly one picker
+               section below.  Setting it commits, so the choice sticks the
+               moment it is made in the Studio — same as a colour. */
+            var animAccess = {
+                get: function () { return curAnim; },
+                set: function (id) { curAnim = id; commitOverride(); },
+                repaint: function () {}      // replaced by buildIconPicker
+            };
 
             /* Sync the summary's single primary icon */
             function updateSummaryPrimary() {
@@ -3159,6 +3248,7 @@
                 } else {
                     obj.iconOn = curIconOn;
                 }
+                if (curAnim) obj.anim = curAnim;
                 pending[idxStr] = obj;
                 row.classList.add('ng-ov-row--active');
                 var eb = summary.querySelector('.ng-ov-edit-btn');
@@ -3185,7 +3275,7 @@
                         updateSlotIcon(slotOpen, curIconOpen, curOn);
                         updateSummaryBlinds();
                         commitOverride();
-                    }));
+                    }, animAccess));
                 if (model === 'blinds-3') {
                     editor.appendChild(makePickerSection('Stop button icon',
                         'Middle icon — click to stop movement', curIconStop, function (cls) {
@@ -3211,6 +3301,7 @@
                 colorRow.appendChild(buildRemoveBtn(function () {
                     curIconOpen = defIconOpen; curIconClose = defIconClose; curIconStop = 'fa-solid fa-stop';
                     curOn = defColorOn; curOff = defColorOff;
+                    curAnim = ''; animAccess.repaint();
                     updateSummaryBlinds();
                     var fo = summary.querySelector('.ng-ov-row-fa--open');
                     var fc = summary.querySelector('.ng-ov-row-fa--close');
@@ -3236,7 +3327,7 @@
                         updateSlotIcon(slotSensor, curIconOn, keepColor ? defColorOn : curOn);
                         updateSummaryPrimary();
                         commitOverride();
-                    }));
+                    }, animAccess));
 
                 var keepWrap = document.createElement('div');
                 keepWrap.className = 'ng-ov-keepcolor-wrap';
@@ -3263,6 +3354,7 @@
                 }));
                 colorRow.appendChild(buildRemoveBtn(function () {
                     curIconOn = defIconOn; curOn = defColorOn; keepColor = true;
+                    curAnim = ''; animAccess.repaint();
                     var fa = summary.querySelector('.ng-ov-row-fa');
                     if (fa) { fa.className = defIconOn + ' ng-ov-row-fa'; fa.style.color = defColorOn; fa.style.opacity = '.55'; }
                 }));
@@ -3284,7 +3376,7 @@
                     updateSlotIcon(slotActive, curIconOn, curOn);
                     updateSummaryPrimary();
                     commitOverride();
-                }));
+                }, animAccess));
                 editor.appendChild(makePickerSection(inactiveLabel + ' icon', null, curIconOff, function (cls) {
                     curIconOff = cls;
                     updateSlotIcon(slotInactive, curIconOff, curOff);
@@ -3299,6 +3391,7 @@
                 }));
                 colorRow.appendChild(buildRemoveBtn(function () {
                     curIconOn = defIconOn; curIconOff = defIconOn; curOn = defColorOn; curOff = defColorOff;
+                    curAnim = ''; animAccess.repaint();
                     var fa = summary.querySelector('.ng-ov-row-fa');
                     if (fa) { fa.className = defIconOn + ' ng-ov-row-fa'; fa.style.color = defColorOn; fa.style.opacity = '.55'; }
                 }));
@@ -3323,7 +3416,7 @@
                     updateSlotIcon(slotMain, curIconOn, curOn);
                     updateSummaryPrimary();
                     commitOverride();
-                }));
+                }, animAccess));
 
                 colorRow.appendChild(makeOvColorPicker(labelOn, curOn, function (v) {
                     curOn = v; updateSlotIcon(slotMain, curIconOn, v); updateSummaryPrimary(); commitOverride();
@@ -3333,6 +3426,7 @@
                 }));
                 colorRow.appendChild(buildRemoveBtn(function () {
                     curIconOn = defIconOn; curOn = defColorOn; curOff = defColorOff;
+                    curAnim = ''; animAccess.repaint();
                     var fa = summary.querySelector('.ng-ov-row-fa');
                     if (fa) { fa.className = defIconOn + ' ng-ov-row-fa'; fa.style.color = defColorOn; fa.style.opacity = '.55'; }
                 }));
@@ -4139,22 +4233,58 @@
             }
             return true;
         },
-        /* Set (or update) just the icon of a device's override, preserving any
-           existing on/off colors. Used by the device-detail / utility box so
-           "Set Nightglass icon" can apply an Icon Studio pick directly without
-           the full override dialog. */
-        setDeviceOverrideIcon: function (idx, iconCls, deviceName) {
-            if (!idx || !iconCls) return false;
-            var m = readOverrideMap();
+        /* Set the on (and optionally off) icon of a device's override,
+           preserving any existing colours and animation. Used by the
+           device-detail / utility box so an Icon Studio pick applies directly
+           without the full override dialog. An empty off clears the stored
+           off, falling back to the on shape — the single-icon default. */
+        setDeviceOverrideIcons: function (idx, onCls, offCls, deviceName) {
+            if (!idx || !onCls) return false;
+            var m  = readOverrideMap();
             var ex = m[String(idx)] || {};
-            m[String(idx)] = {
-                iconOn:    iconCls,
-                iconOff:   ex.iconOff,
-                on:        ex.on  || '#4e9af1',
-                off:       ex.off || '#555770',
-                keepColor: ex.keepColor,
-                name:      ex.name || deviceName || ('IDX ' + idx)
-            };
+            ex.iconOn    = onCls;
+            ex.iconOff   = String(offCls || '').trim() || undefined;
+            ex.on        = ex.on  || '#4e9af1';
+            ex.off       = ex.off || '#555770';
+            ex.name      = ex.name || deviceName || ('IDX ' + idx);
+            m[String(idx)] = ex;
+            saveSetting('deviceIconOverrides', JSON.stringify(m));
+            if (typeof window._dzSetDeviceIconOverrides === 'function') {
+                window._dzSetDeviceIconOverrides(m);
+            }
+            return true;
+        },
+        /* Set (or clear) just the animation.  Separate from the icon because
+           the two no longer share a home: on a Domoticz with the Icon column
+           the shape is the device's and only the animation is ours, so the
+           device icon field has to be able to write one without the other.
+           An entry that ends up holding nothing but a name is dropped rather
+           than left behind as a stored no-op. */
+        setDeviceOverrideAnim: function (idx, animId, deviceName) {
+            if (!idx) return false;
+            var key = String(idx);
+            var m   = readOverrideMap();
+            var ex  = m[key] || {};
+            var id  = String(animId || '');
+            /* Whitelisted against the catalogue icons.js publishes, so a typo
+               or a stale id cannot be persisted. */
+            var known = (window.dzIconAnimations || []).some(function (a) {
+                return a.id === id;
+            });
+            if (id && !known) return false;
+
+            if (id) {
+                ex.anim = id;
+                ex.name = ex.name || deviceName || ('IDX ' + key);
+                m[key]  = ex;
+            } else {
+                delete ex.anim;
+                var meaningful = ['icon', 'iconOn', 'iconOff', 'iconOpen',
+                                  'iconClose', 'iconStop', 'on', 'off',
+                                  'keepColor'].some(function (f) { return ex[f]; });
+                if (meaningful) m[key] = ex;
+                else delete m[key];
+            }
             saveSetting('deviceIconOverrides', JSON.stringify(m));
             if (typeof window._dzSetDeviceIconOverrides === 'function') {
                 window._dzSetDeviceIconOverrides(m);

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -2768,9 +2768,12 @@
            Shows the current icon + a Change button; calls onSelect(cls) on
            pick. The heavy lifting (all-FA enumeration, custom libraries,
            search, categories, Recent, manual class) lives in the Studio. */
+        /* The glyph is the last whitespace token ("ph ph-acorn" → "acorn");
+           anything before it is a style or base class. Mirrors labelOf() in
+           icon-studio.js, which produces the classes shown here. */
         function pickerLabel(cls) {
-            return (cls || '').replace(/^fa-\w+\s+fa-/, '').replace(/^mdi\s+mdi-/, '')
-                              .replace(/^[a-z0-9]+[\s-]/, '').replace(/-/g, ' ').trim() || 'No icon';
+            var token = String(cls || '').trim().split(/\s+/).pop() || '';
+            return token.replace(/^[a-z0-9]+-/i, '').replace(/-/g, ' ').trim() || 'No icon';
         }
 
         function buildIconPicker(initialCls, onSelect) {


### PR DESCRIPTION
This pull request makes significant improvements to icon library integration, device icon animations, and the device icon picker UI in Nightglass for Domoticz. It aligns Nightglass with Domoticz's native icon handling, introduces a more flexible and performant animation system for device icons, and updates documentation and UI styles to match these changes. Accessibility and performance are also enhanced, especially regarding motion preferences and DOM updates.

**Icon library integration and documentation:**
- Updated documentation in `README.md` and `docs/index.html` to reflect that third-party icon libraries are now installed and managed directly within Domoticz under **Setup → Custom Icons**, rather than through Nightglass, simplifying user workflow. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L139-R140) [[2]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL1502-R1509)

**Device icon animation system:**
- Replaced hardcoded, type-based icon animations with a new per-device animation system: animations are now selected in the Icon Studio and applied via `.dz-anim-<id>` classes, with all animation logic consolidated and optimized for compositor performance. Animations are now purely decorative and respect user "prefers-reduced-motion" settings for accessibility. [[1]](diffhunk://#diff-2b37a0c5e6215bffdc720f44ca161a6a682b2939999e92cc2ecb1b7435b00218L625-R753) [[2]](diffhunk://#diff-2b37a0c5e6215bffdc720f44ca161a6a682b2939999e92cc2ecb1b7435b00218R1500-R1511) [[3]](diffhunk://#diff-2b37a0c5e6215bffdc720f44ca161a6a682b2939999e92cc2ecb1b7435b00218L102-R104)

**Device icon picker and UI alignment:**
- Refactored the device icon picker UI in `src/css/pages.css` to match Domoticz's native picker, using the same class names and layout for seamless integration and future compatibility. The custom picker now uses a simpler, inline-flex layout and improved button styling.

**Native glyph and navbar icon handling:**
- Ensured consistent scaling and alignment of device and scene icons by matching Domoticz's glyph sizing rules in `src/css/layout.css`, and hid redundant native glyphs in the navigation bar to prevent duplicate icons. [[1]](diffhunk://#diff-0333339fc66ce92f54ddab6cf379ddba0404fcfd6776c5d786a2dee87f4accc5R364-R394) [[2]](diffhunk://#diff-0333339fc66ce92f54ddab6cf379ddba0404fcfd6776c5d786a2dee87f4accc5R1149-R1156)

**Performance and SPA navigation fixes:**
- Improved the device state mutation observer in `src/js/card-features.js` to prevent unnecessary icon animation flashes on initial load and SPA navigation by ignoring the first appearance of the `data-dz-state` attribute. [[1]](diffhunk://#diff-c71f81997e247398db5cb6fdd09743d104942c6f907ff733ecf702b86981f626R1026-R1032) [[2]](diffhunk://#diff-c71f81997e247398db5cb6fdd09743d104942c6f907ff733ecf702b86981f626R1069)