### PR TITLE
Some more icon fixes

### DIFF
--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -384,6 +384,21 @@ i.dz-fa-device.dz-icon-glyph {
     height: 100%;
 }
 
+/* Domoticz sizes the icon host (.dz-icon-40 / .dz-icon-48) and every child it
+   renders itself fills that host (width/height: 100%), so it never has to say how
+   a smaller child should sit. The theme does produce smaller children: an uploaded
+   custom image is shrunk to 30px so it carries the same visual weight as the
+   glyphs beside it. In a block host that child sits in the top-left corner rather
+   than the middle, which is the icon-off-centre report in issue #241.
+
+   Centring the host fixes those without touching anything else: a child that still
+   fills 100% cannot move. */
+dz-device-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
 /* Scene and group buttons carry the size and glyph classes on one element, so
    the adapter's child selector never reaches them and they keep Domoticz's
    28.8px in a 48px frame — noticeably tighter than the 24px the decorated

--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -1151,10 +1151,12 @@ SECTION.dashCategory .row,
 
 
 
-/* Domoticz's Icon style setting adds a glyph of its own beside every navbar image.
-   The theme has already replaced that image, so the native one is suppressed to stop
-   the navbar rendering each icon twice in the glyph style. Hidden rather than removed
-   because Angular re-renders these menus. */
-i.dz-nav-glyph-hidden {
+/* Domoticz's Icon style setting pairs an image with a glyph of its own: navbar images
+   get a .dz-nav-glyph sibling, and the blinds open/stop/close buttons get a
+   .dz-glyph-only one. The theme pins that setting to glyphs and replaces the image
+   itself, so without this both would draw and every such icon would render twice.
+   Only the ones the theme actually replaced are marked, and they are hidden rather
+   than removed because Angular re-renders these nodes. */
+i.dz-native-glyph-hidden {
     display: none !important;
 }

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -1116,20 +1116,26 @@
         img.classList.add('dz-icon-replaced');
         iconMap.set(img, icon);
         img.parentNode.insertBefore(icon, img);
-        hideNativeNavGlyph(img);
+        hideNativeGlyph(img);
         return true;
     }
 
-    /* Domoticz's own "Icon style" setting puts a glyph of its own after each navbar
-       image and shows it instead of the image when the style is set to glyphs. The
-       theme already replaced that image, so both would render and the navbar would
-       show every icon twice. The theme owns the navbar look here, so its glyph is
-       hidden rather than removed — Angular re-renders these menus, and a removed
-       node would just come back. */
-    function hideNativeNavGlyph(img) {
+    /* Domoticz's own "Icon style" setting pairs each image with a glyph of its own and
+       shows the glyph instead of the image when the style is set to glyphs — navbar
+       images get a .dz-nav-glyph sibling, the blinds open/stop/close buttons a
+       .dz-glyph-only one. The theme pins that setting to glyphs and has already
+       replaced the image, so both would draw and the icon would render twice (the
+       doubled roller-shutter chevrons). The theme owns the look here, so the native
+       glyph is hidden rather than removed — Angular re-renders these nodes, and a
+       removed one would just come back.
+
+       Keyed off the sibling the image actually has, so an image the theme skipped
+       keeps Domoticz's glyph and never ends up with no icon at all. */
+    function hideNativeGlyph(img) {
         var next = img.nextElementSibling;
-        if (next && next.tagName === 'I' && next.classList.contains('dz-nav-glyph')) {
-            next.classList.add('dz-nav-glyph-hidden');
+        if (next && next.tagName === 'I' &&
+            (next.classList.contains('dz-nav-glyph') || next.classList.contains('dz-glyph-only'))) {
+            next.classList.add('dz-native-glyph-hidden');
         }
     }
 
@@ -1152,6 +1158,11 @@
 
         if (!curSrc || curSrc === prevSrc || curSrc.indexOf('{{') !== -1) return;
         if (shouldSkip(curSrc)) return;
+
+        /* A blinds button swaps its src on every open/close, and Angular may have
+           rebuilt the paired native glyph along the way, dropping the marker with it.
+           Re-applying here is a no-op when the class is already there. */
+        hideNativeGlyph(img);
 
         /* Resolve icon first so colors are available as fallback for overrides */
         var resolved = resolveIcon(curSrc);


### PR DESCRIPTION
This pull request improves how custom and native glyph icons are handled and centered in the Domoticz UI theme. The changes ensure that custom images are visually aligned with glyphs, and that native glyphs are properly hidden to prevent duplicate icons, especially in dynamic Angular-rendered menus and buttons.

**Icon alignment and centering:**

* Added a CSS rule to center children of the `dz-device-icon` host using flexbox, ensuring that smaller custom images (like uploaded icons) appear centered within their container, fixing off-center icon issues.

**Native glyph hiding and consistency:**

* Updated the CSS class from `dz-nav-glyph-hidden` to `dz-native-glyph-hidden` and improved the selector and comments to clarify that both navbar and blinds button glyphs are hidden only when replaced by the theme, preventing duplicate icon rendering.
* Refactored the JavaScript function from `hideNativeNavGlyph` to `hideNativeGlyph`, expanding its logic to handle both `.dz-nav-glyph` and `.dz-glyph-only` siblings, and updated the class it adds to match the new CSS (`dz-native-glyph-hidden`). Improved comments for clarity.
* Ensured that `hideNativeGlyph` is called whenever a custom icon is applied, including after dynamic changes (such as blinds button state changes), so the native glyph remains hidden even if Angular re-renders the DOM.