### PR TITLE
Give Domoticz's stat bar a track the dark surfaces do not swallow

### DIFF
--- a/src/css/components.css
+++ b/src/css/components.css
@@ -302,6 +302,21 @@
     color: var(--dz-danger) !important;
 }
 
+/* Domoticz draws a value-in-range bar along the bottom of a stat widget: a track
+   with a coloured fill whose width is the value. Its track is
+   rgba(255,255,255,0.1), which all but disappears against the theme's dark
+   surfaces, so only the fill stays visible — and a short fill then reads as a
+   stray coloured stripe sitting under the icon rather than as a partly-filled
+   bar. That is the "blue stripes" in issue #248.
+
+   Giving the track real contrast puts the fill back in context. Two classes so
+   the rule wins on specificity rather than on load order, and the overlay token
+   so the track stays visible in light mode too, where it flips to black. */
+.dd-stat-card .dd-stat-bar {
+    background: rgba(var(--dz-overlay-rgb), 0.14);
+    box-shadow: inset 0 0 0 1px rgba(var(--dz-overlay-rgb), 0.07);
+}
+
 /* GridStack — glass card */
 .grid-stack-item-content {
     background: rgba(var(--dz-surface-rgb), 0.82) !important;


### PR DESCRIPTION
Domoticz draws a value-in-range bar along the bottom of a stat widget: a 7px rounded track with a coloured fill whose width is the value. The track is rgba(255,255,255,0.1), which the theme's dark card surfaces all but swallow, so only the fill stays visible — and a short fill then reads as a stray coloured stripe sitting under the icon rather than as a partly-filled bar. Reported as "blue stripes added to some icons" in issue #248, on exactly the widgets that have ranges configured, which is what makes the bar render at all.

The theme had no rule for this element, so it kept Domoticz's own track.

Two classes so the rule wins on specificity rather than on load order, and the overlay token rather than a literal white so the track stays visible in light mode, where it flips to black.

The widget's background sparkline is deliberately left alone: that curve is wanted, and it is a different element (.dd-widget-spark).