### PR TITLE
Development

### DIFF
--- a/custom.js
+++ b/custom.js
@@ -37,6 +37,7 @@
         'src/js/device-detail.js',  /* Device detail page: Nightglass icon source + override entry point */
         'src/js/popups.js',         /* Feature 9: popup/modal redesigns */
         'src/js/toasts.js',         /* Feature 10: live toasts */
+        'src/js/icon-migrate.js',   /* One-shot: per-device icon shapes → Domoticz's Icon column */
         'src/js/realtime.js',       /* Feature 11: WebSocket live card updates */
         'src/js/command-palette.js',/* Feature 12: Ctrl+K command palette */
         'src/js/notifications.js',  /* Feature 13: notification history panel (N key) */

--- a/src/js/device-detail.js
+++ b/src/js/device-detail.js
@@ -812,6 +812,11 @@
         isNative:     nativeIconStorage,
         probeNative:  probeNativeStorage,
         parse:        parseIcon,
+        /* Published alongside write() because it feeds it: the record read
+           here is the one writeIcon() wants (Name and Protected present, so no
+           second read) and it is cached, so a caller that walks several devices
+           and the device page itself share one fetch each. */
+        read:         fetchDevice,
         write:        writeIcon
     };
 

--- a/src/js/icon-migrate.js
+++ b/src/js/icon-migrate.js
@@ -1,0 +1,219 @@
+/* Moving a per-device icon SHAPE out of the theme blob and into Domoticz.
+
+   Nightglass used to be the only store for a per-device icon: the shape went
+   into deviceIconOverrides alongside the colour, and icons.js drew it. Domoticz
+   then grew a DeviceStatus.Icon column of its own, and where that exists the
+   server resolves the glyph before the theme ever sees it — so a shape left in
+   the blob is simply ignored by the device lists, while the device edit page
+   (which reads the Icon column) reports something else. The user's pick stops
+   working and the two surfaces disagree about what it even is.
+
+   Nothing moved those shapes when the column arrived, so this does, once,
+   automatically: shape to the Icon column, colour and animation left in the
+   blob where they are still the only store for them.
+
+   On a Domoticz without the column this module does nothing whatsoever — there
+   the blob shape IS the effective icon and moving it would delete the feature.
+*/
+(function () {
+    'use strict';
+
+    var KEY = 'deviceIconOverrides';
+
+    /* The blob keys applyDeviceOverride() in icons.js reads as a shape.
+       'icon' is the pre-rename single-icon field; iconOpen / iconClose are the
+       blinds Open and Close buttons, which map onto the native on/off pair the
+       same way the theme's own fallback chain does. An off equal to on is
+       dropped: both stores read `off || on`, so storing it twice says nothing. */
+    function shapeOf(ov) {
+        var on  = ov.iconOn  || ov.icon      || ov.iconOpen || '';
+        var off = ov.iconOff || ov.iconClose || '';
+        if (!on) return null;
+        return { on: on, off: (off && off !== on) ? off : '' };
+    }
+
+    /* Removed from an entry once its shape is stored on the device.
+       iconStop is NOT among them and is deliberately not a shape to shapeOf():
+       the Icon column is an on/off pair and has nowhere to put a third glyph,
+       so the blinds stop icon stays in the blob rather than being thrown away —
+       and an entry holding only iconStop has nothing to migrate, so it is never
+       picked up and never revisited. */
+    var MIGRATED_KEYS = ['icon', 'iconOn', 'iconOff', 'iconOpen', 'iconClose'];
+
+    /* What still earns an entry its place once the shape is gone. 'name' is
+       only a label for the settings list, so an entry down to a name is dead
+       weight and goes. */
+    var KEEP_KEYS = ['on', 'off', 'keepColor', 'anim', 'iconStop'];
+
+    /* NormaliseDeviceIcon() in the server refuses a class outside
+       [A-Za-z0-9 _-], a library prefix (the first token) over 32 chars or a
+       class over 128, and through write()'s boolean that refusal is
+       indistinguishable from "this session may not write". Screen for it here
+       so one unstorable entry is skipped rather than read as a permission
+       failure — which would stop every entry behind it, on every page load. */
+    function storable(cls) {
+        if (!/^[A-Za-z0-9 _-]+$/.test(cls) || cls.length > 128) return false;
+        return (cls.split(' ')[0] || '').length <= 32;
+    }
+
+    function readMap(settings) {
+        try {
+            var raw = settings.get(KEY) || '{}';
+            var m = (typeof raw === 'string') ? JSON.parse(raw) : raw;
+            return (m && typeof m === 'object') ? m : {};
+        } catch (e) { return {}; }
+    }
+
+    function trim(map, idx) {
+        var ov = map[idx];
+        MIGRATED_KEYS.forEach(function (k) { delete ov[k]; });
+        var worthKeeping = KEEP_KEYS.some(function (k) { return ov[k]; });
+        if (!worthKeeping) delete map[idx];
+    }
+
+    function migrate(store, settings) {
+        var map  = readMap(settings);
+        var todo = Object.keys(map).filter(function (idx) {
+            return /^\d+$/.test(idx) && !!shapeOf(map[idx] || {});
+        });
+        if (!todo.length) return;
+
+        var moved = [];
+
+        /* One device at a time. Each step is a read plus a setused, and firing
+           twenty of those at a page load would compete with the page's own
+           startup requests for no gain — there is nothing waiting on this. */
+        function step(i) {
+            if (i >= todo.length) { finish(); return; }
+            var idx = todo[i];
+            store.read(idx, function (device) {
+                if (!device) {
+                    /* Deleted, or just unreadable right now. Leave the entry:
+                       it costs a few bytes, and a device that comes back
+                       migrates on a later load. */
+                    window.ngLog('[IconMigrate]', idx, 'no such device — skipped');
+                    step(i + 1);
+                    return;
+                }
+                /* A shape already in the Icon column was picked later and
+                   through Domoticz itself, which is exactly the store that now
+                   wins — overwriting it with the blob's older shape would undo
+                   a choice the user can see taking effect. */
+                if (store.parse(device.Icon)) {
+                    window.ngLog('[IconMigrate]', idx, 'already has a native icon — skipped');
+                    step(i + 1);
+                    return;
+                }
+                /* An uploaded PNG is the same case in a different column: it is
+                   what the lists actually draw today, and Icon and CustomImage
+                   are alternatives, so writing a glyph clears it. Migrating
+                   over one would silently destroy the assignment with nothing
+                   left to restore it from. */
+                if ((parseInt(device.CustomImage, 10) || 0) > 0) {
+                    window.ngLog('[IconMigrate]', idx, 'has a custom image — skipped');
+                    step(i + 1);
+                    return;
+                }
+
+                var shape = shapeOf(map[idx]);
+                if (!storable(shape.on) || (shape.off && !storable(shape.off))) {
+                    window.ngLog('[IconMigrate]', idx, 'shape the server would refuse — skipped');
+                    step(i + 1);
+                    return;
+                }
+                store.write(device, { on: shape.on, off: shape.off }, function (ok) {
+                    if (!ok) {
+                        /* setused answers 403 to a non-admin session, and there
+                           is no admin to become on this page load. Nothing is
+                           lost — the entry still holds the shape — so stop here
+                           rather than retrying every device into the same wall,
+                           and say nothing: the user did not ask for this and
+                           cannot act on it. */
+                        window.ngLog('[IconMigrate]', idx, 'write refused — stopping');
+                        finish();
+                        return;
+                    }
+                    moved.push(idx);
+                    step(i + 1);
+                });
+            });
+        }
+
+        function finish() {
+            if (!moved.length) return;
+            moved.forEach(function (idx) { trim(map, idx); });
+            /* Devices first, blob last, never the other way round: until setused
+               has stored it, the blob is the only copy of the shape, so trimming
+               first and then failing the write would lose it outright. In this
+               order a failed save leaves the shape claimed in the blob AND
+               present on the device, and the next load reads that device as an
+               already-native pick and skips it — the entry keeps a shape that is
+               inert on this Domoticz, which is untidy but never wrong, and
+               nothing can be clobbered.
+
+               One save for the whole run rather than one per device: each is a
+               full blob POST, and a failure costs the same either way — every
+               device it covers is already carrying its shape.
+
+               setAndPersist rather than set: this has written DeviceStatus, so
+               the trim cannot be left waiting for a "Save to Domoticz" click
+               that may never come. It re-applies the settings on the way, which
+               is what hands icons.js the trimmed map so the colours keep
+               landing on the now-native glyphs. */
+            var saving = settings.setAndPersist
+                ? settings.setAndPersist(KEY, JSON.stringify(map))
+                : Promise.resolve(settings.set(KEY, JSON.stringify(map)) || false);
+            Promise.resolve(saving).then(function (saved) {
+                if (!saved) window.ngLog('[IconMigrate]', 'trimmed blob was not saved');
+            });
+            announce(moved.length);
+        }
+
+        step(0);
+    }
+
+    /* Writing to the user's device data is not something to do behind their
+       back, so say it happened — once, with a count, not once per device. */
+    function announce(n) {
+        window.ngLog('[IconMigrate]', 'moved', n, 'icon(s) into Domoticz');
+        if (typeof window.ngShowToast !== 'function') return;
+        window.ngShowToast({
+            icon:  'fa-right-left',
+            color: 'var(--dz-accent, #4e9af1)',
+            title: 'Device icons moved to Domoticz',
+            body:  'Nightglass used to store the shape of ' + n + ' device icon' +
+                   (n === 1 ? '' : 's') + ' itself. Domoticz owns ' +
+                   (n === 1 ? 'it' : 'them') + ' now, so the device lists and the ' +
+                   'device pages agree again and the choice survives without the ' +
+                   'theme. Colours and animations are unchanged.',
+            duration: 12000,
+            type: 'system'
+        });
+    }
+
+    var _ran = false;
+    function run() {
+        if (_ran) return;
+        var store    = window.dzDeviceIconStore;
+        var settings = window.dzNightglassSettings;
+        if (!store || !store.probeNative || !store.read || !store.write) return;
+        _ran = true;
+        /* isNative() can only answer yes from a route that has already loaded
+           dzIconService, and this runs from whatever page the user happened to
+           open. probeNative() asks the server for the file instead, which is
+           the same question without the routing false negative. */
+        store.probeNative(function (native) {
+            if (native) migrate(store, settings);
+        });
+    }
+
+    /* Waits for the settings module to have its stored values: run against a
+       blob that has not loaded yet and every entry looks absent. */
+    var _tries = 0;
+    function init() {
+        var s = window.dzNightglassSettings;
+        if (s && s.whenReady) { s.whenReady(run); return; }
+        if (++_tries < 20) setTimeout(init, 500);
+    }
+    init();
+}());

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -626,6 +626,20 @@
     var _presetsSaveTimer = null; // debounce handle for legacy preset writes
     var LS_KEY         = 'ngThemeSettings';
 
+    /* get() answers from DEFAULTS while _settings is still null, so a caller
+       cannot tell "nothing stored" from "not read yet" — and one that acts on
+       an empty collection would draw the wrong conclusion. whenReady() below
+       hands out this latch instead. */
+    var _readyDone = false;
+    var _readyCbs  = [];
+    function _signalReady() {
+        if (_readyDone) return;
+        _readyDone = true;
+        var cbs = _readyCbs;
+        _readyCbs = [];
+        cbs.forEach(function (fn) { try { fn(); } catch (e) {} });
+    }
+
     /* Collection fields are held in _settings as JSON *strings* (the shape the
        get/set API and every caller expects), but persisted as native
        objects/arrays so their quotes are NOT double-escaped inside the
@@ -774,7 +788,13 @@
     // automatic retry with the freshly-read token handles the normal case
     // (another session wrote between our read and our write); a second conflict
     // stops prompting and reports, rather than looping forever.
-    function _postThemeSettings(btn, retryCount) {
+    //
+    // Resolves true only when the blob reached the server, so a caller that has
+    // already changed something outside the blob can tell whether the two are
+    // still in step.  quiet suppresses the conflict confirm(): a save the user
+    // did not ask for (the icon-shape migration) must never stop a page load on
+    // a modal question — it reports false and leaves the stored copy alone.
+    function _postThemeSettings(btn, retryCount, quiet) {
         retryCount = retryCount || 0;
         var json = JSON.stringify(serializeSettings());
         var params = {
@@ -818,7 +838,7 @@
                     btn.innerHTML = '<i class="fa-solid fa-check"></i> Saved!';
                     setTimeout(function () { btn.innerHTML = SAVE_BTN_HTML; btn.disabled = false; }, 2000);
                 }
-                return;
+                return true;
             }
 
             // Every non-OK reply carries the reason in data.error (status is only
@@ -832,7 +852,13 @@
                     errorToast('var(--dz-danger, #e05555)', 'Save conflict',
                         'Another session keeps changing these settings. Reload the ' +
                         'page and try again.');
-                    return;
+                    return false;
+                }
+                if (quiet) {
+                    // Nobody asked for this save, so nobody can be asked which
+                    // copy wins: the server's stands and the caller is told.
+                    restoreBtn();
+                    return false;
                 }
                 // Another session saved after we last read — re-fetch the current
                 // server value AND token (loadFromThemeApi updates _lastupdate),
@@ -852,16 +878,17 @@
                         }
                         _dirty = false;
                         _showUnsavedToast(false);
-                        return;
+                        return false;
                     }
                     // User chose to overwrite — retry WITH the fresh token so the
                     // server's compare-and-swap matches and the write lands.
-                    return _postThemeSettings(btn, retryCount + 1);
+                    return _postThemeSettings(btn, retryCount + 1, quiet);
                 }, function () {
                     // Re-read failed — surface the conflict rather than silently drop.
                     errorToast('var(--dz-danger, #e05555)', 'Save conflict',
                         'Settings were changed elsewhere and the current server copy ' +
                         'could not be read. Reload the page and try again.');
+                    return false;
                 });
             }
 
@@ -874,29 +901,31 @@
                 errorToast('var(--dz-warning, #f0a832)', 'Settings not synced',
                     'Your session type does not support per-user settings. ' +
                     'Settings are stored in this browser only.');
-                return;
+                return false;
             }
 
             if (err === 'too_large') {
                 errorToast('var(--dz-danger, #e05555)', 'Settings too large',
                     'The settings blob exceeds the 16 KB server limit. ' +
                     'Try removing device icon styling or user presets.');
-                return;
+                return false;
             }
 
             if (err === 'too_many_themes') {
                 errorToast('var(--dz-danger, #e05555)', 'Too many theme configs',
                     'The server has reached its per-user theme-config limit. ' +
                     'Use the Reset All button to clear stale entries.');
-                return;
+                return false;
             }
 
             // invalid_theme / invalid_json / missing_value / post_required / db_error
             errorToast('var(--dz-danger, #e05555)', 'Save failed',
                 (data.message || 'The server rejected the settings.') + ' (' + err + ')');
+            return false;
         }).catch(function (e) {
             console.warn('Nightglass: _postThemeSettings failed', e);
             restoreBtn();
+            return false;
         });
     }
 
@@ -935,6 +964,36 @@
         });
     }
 
+    // Legacy path: store the blob as a JSON user variable (compact form too, so
+    // the user-variable value stays small and round-trips identically).
+    // Resolves true when the variable was written, for callers that need to know.
+    function writeJsonUvar() {
+        var json = JSON.stringify(serializeSettings());
+        if (_uvarIdx) {
+            return apiCall({
+                type: 'command', param: 'updateuservariable',
+                idx: _uvarIdx, vname: UVAR_NAME, vtype: UVAR_TYPE, vvalue: json
+            }).then(function (d) {
+                return !!(d && d.status === 'OK');
+            }, function () { return false; });
+        }
+        return apiCall({
+            type: 'command', param: 'adduservariable',
+            vname: UVAR_NAME, vtype: UVAR_TYPE, vvalue: json
+        }).then(function (d) {
+            var ok = !!(d && d.status === 'OK');
+            // Re-fetch so we have the idx for future update calls
+            return apiCall({ type: 'command', param: 'getuservariables' }).then(function (data) {
+                if (data && data.result) {
+                    data.result.forEach(function (uv) {
+                        if (uv.Name === UVAR_NAME) _uvarIdx = uv.idx;
+                    });
+                }
+                return ok;
+            }, function () { return ok; });
+        }, function () { return false; });
+    }
+
     // Debounced persistence helper called from saveSetting().
     // On the new API, just marks the in-memory state dirty so the user knows
     // to click "Save to Domoticz" — the actual POST happens then.
@@ -946,28 +1005,7 @@
                 _markDirty();
                 return;
             }
-            // Legacy path: store as a JSON user variable (compact form too, so
-            // the user-variable value stays small and round-trips identically).
-            var json = JSON.stringify(serializeSettings());
-            if (_uvarIdx) {
-                apiCall({
-                    type: 'command', param: 'updateuservariable',
-                    idx: _uvarIdx, vname: UVAR_NAME, vtype: UVAR_TYPE, vvalue: json
-                });
-            } else {
-                apiCall({
-                    type: 'command', param: 'adduservariable',
-                    vname: UVAR_NAME, vtype: UVAR_TYPE, vvalue: json
-                }).then(function () {
-                    // Re-fetch so we have the idx for future update calls
-                    return apiCall({ type: 'command', param: 'getuservariables' });
-                }).then(function (data) {
-                    if (!data || !data.result) return;
-                    data.result.forEach(function (uv) {
-                        if (uv.Name === UVAR_NAME) _uvarIdx = uv.idx;
-                    });
-                });
-            }
+            writeJsonUvar();
         }, 400);
     }
 
@@ -1252,6 +1290,34 @@
             saveToLocalStorage();
         }
         applySettings();
+    }
+
+    /* Set a value and push the blob to the server right away, instead of the
+       usual "mark dirty, wait for Save to Domoticz".  For changes the user did
+       not make by hand and so cannot be asked to confirm: the icon-shape
+       migration has already written DeviceStatus by the time it trims the blob,
+       so leaving that trim to a click that may never come would keep the two
+       stores disagreeing.  It writes the whole blob, as every save does — safe
+       here only because the migration runs before the settings panel exists and
+       therefore before there can be pending hand edits to sweep up with it.
+       Resolves true when the value reached durable storage. */
+    function persistNow(key, value) {
+        if (!_settings) return Promise.resolve(false);
+        _settings[key] = value;
+        window.ngLog('[Settings]', 'set+persist', key);
+        saveToLocalStorage();
+        applySettings();
+        if (!_apiAvailable) return Promise.resolve(true); // this browser only, but stored
+        if (_useNewApi) {
+            /* Any debounced save still pending would fire after ours and do
+               nothing but raise the unsaved-changes toast for a blob already on
+               the server. */
+            clearTimeout(_saveTimer);
+            return Promise.resolve(_postThemeSettings(null, 0, true)).then(function (ok) {
+                return !!ok;
+            });
+        }
+        return writeJsonUvar();
     }
 
     /* ── Apply settings to the page ────────────────────────────── */
@@ -4406,6 +4472,9 @@
         loadSettings().then(reconcilePresets).then(function () {
             window.ngLog('[Settings]', 'loaded:', JSON.stringify(_settings));
             applySettings();
+            /* Before the panel work below, which is retried on a timer and can
+               take seconds: a whenReady() caller only needs the values. */
+            _signalReady();
             injectPanel();
             hookOtherTabs();
             hookNativeSaveButton();
@@ -4501,6 +4570,18 @@
     window.dzNightglassSettings = {
         get: function (key) { return _settings ? _settings[key] : DEFAULTS[key]; },
         set: saveSetting,
+        /* Run cb once the stored values are in — immediately if they already
+           are.  Anything that reasons about an *absence* (an empty collection,
+           a missing entry) has to wait for this; get() alone would hand it
+           DEFAULTS and it would act on the wrong picture. */
+        whenReady: function (cb) {
+            if (typeof cb !== 'function') return;
+            if (_readyDone) cb();
+            else _readyCbs.push(cb);
+        },
+        /* set(), but written through to the server now rather than left for the
+           user to save. Returns a promise resolving true on success. */
+        setAndPersist: persistNow,
         reset: function () {
             Object.keys(DEFAULTS).forEach(function (key) {
                 saveSetting(key, DEFAULTS[key]);


### PR DESCRIPTION
This pull request introduces a one-time migration tool to move per-device icon shapes from the theme's storage blob into Domoticz's native `Icon` column, ensuring consistency between device lists and device detail pages. It also improves the reliability and clarity of settings persistence, especially for background or automated changes, and adds infrastructure to signal when settings are ready for use.

Key changes include:

**Device Icon Migration:**

* Added a new module `src/js/icon-migrate.js` that automatically migrates per-device icon shapes from the theme blob to Domoticz's `Icon` column, only if the column exists, and leaves colors and animations in the blob. This ensures device lists and detail pages display the same icon, and only runs once per device.
* Registered the migration script in `custom.js` so it loads with the rest of the application.
* Exposed a `read` method in the device icon store to allow efficient access to device records, supporting the migration process.

**Settings Persistence Improvements:**

* Added a `persistNow` method to immediately write a setting to the server, bypassing the usual "Save to Domoticz" flow, for use by automated processes like the icon migration. It returns a promise indicating success.
* Refactored the settings save logic to return explicit success/failure values for all save operations, and added a `quiet` option to suppress user prompts for background saves. [[1]](diffhunk://#diff-4c429bcf7b75b1da1a36b474c40f59c95987ffdf69e856b954b55c9876cae55bL777-R797) [[2]](diffhunk://#diff-4c429bcf7b75b1da1a36b474c40f59c95987ffdf69e856b954b55c9876cae55bL821-R841) [[3]](diffhunk://#diff-4c429bcf7b75b1da1a36b474c40f59c95987ffdf69e856b954b55c9876cae55bL835-R861) [[4]](diffhunk://#diff-4c429bcf7b75b1da1a36b474c40f59c95987ffdf69e856b954b55c9876cae55bL855-R891) [[5]](diffhunk://#diff-4c429bcf7b75b1da1a36b474c40f59c95987ffdf69e856b954b55c9876cae55bL877-R928)

**Settings Readiness and Local Storage:**

* Implemented a readiness signaling mechanism (`whenReady`) so that consumers can reliably wait for settings to be loaded before acting, avoiding race conditions. [[1]](diffhunk://#diff-4c429bcf7b75b1da1a36b474c40f59c95987ffdf69e856b954b55c9876cae55bR629-R642) [[2]](diffhunk://#diff-4c429bcf7b75b1da1a36b474c40f59c95987ffdf69e856b954b55c9876cae55bR4475-R4477)

**Legacy API Improvements:**

* Updated legacy settings persistence to provide a `writeJsonUvar` function that returns a promise, allowing callers to reliably detect when changes have been saved.

These changes ensure a seamless transition for users to the new icon storage mechanism, improve reliability for automated settings changes, and provide a more robust API for interacting with user settings.