### PR TITLE
Various improvements around the color/rgb/rgbww pickers (dialogs and inline)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ Fine-tune every color with live preview:
 - **Background & Surfaces** - Page background, navbar, cards, surfaces
 - **Borders & Text** - Border colors and text hierarchy
 - **Dual Mode Support** - Separate colors for dark and light modes
+- **Recently Used Colors** - The last 5 colors you picked follow you into every
+  picker in the theme - the settings panel, per-device icon overrides, the RGB /
+  RGBWW light popup and Domoticz's own color fields (bar and gauge ranges,
+  Dashboard 2.0 widget settings) - so matching two devices no longer means
+  copying a hex code around
 
 ### ✨ Per-Device Icon Overrides
 - Assign any Font Awesome 7 icon to individual devices

--- a/custom.js
+++ b/custom.js
@@ -29,6 +29,7 @@
 
     var modules = [
         'src/js/core.js',           /* Ace editor, Highcharts theme, logo, dark/light toggle */
+        'src/js/colors.js',         /* Shared colour kit: recently-used colour list */
         'src/js/icons.js',          /* Font Awesome PNG → icon replacement system */
         'src/js/card-features.js',  /* bigtext, timestamps, moon phase, tilt/temp/glow/flash */
         'src/js/sparklines.js',     /* Feature 7: sparkline micro-charts */

--- a/custom.js
+++ b/custom.js
@@ -37,6 +37,7 @@
         'src/js/icon-studio.js',    /* Icon Studio: full icon picker overlay + custom icon libraries */
         'src/js/device-detail.js',  /* Device detail page: Nightglass icon source + override entry point */
         'src/js/popups.js',         /* Feature 9: popup/modal redesigns */
+        'src/js/inline-picker.js',  /* Nightglass colour control for device/scene/group/timer pages */
         'src/js/toasts.js',         /* Feature 10: live toasts */
         'src/js/icon-migrate.js',   /* One-shot: per-device icon shapes → Domoticz's Icon column */
         'src/js/realtime.js',       /* Feature 11: WebSocket live card updates */

--- a/src/css/components.css
+++ b/src/css/components.css
@@ -1852,6 +1852,81 @@ body.dz-light .dd-toast {
 }
 
 
+/* ── Recently used colours ───────────────────────────────────────
+   One strip, four homes: the settings-panel popover, the icon-override
+   editor, the bar-range dialog and the device RGB/RGBW popup. Built by
+   ngColors.buildRow() in src/js/colors.js, so it has to sit neutrally
+   inside all of them — hence no background of its own, just a hairline
+   above and the surrounding padding.
+   ──────────────────────────────────────────────────────────────── */
+
+.ng-recent {
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px solid var(--dz-border);
+}
+
+.ng-recent-label {
+    display: block;
+    margin-bottom: 7px;
+    font-size: 0.66rem;
+    font-weight: 600;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    color: var(--dz-text-muted);
+}
+
+.ng-recent-swatches {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    min-height: 24px;
+}
+
+.ng-recent-swatch {
+    width: 24px;
+    height: 24px;
+    border-radius: 7px;
+    border: 2px solid transparent !important;
+    padding: 0 !important;
+    cursor: pointer;
+    flex-shrink: 0;
+    box-shadow: inset 0 0 0 1px rgba(var(--dz-overlay-rgb), 0.12);
+    transition: transform 0.15s, border-color 0.15s;
+}
+
+.ng-recent-swatch:hover,
+.ng-recent-swatch:focus-visible {
+    transform: scale(1.15);
+    border-color: rgba(255, 255, 255, 0.55) !important;
+    outline: none;
+}
+
+.ng-recent-empty {
+    font-size: 0.7rem;
+    font-style: italic;
+    color: var(--dz-text-faint);
+}
+
+body.dz-light .ng-recent-swatch:hover,
+body.dz-light .ng-recent-swatch:focus-visible {
+    border-color: var(--dz-accent) !important;
+}
+
+/* Inside the device colour popup the strip is one of several stacked
+   blocks, so it borrows that popup's tighter rhythm. */
+#rgbw_popup .ng-recent {
+    margin-top: 0;
+    margin-bottom: 12px;
+}
+
+/* Nothing to show yet — don't leave a labelled empty band in the
+   compact device popup. */
+#rgbw_popup .ng-recent--empty {
+    display: none;
+}
+
+
 /* ── Reduced motion ──────────────────────────────────────────────── */
 
 @media (prefers-reduced-motion: reduce) {
@@ -1866,6 +1941,9 @@ body.dz-light .dd-toast {
     }
     .dd-page:not(.edit-mode) .grid-stack-item .grid-stack-item-content:hover {
         transform: none;
+    }
+    .ng-recent-swatch {
+        transition: none !important;
     }
 }
 

--- a/src/css/modals.css
+++ b/src/css/modals.css
@@ -422,33 +422,40 @@
         border-radius: 6px !important;
     }
 
-    /* ── jQWCP — jQuery Wheel Color Picker widget ──────────────── */
+    /* ── jQWCP — jQuery Wheel Color Picker widget ──────────────────
+       Deliberately unscoped. Domoticz mounts this widget in three
+       different hosts — #rgbw_popup, #rgbw-picker (device edit, timers)
+       and the scenes page's own table.colorpicker — and the old
+       host-prefixed selectors missed the third one entirely, which is
+       why the scenes picker showed up unthemed. The jQWCP- prefix is
+       unique to the widget, so there is nothing else to collide with.
+
+       inline-picker.js normally replaces all of this with the Nightglass
+       control; these rules are what the widget falls back to if that
+       script cannot mount (no jQuery UI, an unexpected host).
+       ──────────────────────────────────────────────────────────── */
 
     /* Main container */
-    #rgbw_popup .jQWCP-wWidget,
-    #rgbw-picker .jQWCP-wWidget {
+    .jQWCP-wWidget {
         background: transparent !important;
         border: none !important;
         box-shadow: none !important;
     }
 
     /* Color wheel (hue + temperature wheel) */
-    #rgbw_popup .jQWCP-wWheel,
-    #rgbw-picker .jQWCP-wWheel {
+    .jQWCP-wWheel {
         border-radius: 50%;
         box-shadow: 0 0 16px rgba(0, 0, 0, 0.3), inset 0 0 0 1px rgba(var(--dz-overlay-rgb), 0.06);
         background-color: transparent;
     }
 
     /* Wheel overlay (saturation dim layer) */
-    #rgbw_popup .jQWCP-wWheelOverlay,
-    #rgbw-picker .jQWCP-wWheelOverlay {
+    .jQWCP-wWheelOverlay {
         border-radius: 50%;
     }
 
     /* Wheel cursor (the draggable dot on the wheel) */
-    #rgbw_popup .jQWCP-wWheelCursor,
-    #rgbw-picker .jQWCP-wWheelCursor {
+    .jQWCP-wWheelCursor {
         border: 2px solid #fff !important;
         border-radius: 50% !important;
         box-shadow: 0 0 6px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(0, 0, 0, 0.2) !important;
@@ -459,8 +466,7 @@
     }
 
     /* Slider wrappers (Value, Kelvin/Temperature, Master, RGB channels, etc.) */
-    #rgbw_popup .jQWCP-slider-wrapper,
-    #rgbw-picker .jQWCP-slider-wrapper {
+    .jQWCP-slider-wrapper {
         background: var(--dz-surface-2) !important;
         border: 1px solid var(--dz-border) !important;
         border-radius: 8px !important;
@@ -469,31 +475,58 @@
         overflow: hidden;
     }
 
+    /* Domoticz widens the columns to 30px to fit the value box it added
+       under each slider. Our padding and border eat into that, which is
+       what clipped the brightness percentage on the scenes page (#236) —
+       give the column back the room it needs. */
+    .jQWCP-wWidget.jQWCP-hasvalues .jQWCP-slider-wrapper {
+        width: 38px !important;
+        padding: 4px 2px !important;
+        overflow: visible;
+    }
+
+    /* The typed percentage under a slider. Left to the theme's generic
+       input padding it renders "100%" as "10…". */
+    .jQWCP-svalue {
+        box-sizing: border-box !important;
+        width: 100% !important;
+        min-width: 0 !important;
+        padding: 0 1px !important;
+        text-align: center !important;
+        font-size: 10px !important;
+        line-height: 22px !important;
+        background: var(--dz-surface-3) !important;
+        color: var(--dz-text) !important;
+        border: 1px solid var(--dz-border) !important;
+        border-radius: 5px !important;
+    }
+
+    .jQWCP-svalue:focus {
+        border-color: var(--dz-accent) !important;
+        outline: none !important;
+    }
+
     /* Canvas slider bars (the gradient strips) */
-    #rgbw_popup .jQWCP-slider,
-    #rgbw-picker .jQWCP-slider {
+    .jQWCP-slider {
         border-radius: 6px !important;
         cursor: pointer;
     }
 
     /* Slider cursors (small triangular / bar indicator) */
-    #rgbw_popup .jQWCP-scursor,
-    #rgbw-picker .jQWCP-scursor {
+    .jQWCP-scursor {
         border-color: #fff transparent transparent transparent !important;
         filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.4));
     }
 
     /* Preview swatch box */
-    #rgbw_popup .jQWCP-wPreview,
-    #rgbw-picker .jQWCP-wPreview {
+    .jQWCP-wPreview {
         border: 1px solid var(--dz-border) !important;
         border-radius: 8px !important;
         overflow: hidden;
         margin-top: 8px;
     }
 
-    #rgbw_popup .jQWCP-wPreviewBox,
-    #rgbw-picker .jQWCP-wPreviewBox {
+    .jQWCP-wPreviewBox {
         border-radius: 6px !important;
     }
 
@@ -1260,6 +1293,106 @@ body.dz-light .ng-sp-track {
 
 .ng-rgbw-preset--off:hover {
     background: rgba(220, 53, 69, 0.1) !important;
+}
+
+/* ── 9h-6. In-page colour picker ──────────────────────────────────
+   The Nightglass control that src/js/inline-picker.js mounts into
+   Domoticz's #rgbw-picker host — the Light/Switch edit page, the scene
+   and group level editors, and the timer editor. Domoticz's own jQWCP
+   widget stays underneath as the engine, parked off-screen.
+   ──────────────────────────────────────────────────────────────── */
+
+.ng-ip-panel {
+    width: 264px;
+    max-width: 100%;
+    padding: 14px;
+    background: var(--dz-surface-2);
+    border: 1px solid var(--dz-border);
+    border-radius: 16px;
+    color: var(--dz-text);
+}
+
+/* Domoticz's mode icon strip and hex row are replaced by our tabs and
+   hex field; the widget itself has to stay alive, so it is moved out of
+   sight rather than switched off. */
+.ng-ip-host #ColorMode,
+.ng-ip-host .pickerrgbcolorrow {
+    display: none !important;
+}
+
+.ng-ip-host .ng-ip-engine-cell {
+    position: relative;
+    height: 0;
+    padding: 0 !important;
+    overflow: hidden;
+}
+
+.ng-ip-host .ng-ip-engine {
+    position: absolute;
+    left: -99999px;
+    top: 0;
+    width: 240px;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.ng-ip-panel .ng-rgbw-pane {
+    margin-bottom: 4px;
+}
+
+.ng-ip-panel .ng-rgbw-slider-row:last-child {
+    margin-bottom: 0;
+}
+
+.ng-ip-wheel {
+    display: block;
+    border-radius: 50%;
+    touch-action: none;
+    cursor: crosshair;
+}
+
+.ng-ip-warmth {
+    display: block;
+    border-radius: 18px;
+    touch-action: none;
+    cursor: crosshair;
+    max-width: 100%;
+}
+
+.ng-ip-panel .ng-recent {
+    margin-top: 0;
+    margin-bottom: 12px;
+}
+
+/* Nothing picked yet — don't leave a labelled empty band in a control
+   that is already competing for room on a crowded settings page. */
+.ng-ip-panel .ng-recent--empty {
+    display: none;
+}
+
+.ng-ip-note {
+    display: flex;
+    align-items: flex-start;
+    gap: 7px;
+    margin-bottom: 12px;
+    padding: 9px 11px;
+    border-radius: 10px;
+    background: var(--dz-surface-3);
+    border: 1px solid var(--dz-border);
+    color: var(--dz-text-muted);
+    font-size: 0.74rem;
+    line-height: 1.45;
+}
+
+.ng-ip-note i {
+    margin-top: 2px;
+    color: var(--dz-accent);
+}
+
+@media (max-width: 520px) {
+    .ng-ip-panel {
+        width: 100%;
+    }
 }
 
 /* ── 9i. Tips of the Day modal ────────────────────────────────── */

--- a/src/css/modals.css
+++ b/src/css/modals.css
@@ -1492,8 +1492,10 @@ body.dz-light .ng-sp-track {
     box-shadow: 0 0 0 2px rgba(var(--dz-accent-rgb), 0.18) !important;
 }
 
-/* Hide native color input — JS swaps it for a themed swatch trigger */
-.dd-range-color-picker {
+/* Hide native colour inputs the JS has actually swapped for a themed swatch
+   trigger. Keyed off the marker attribute rather than the class so a field
+   the script never reached keeps its working native picker. */
+input[type="color"][data-ng-rcp] {
     display: none !important;
 }
 

--- a/src/css/modals.css
+++ b/src/css/modals.css
@@ -1170,24 +1170,28 @@ body.dz-light .ng-sp-track {
     padding-left: 0 !important;
 }
 
-/* Brightness slider row */
+/* Brightness slider row. Tighter gaps than the other rows: it carries two
+   icons, a slider and the percentage field, and the popup is only 260px. */
 .ng-rgbw-slider-row {
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: 8px;
     margin-bottom: 14px;
+    max-width: 100%;
 }
 
 /* Type the percentage instead of chasing it with the slider */
 .ng-rgbw-bright-field {
     display: inline-flex;
     align-items: center;
+    justify-content: flex-end;
     gap: 1px;
-    flex-shrink: 0;
+    flex: 0 0 auto;
+    box-sizing: border-box;
     background: var(--dz-surface-2);
     border: 1px solid var(--dz-border);
     border-radius: 7px;
-    padding: 3px 7px;
+    padding: 3px 5px;
     transition: border-color 0.15s, box-shadow 0.15s;
 }
 
@@ -1197,8 +1201,13 @@ body.dz-light .ng-sp-track {
 }
 
 .ng-rgbw-bright-input {
-    width: 2.4em;
+    /* Wide enough for "100" in the monospace face, and no wider — the row
+       has an icon, a slider and another icon to fit alongside it. */
+    width: 2.2em;
+    min-width: 0;
+    flex: 0 0 auto;
     padding: 0 !important;
+    margin: 0 !important;
     border: none !important;
     background: none !important;
     color: var(--dz-text) !important;
@@ -1227,7 +1236,11 @@ body.dz-light .ng-sp-track {
 }
 
 .ng-rgbw-slider {
-    flex: 1;
+    flex: 1 1 0;
+    /* A flex item's min-width defaults to its intrinsic size, and a range
+       input's is wide enough (~170px) to push the percentage field out past
+       the picker's edge. Let it actually shrink. */
+    min-width: 0;
     -webkit-appearance: none;
     appearance: none;
     height: 5px;
@@ -1320,20 +1333,22 @@ body.dz-light .ng-sp-track {
     display: none !important;
 }
 
+/* The widget stays alive as the engine, just out of sight. Parked by rule
+   rather than by moving nodes or tagging the element: refreshWidget()
+   re-appends its wheels and sliders onto .jQWCP-wWidget on every mode
+   change, and resets that element's class attribute while it is at it. */
+.ng-ip-host .jQWCP-wWidget {
+    position: absolute !important;
+    left: -99999px !important;
+    top: 0 !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+}
+
 .ng-ip-host .ng-ip-engine-cell {
     position: relative;
     height: 0;
     padding: 0 !important;
-    overflow: hidden;
-}
-
-.ng-ip-host .ng-ip-engine {
-    position: absolute;
-    left: -99999px;
-    top: 0;
-    width: 240px;
-    opacity: 0;
-    pointer-events: none;
 }
 
 .ng-ip-panel .ng-rgbw-pane {

--- a/src/css/modals.css
+++ b/src/css/modals.css
@@ -1104,11 +1104,37 @@ body.dz-light .ng-sp-track {
     transition: background 0.1s;
 }
 
+/* Editable hex field. Goes read-only in white mode, where the value on show
+   is a colour-temperature name rather than something you can type. */
 .ng-rgbw-hex {
+    flex: 1;
+    min-width: 0;
     font-size: 0.78rem;
     font-family: monospace;
-    color: var(--dz-text-muted);
+    color: var(--dz-text) !important;
     letter-spacing: 0.03em;
+    background: var(--dz-surface-2) !important;
+    border: 1px solid var(--dz-border) !important;
+    border-radius: 7px !important;
+    padding: 5px 9px !important;
+    transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.ng-rgbw-hex:focus {
+    border-color: var(--dz-accent) !important;
+    outline: none !important;
+    box-shadow: 0 0 0 2px rgba(var(--dz-accent-rgb), 0.18) !important;
+}
+
+.ng-rgbw-hex[readonly] {
+    color: var(--dz-text-muted) !important;
+    background: transparent !important;
+    border-color: transparent !important;
+    box-shadow: none !important;
+    cursor: default;
+    font-family: inherit;
+    letter-spacing: normal;
+    padding-left: 0 !important;
 }
 
 /* Brightness slider row */
@@ -1117,6 +1143,42 @@ body.dz-light .ng-sp-track {
     align-items: center;
     gap: 10px;
     margin-bottom: 14px;
+}
+
+/* Type the percentage instead of chasing it with the slider */
+.ng-rgbw-bright-field {
+    display: inline-flex;
+    align-items: center;
+    gap: 1px;
+    flex-shrink: 0;
+    background: var(--dz-surface-2);
+    border: 1px solid var(--dz-border);
+    border-radius: 7px;
+    padding: 3px 7px;
+    transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.ng-rgbw-bright-field:focus-within {
+    border-color: var(--dz-accent);
+    box-shadow: 0 0 0 2px rgba(var(--dz-accent-rgb), 0.18);
+}
+
+.ng-rgbw-bright-input {
+    width: 2.4em;
+    padding: 0 !important;
+    border: none !important;
+    background: none !important;
+    color: var(--dz-text) !important;
+    font-size: 0.78rem;
+    font-family: monospace;
+    text-align: right;
+    outline: none !important;
+    box-shadow: none !important;
+}
+
+.ng-rgbw-bright-unit {
+    font-size: 0.72rem;
+    color: var(--dz-text-muted);
 }
 
 .ng-rgbw-icon-dim {

--- a/src/js/colors.js
+++ b/src/js/colors.js
@@ -1,0 +1,152 @@
+/*
+ *  Nightglass — shared colour kit
+ *
+ *  Every colour picker in the theme (the bar-range dialog, the device
+ *  RGB/RGBW popup, the settings panel, the per-device icon override
+ *  editor) feeds one "recently used" list, so a colour tuned on one
+ *  device is a single click away on the next instead of a hex string to
+ *  copy across.
+ *
+ *  The list is per browser (localStorage) rather than a Domoticz user
+ *  variable: it changes on nearly every drag, and it is a convenience
+ *  rather than a setting worth syncing.
+ *
+ *  window.ngColors
+ *      .normalize(v)   → '#rrggbb' | null   (accepts #abc, ABC, #AABBCC)
+ *      .recent()       → array, newest first, at most MAX entries
+ *      .remember(hex)  → record a colour the user actually committed to
+ *      .onChange(fn)   → subscribe; returns an unsubscribe function
+ *      .buildRow(opts) → a ready-made, self-updating swatch strip
+ */
+(function () {
+    'use strict';
+
+    var STORAGE_KEY = 'ng-recent-colors';
+    var MAX = 5;
+
+    var _listeners = [];
+
+    function normalize(v) {
+        if (typeof v !== 'string') return null;
+        var hex = v.trim().replace(/^#/, '');
+        if (hex.length === 3) hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+        if (!/^[0-9a-f]{6}$/i.test(hex)) return null;
+        return '#' + hex.toLowerCase();
+    }
+
+    function load() {
+        var raw = null;
+        try { raw = JSON.parse(localStorage.getItem(STORAGE_KEY)); } catch (e) {}
+        if (!Array.isArray(raw)) return [];
+        var out = [];
+        raw.forEach(function (c) {
+            var hex = normalize(c);
+            if (hex && out.indexOf(hex) === -1) out.push(hex);
+        });
+        return out.slice(0, MAX);
+    }
+
+    var _list = load();
+
+    function save() {
+        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(_list)); } catch (e) {}
+    }
+
+    /* Fan out to subscribers, dropping those whose row has been torn down
+       with the dialog that owned it.  `seen` guards rows that were built
+       detached and are appended a moment later. */
+    function notify() {
+        var snapshot = _list.slice();
+        _listeners = _listeners.filter(function (l) {
+            if (l.el) {
+                var attached = document.contains(l.el);
+                if (l.seen && !attached) return false;
+                if (attached) l.seen = true;
+            }
+            try { l.fn(snapshot); } catch (e) {}
+            return true;
+        });
+    }
+
+    function remember(color) {
+        var hex = normalize(color);
+        if (!hex) return;
+        var at = _list.indexOf(hex);
+        if (at === 0) return;               /* already the newest — nothing moved */
+        if (at !== -1) _list.splice(at, 1);
+        _list.unshift(hex);
+        _list = _list.slice(0, MAX);
+        save();
+        notify();
+    }
+
+    function onChange(fn, el) {
+        var entry = { fn: fn, el: el || null, seen: false };
+        _listeners.push(entry);
+        return function off() {
+            var i = _listeners.indexOf(entry);
+            if (i !== -1) _listeners.splice(i, 1);
+        };
+    }
+
+    /* A label plus up to MAX swatch buttons, re-rendering itself whenever
+       the list changes so several pickers can be open at once.
+         opts.onPick(hex)  — required to be useful; fired on click
+         opts.label        — heading text, default "Recent"
+         opts.emptyText    — placeholder while nothing has been picked yet
+         opts.className    — extra class for context-specific spacing      */
+    function buildRow(opts) {
+        opts = opts || {};
+
+        var row = document.createElement('div');
+        row.className = 'ng-recent' + (opts.className ? ' ' + opts.className : '');
+
+        var label = document.createElement('span');
+        label.className = 'ng-recent-label';
+        label.textContent = opts.label || 'Recent';
+        row.appendChild(label);
+
+        var strip = document.createElement('div');
+        strip.className = 'ng-recent-swatches';
+        row.appendChild(strip);
+
+        function render(list) {
+            strip.textContent = '';
+            row.classList.toggle('ng-recent--empty', !list.length);
+            if (!list.length) {
+                var empty = document.createElement('span');
+                empty.className = 'ng-recent-empty';
+                empty.textContent = opts.emptyText || 'Colours you pick show up here';
+                strip.appendChild(empty);
+                return;
+            }
+            list.forEach(function (hex) {
+                var btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = 'ng-recent-swatch';
+                btn.style.background = hex;
+                btn.title = hex;
+                btn.setAttribute('data-color', hex);
+                btn.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (opts.onPick) opts.onPick(hex);
+                });
+                strip.appendChild(btn);
+            });
+        }
+
+        render(_list.slice());
+        onChange(render, row);
+        return row;
+    }
+
+    window.ngColors = {
+        MAX: MAX,
+        normalize: normalize,
+        recent: function () { return _list.slice(); },
+        remember: remember,
+        onChange: onChange,
+        buildRow: buildRow
+    };
+}());

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -394,3 +394,57 @@ window.ngLog = function (prefix) {
     args.unshift(prefix);
     console.log.apply(console, args);
 };
+
+
+/* ── Shared jQuery UI dialog focus relaxation ────────────────────
+   Domoticz opens its device dialogs (Utility "edit device", timers,
+   the bar-range editor's host form, …) as jQuery UI dialogs with
+   modal: true, which install a document-wide focusin trap.  jQuery UI
+   1.12's _allowInteraction() only accepts focus inside .ui-dialog /
+   .ui-datepicker and drags it back out otherwise, so a Nightglass
+   overlay parked on <body> — the Icon Studio (#230), the range colour
+   picker (#253) — cannot focus its own text fields.  Pressing Escape
+   appeared to "unlock" them only because it closed the dialog and took
+   the trap with it.
+
+   ngRelaxDialogFocus(selector) teaches every currently open dialog to
+   treat matching elements as legitimate and returns an undo function.
+   Live instances are patched rather than the widget prototype, so
+   nothing global is monkey-patched and dialogs created before this
+   script ran are covered too.  The wrapper reads a live selector list,
+   so overlapping overlays may register and unregister in any order.
+─────────────────────────────────────────────────────────────────── */
+window.ngRelaxDialogFocus = function (selector) {
+    var noop = function () {};
+    var $ = window.jQuery;
+    if (!$ || !$.fn || !$.fn.jquery || !selector) return noop;
+
+    var patched = [];
+    try {
+        $('.ui-dialog-content').each(function () {
+            var inst = $(this).data('uiDialog') || $(this).data('dialog');
+            if (!inst || typeof inst._allowInteraction !== 'function') return;
+            if (!inst._ngRelaxSelectors) {
+                inst._ngRelaxSelectors = [];
+                var orig = inst._allowInteraction;
+                inst._allowInteraction = function (event) {
+                    var sels = inst._ngRelaxSelectors;
+                    for (var i = 0; i < sels.length; i++) {
+                        if ($(event.target).closest(sels[i]).length) return true;
+                    }
+                    return orig.call(this, event);
+                };
+            }
+            inst._ngRelaxSelectors.push(selector);
+            patched.push(inst);
+        });
+    } catch (e) { /* no jQuery UI, or a dialog mid-teardown */ }
+
+    return function restore() {
+        patched.forEach(function (inst) {
+            var i = inst._ngRelaxSelectors ? inst._ngRelaxSelectors.indexOf(selector) : -1;
+            if (i !== -1) inst._ngRelaxSelectors.splice(i, 1);
+        });
+        patched = [];
+    };
+};

--- a/src/js/events-editor.js
+++ b/src/js/events-editor.js
@@ -642,6 +642,7 @@
     var _h = 210, _s = 0.6, _v = 1.0, _curX = 0, _curY = 0;
     var _target = null, _dragging = false;
     var _wheelCache = null, _wheelCacheV = -1;
+    var _restoreDialogFocus = null, _keyHandler = null;
 
     // ── overlay DOM (built once) ──────────────────────────────────────────
 
@@ -699,6 +700,13 @@
         preview.appendChild(_swatch); preview.appendChild(_hexInput);
         popup.appendChild(preview);
 
+        // recently used colours — shared with every other picker in the theme
+        if (window.ngColors) {
+            popup.appendChild(window.ngColors.buildRow({
+                onPick: function (hex) { applyHex(hex, true); }
+            }));
+        }
+
         // action buttons
         var actions = document.createElement('div');
         actions.className = 'ng-rcp-actions';
@@ -746,20 +754,27 @@
             });
         });
 
-        // hex input
-        _hexInput.addEventListener('input', function () {
-            var rgb = hexToRgb(this.value);
-            if (!rgb) return;
-            var hsv = rgbToHsv(rgb[0], rgb[1], rgb[2]);
-            _h = hsv[0]; _s = hsv[1]; _v = hsv[2];
-            _slider.value = Math.round(_v * 100);
-            updateCursorFromHsv();
-            redraw(); updateSwatch();
-        });
+        // hex input — don't rewrite the field while it is being typed into,
+        // that would move the caret out from under the user
+        _hexInput.addEventListener('input', function () { applyHex(this.value, false); });
         _hexInput.addEventListener('blur', function () {
             var rgb = hexToRgb(this.value);
             if (rgb) this.value = rgbToHex(rgb[0], rgb[1], rgb[2]);
         });
+    }
+
+    /* Drive the whole dialog from a hex string. syncInput controls whether the
+       hex field itself is rewritten (wanted for a recent-swatch click, not
+       while typing). */
+    function applyHex(hex, syncInput) {
+        var rgb = hexToRgb(hex);
+        if (!rgb) return;
+        var hsv = rgbToHsv(rgb[0], rgb[1], rgb[2]);
+        _h = hsv[0]; _s = hsv[1]; _v = hsv[2];
+        _slider.value = Math.round(_v * 100);
+        if (syncInput) _hexInput.value = rgbToHex(rgb[0], rgb[1], rgb[2]);
+        updateCursorFromHsv();
+        redraw(); updateSwatch();
     }
 
     function pick(e) {
@@ -805,10 +820,43 @@
         updateCursorFromHsv();
         redraw(); syncFromHsv();
         _overlay.classList.add('ng-rcp-overlay--open');
+
+        /* #253: the bar-range editor is a Bootstrap modal opened from inside
+           one of Domoticz's jQuery UI modal dialogs, whose focusin trap would
+           otherwise pull focus straight back out of our hex field — leaving it
+           editable only after Escape had closed the dialog (and the edit). */
+        if (!_restoreDialogFocus && window.ngRelaxDialogFocus) {
+            _restoreDialogFocus = window.ngRelaxDialogFocus('#ng-rcp-overlay');
+        }
+
+        /* Escape must dismiss the picker only. Both the Bootstrap modal and the
+           jQuery UI dialog underneath close on Escape as well, so swallow it
+           here rather than let it reach either of them. */
+        if (!_keyHandler) {
+            _keyHandler = function (e) {
+                var key = e.key || e.keyCode;
+                if (key === 'Escape' || key === 'Esc' || key === 27) {
+                    e.preventDefault(); e.stopPropagation();
+                    closeOverlay();
+                } else if ((key === 'Enter' || key === 13) && document.activeElement === _hexInput) {
+                    e.preventDefault(); e.stopPropagation();
+                    commitAndClose();
+                }
+            };
+            document.addEventListener('keydown', _keyHandler, true);
+        }
     }
 
     function closeOverlay() {
         if (_overlay) _overlay.classList.remove('ng-rcp-overlay--open');
+        if (_keyHandler) {
+            document.removeEventListener('keydown', _keyHandler, true);
+            _keyHandler = null;
+        }
+        if (_restoreDialogFocus) {
+            _restoreDialogFocus();
+            _restoreDialogFocus = null;
+        }
         _target = null;
     }
 
@@ -820,16 +868,26 @@
             _target.dispatchEvent(new Event('input',  { bubbles: true }));
             _target.dispatchEvent(new Event('change', { bubbles: true }));
             if (_target._ngRcpTrigger) _target._ngRcpTrigger.style.background = hex;
+            if (window.ngColors) window.ngColors.remember(hex);
         }
         closeOverlay();
     }
 
     // ── inject swatch triggers ────────────────────────────────────────────
 
+    /* Every native colour input Domoticz renders — bar/gauge ranges, the
+       Dashboard 2.0 widget settings colour fields — gets the themed dialog
+       instead of the OS picker, so they all share one look and one recent
+       list. Only inputs we successfully replaced are hidden (the CSS keys off
+       data-ng-rcp), so a failure here leaves the native control usable. */
+    var _hasTriggers = false;
+
     function injectTriggers() {
-        var inputs = document.querySelectorAll('.dd-range-color-picker:not([data-ng-rcp])');
+        var inputs = document.querySelectorAll('input[type="color"]:not([data-ng-rcp])');
         inputs.forEach(function (input) {
+            if (!input.parentNode) return;
             input.setAttribute('data-ng-rcp', '1');
+            _hasTriggers = true;
             var btn = document.createElement('button');
             btn.type = 'button';
             btn.className = 'ng-rcp-trigger';
@@ -837,15 +895,37 @@
             btn.style.background = input.value || '#4e9af1';
             btn.addEventListener('click', function (e) {
                 e.stopPropagation();
+                e.preventDefault();
                 openOverlay(input);
             });
             input._ngRcpTrigger = btn;
             input.parentNode.insertBefore(btn, input);
         });
+        syncTriggers();
+    }
+
+    /* ng-model writes the model value into the input after the element is in
+       the DOM, and does it silently — no change event to listen for. Re-read
+       the inputs on every pass instead so each swatch converges on the colour
+       its field actually holds. */
+    function syncTriggers() {
+        /* The observer fires on every DOM change Domoticz makes; skip the
+           query outright on the pages that have no colour fields at all. */
+        if (!_hasTriggers) return;
+        document.querySelectorAll('input[type="color"][data-ng-rcp]').forEach(function (input) {
+            if (input._ngRcpTrigger) {
+                input._ngRcpTrigger.style.background = input.value || '#4e9af1';
+            }
+        });
     }
 
     new MutationObserver(function (muts) {
-        if (muts.some(function (m) { return m.addedNodes.length > 0; })) injectTriggers();
+        if (muts.some(function (m) { return m.addedNodes.length > 0; })) {
+            injectTriggers();
+            /* One more pass once the digest that inserted the field has
+               finished writing values into it. */
+            setTimeout(syncTriggers, 0);
+        }
     }).observe(document.body, { childList: true, subtree: true });
 
     if (document.readyState !== 'loading') {

--- a/src/js/icon-studio.js
+++ b/src/js/icon-studio.js
@@ -629,44 +629,21 @@
 
     /* ── Overlay ──────────────────────────────────────────────────── */
     var _overlay = null;
-    var _relaxedDialogs = [];
+    var _restoreDialogFocus = null;
     var _escHandler = null;
 
-    /* jQuery UI modal dialogs (Domoticz's Utility "edit device" dialogs use
-       modal: true) install a document-wide focusin trap. jQuery UI 1.12's
-       _allowInteraction() only permits focus inside .ui-dialog / .ui-datepicker
-       and drags it back otherwise — so our overlay, which lives on <body>,
-       could not focus its own search box. Pressing Escape closed the dialog,
-       removing the trap, which is why the field then became usable (#230).
-
-       Teach any OPEN dialog to treat our overlay as legitimate, per instance so
-       nothing global is monkey-patched, and undo it when we close. Doing this
-       on the live instances (rather than the widget prototype) also works when
-       the dialog was created before this module loaded. */
+    /* Without this the overlay's search box cannot take focus while one of
+       Domoticz's jQuery UI modal dialogs is open (#230) — see
+       ngRelaxDialogFocus in core.js for the why. */
     function relaxOpenModalDialogs() {
-        var $ = window.jQuery;
-        if (!$ || !$.fn || !$.fn.jquery) return;
-        try {
-            $('.ui-dialog-content').each(function () {
-                var inst = $(this).data('uiDialog') || $(this).data('dialog');
-                if (!inst || typeof inst._allowInteraction !== 'function') return;
-                if (inst._ngIsRelaxed) return;
-                var orig = inst._allowInteraction;
-                inst._allowInteraction = function (event) {
-                    if ($(event.target).closest('.ng-is-overlay').length) return true;
-                    return orig.call(this, event);
-                };
-                inst._ngIsRelaxed = true;
-                _relaxedDialogs.push({ inst: inst, orig: orig });
-            });
-        } catch (e) {}
+        if (_restoreDialogFocus || !window.ngRelaxDialogFocus) return;
+        _restoreDialogFocus = window.ngRelaxDialogFocus('.ng-is-overlay');
     }
 
     function restoreRelaxedDialogs() {
-        _relaxedDialogs.forEach(function (r) {
-            try { r.inst._allowInteraction = r.orig; delete r.inst._ngIsRelaxed; } catch (e) {}
-        });
-        _relaxedDialogs = [];
+        if (!_restoreDialogFocus) return;
+        _restoreDialogFocus();
+        _restoreDialogFocus = null;
     }
 
     function close() {

--- a/src/js/inline-picker.js
+++ b/src/js/inline-picker.js
@@ -565,15 +565,19 @@
         _modes = modes;
         _sig = sig;
 
-        /* Park Domoticz's widget off-screen rather than display:none — it
-           stays the engine, and its canvases keep real dimensions. */
-        var cell = engine.parentNode;
-        if (cell && !cell.classList.contains('ng-ip-engine-cell')) {
-            cell.classList.add('ng-ip-engine-cell');
-            var sink = el('div', 'ng-ip-engine');
-            while (cell.firstChild) sink.appendChild(cell.firstChild);
-            cell.appendChild(sink);
-        }
+        /* Park Domoticz's widget off-screen rather than display:none — it stays
+           the engine, and its canvases keep real dimensions.
+
+           The parking itself is done in CSS, keyed on .ng-ip-host, because
+           jQWCP fights both alternatives: refreshWidget() re-appends every
+           active wheel and slider straight onto .jQWCP-wWidget (so anything
+           we move into a wrapper comes straight back out, redrawn below our
+           panel), and it opens by resetting the widget's class attribute
+           outright (so a marker class we add does not survive a mode change).
+           A rule aimed at the widget element outlives both. */
+        var widget = engine.closest ? engine.closest('.jQWCP-wWidget') : null;
+        var cell = (widget && widget.parentNode) || engine.parentNode;
+        if (cell && cell.classList) cell.classList.add('ng-ip-engine-cell');
 
         (table || host).classList.add('ng-ip-host');
 

--- a/src/js/inline-picker.js
+++ b/src/js/inline-picker.js
@@ -1,0 +1,609 @@
+/*
+ *  Nightglass — in-page colour picker
+ *
+ *  Domoticz builds its colour control with ShowRGBWPicker(selector, …),
+ *  which drops a jQWCP wheel widget into a host table. Four places use it:
+ *  the Light/Switch edit page (device-color-settings), the scene and group
+ *  level editors, and the timer editor. Only the device-card popup
+ *  (#rgbw_popup) ever got a Nightglass rewrite — these hosts were left
+ *  wearing Domoticz's widget with our CSS painted over it.
+ *
+ *  Rather than reimplement mode selection, the colour JSON, the debounce
+ *  and each host's change callback, this keeps jQWCP as the engine and
+ *  parks it off-screen. Our controls write into it and fire the
+ *  'slidermove'/'sliderup' pair Domoticz already listens for, so every
+ *  host keeps behaving exactly as Domoticz intends — the timer editor
+ *  still stages a value, the device page still commands the light.
+ */
+(function () {
+    'use strict';
+
+    var WSIZE = 200;                 /* wheel canvas, matches the popup   */
+    var WR    = WSIZE / 2;
+    var COMMIT_THROTTLE = 120;       /* ms; Domoticz debounces 400 on top */
+
+    /* ── Colour maths ─────────────────────────────────────────────── */
+
+    function hsvToRgb(h, s, v) {
+        var r, g, b, i = Math.floor(h * 6), f = h * 6 - i;
+        var p = v*(1-s), q = v*(1-f*s), t = v*(1-(1-f)*s);
+        switch (i % 6) {
+            case 0: r=v; g=t; b=p; break; case 1: r=q; g=v; b=p; break;
+            case 2: r=p; g=v; b=t; break; case 3: r=p; g=q; b=v; break;
+            case 4: r=t; g=p; b=v; break; default: r=v; g=p; b=q;
+        }
+        return { r: Math.round(r*255), g: Math.round(g*255), b: Math.round(b*255) };
+    }
+
+    function rgbToHsv(r, g, b) {
+        r/=255; g/=255; b/=255;
+        var max=Math.max(r,g,b), min=Math.min(r,g,b), d=max-min;
+        var h, s = max===0 ? 0 : d/max, v = max;
+        if (max === min) { h = 0; }
+        else {
+            switch (max) {
+                case r: h=((g-b)/d+(g<b?6:0))/6; break;
+                case g: h=((b-r)/d+2)/6; break;
+                default: h=((r-g)/d+4)/6;
+            }
+        }
+        return { h: h, s: s, v: v };
+    }
+
+    function warmthToRgb(w) {
+        return {
+            r: Math.round(232 + (255-232)*w),
+            g: Math.round(244 + (179-244)*w),
+            b: Math.round(253 + (71-253)*w)
+        };
+    }
+
+    function toHex(n) { return ('0' + n.toString(16)).slice(-2); }
+
+    function parseHex(v) {
+        var hex = String(v == null ? '' : v).trim().replace(/^#/, '');
+        if (hex.length === 3) hex = hex[0]+hex[0]+hex[1]+hex[1]+hex[2]+hex[2];
+        if (!/^[0-9a-f]{6}$/i.test(hex)) return null;
+        var n = parseInt(hex, 16);
+        return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+    }
+
+    /* ── State (one host exists at a time — the selector is hardcoded
+          to '#rgbw-picker' inside Domoticz's component) ────────────── */
+
+    var _host = null, _engine = null, _panel = null, _sig = '';
+    var _modes = [], _mode = 'color';
+    var _hasTemp = false, _isRel = false;
+    var _h = 0, _s = 1, _warmth = 0.5, _white = 1, _bright = 100;
+    var _els = {};
+    var _commitTimer = 0, _commitPending = false;
+
+    function $$() { return window.jQuery; }
+
+    /* ── Engine bridge ────────────────────────────────────────────── */
+
+    /* colorPickerMode is private to ShowRGBWPicker, but getJSONColor()
+       reports it through the mode field of the JSON it builds. */
+    function readMode() {
+        var m = null;
+        try { m = JSON.parse(_engine.getJSONColor()).m; } catch (e) { /* see below */ }
+        if (m === 1) return 'white';
+        if (m === 2) return 'temperature';
+        if (m === 3) return 'color';
+        if (m === 4) return 'custom';
+        /* Relative dimmers put Domoticz in a "…_no_master" mode, for which
+           getJSONColor returns nothing at all. Keep what we had. */
+        return hasMode(_mode) ? _mode : (_modes[0] ? _modes[0].id : 'color');
+    }
+
+    function hasMode(id) {
+        return _modes.some(function (m) { return m.id === id; });
+    }
+
+    function syncFromEngine() {
+        var c;
+        try { c = $$()(_engine).wheelColorPicker('getColor'); } catch (e) { return; }
+        if (!c) return;
+        _h = c.h || 0;
+        _s = (c.s == null) ? 1 : c.s;
+        _warmth = (c.t == null) ? 0.5 : c.t;
+        _white = (c.w == null) ? 1 : c.w;
+        _bright = Math.max(1, Math.min(100, Math.round((c.m == null ? 1 : c.m) * 100)));
+        _mode = readMode();
+    }
+
+    /* Push our state into jQWCP and fire the events Domoticz bound to it.
+       Everything downstream — the colour JSON, the 400ms debounce, the
+       per-host callback — stays Domoticz's own code. */
+    function commitNow() {
+        _commitPending = false;
+        try {
+            var $inp = $$()(_engine);
+            $inp.wheelColorPicker('setHsv', _h, _s, 1);
+            if (_hasTemp) $inp.wheelColorPicker('setTemperature', _warmth);
+            $inp.wheelColorPicker('setWhite', _white);
+            if (!_isRel) $inp.wheelColorPicker('setMaster', _bright / 100);
+            $inp.trigger('slidermove');
+            $inp.trigger('sliderup');
+        } catch (e) {
+            if (window.ngLog) window.ngLog('[ng-picker]', 'commit failed', e);
+            return;
+        }
+        if (window.ngColors && (_mode === 'color' || _mode === 'custom')) {
+            window.ngColors.remember(currentHex());
+        }
+    }
+
+    /* Dragging the wheel fires continuously; Domoticz debounces the send
+       but still rebuilds the JSON each time, so throttle on our side. */
+    function commit() {
+        if (_commitTimer) { _commitPending = true; return; }
+        commitNow();
+        _commitTimer = setTimeout(function () {
+            _commitTimer = 0;
+            if (_commitPending) commit();
+        }, COMMIT_THROTTLE);
+    }
+
+    /* ── Drawing ──────────────────────────────────────────────────── */
+
+    function drawWheel(canvas) {
+        var ctx = canvas.getContext('2d');
+        var img = ctx.createImageData(WSIZE, WSIZE);
+        var d = img.data;
+        for (var y = 0; y < WSIZE; y++) {
+            for (var x = 0; x < WSIZE; x++) {
+                var dx = x - WR, dy = y - WR, dist = Math.sqrt(dx*dx + dy*dy);
+                var i4 = (y*WSIZE + x) * 4;
+                if (dist > WR) { d[i4+3] = 0; continue; }
+                var rgb = hsvToRgb(((Math.atan2(dy, dx) / (2*Math.PI)) + 1) % 1, dist / WR, 1);
+                d[i4] = rgb.r; d[i4+1] = rgb.g; d[i4+2] = rgb.b; d[i4+3] = 255;
+            }
+        }
+        ctx.putImageData(img, 0, 0);
+
+        var angle = _h * 2 * Math.PI, rad = _s * (WR - 6);
+        var cx = WR + rad * Math.cos(angle), cy = WR + rad * Math.sin(angle);
+        var cur = hsvToRgb(_h, _s, 1);
+        ctx.beginPath(); ctx.arc(cx, cy, 9, 0, 2*Math.PI);
+        ctx.fillStyle = 'rgb('+cur.r+','+cur.g+','+cur.b+')'; ctx.fill();
+        ctx.strokeStyle = '#ffffff'; ctx.lineWidth = 2.5; ctx.stroke();
+        ctx.beginPath(); ctx.arc(cx, cy, 11, 0, 2*Math.PI);
+        ctx.strokeStyle = 'rgba(0,0,0,0.3)'; ctx.lineWidth = 1; ctx.stroke();
+    }
+
+    function drawWarmth(canvas) {
+        var ctx = canvas.getContext('2d');
+        var g = ctx.createLinearGradient(0, 0, canvas.width, 0);
+        g.addColorStop(0,   '#E8F4FD');
+        g.addColorStop(0.5, '#FFF5E0');
+        g.addColorStop(1,   '#FFB347');
+        ctx.fillStyle = g;
+        ctx.beginPath();
+        if (ctx.roundRect) ctx.roundRect(0, 0, canvas.width, canvas.height, 16);
+        else ctx.rect(0, 0, canvas.width, canvas.height);
+        ctx.fill();
+
+        var x = _warmth * (canvas.width - 1);
+        var rgb = warmthToRgb(_warmth);
+        ctx.beginPath(); ctx.arc(x, canvas.height/2, 12, 0, 2*Math.PI);
+        ctx.fillStyle = 'rgb('+rgb.r+','+rgb.g+','+rgb.b+')'; ctx.fill();
+        ctx.strokeStyle = '#ffffff'; ctx.lineWidth = 2.5; ctx.stroke();
+    }
+
+    function currentHex() {
+        var rgb = hsvToRgb(_h, _s, 1);
+        return '#' + toHex(rgb.r) + toHex(rgb.g) + toHex(rgb.b);
+    }
+
+    /* ── Painting our controls from state ─────────────────────────── */
+
+    var WHEEL_MODES  = { color: 1, custom: 1 };
+    var WARMTH_MODES = { temperature: 1 };
+
+    function showsWheel()  { return !!WHEEL_MODES[_mode]; }
+    function showsWarmth() { return !!WARMTH_MODES[_mode] || (_mode === 'custom' && _hasTemp); }
+
+    function render() {
+        if (!_panel) return;
+
+        _panel.querySelectorAll('.ng-ip-tab').forEach(function (t) {
+            t.classList.toggle('ng-rgbw-tab--active', t.getAttribute('data-mode') === _mode);
+        });
+
+        toggle(_els.wheelBlock,  showsWheel());
+        toggle(_els.warmthBlock, showsWarmth());
+        toggle(_els.whiteBlock,  _mode === 'custom');
+        toggle(_els.whiteNote,   _mode === 'white');
+        toggle(_els.recentSlot,  showsWheel());
+
+        if (showsWheel() && _els.wheel)   drawWheel(_els.wheel);
+        if (showsWarmth() && _els.warmth) drawWarmth(_els.warmth);
+        if (_els.whiteRange) _els.whiteRange.value = Math.round(_white * 100);
+
+        if (_els.brightRange) _els.brightRange.value = _bright;
+        if (_els.brightNum && document.activeElement !== _els.brightNum) {
+            _els.brightNum.value = _bright;
+        }
+
+        var rgb = showsWheel() ? hsvToRgb(_h, _s, 1) : warmthToRgb(_warmth);
+        if (_els.swatch) _els.swatch.style.background = 'rgb('+rgb.r+','+rgb.g+','+rgb.b+')';
+
+        if (_els.hex) {
+            if (showsWheel()) {
+                _els.hex.readOnly = false;
+                _els.hex.title = 'Type or paste a hex colour';
+                if (document.activeElement !== _els.hex) _els.hex.value = currentHex();
+            } else {
+                /* Colour temperature and plain white have no hex to type. */
+                _els.hex.readOnly = true;
+                _els.hex.title = _mode === 'white'
+                    ? 'This light is in white mode'
+                    : 'Colour temperature — use the warmth bar';
+                _els.hex.value = _mode === 'white' ? 'White'
+                    : (_warmth < 0.3 ? 'Cool white' : _warmth > 0.7 ? 'Warm white' : 'Natural');
+            }
+        }
+    }
+
+    function toggle(el, on) { if (el) el.style.display = on ? '' : 'none'; }
+
+    /* ── Mode switching ───────────────────────────────────────────── */
+
+    /* Domoticz binds the real mode change to its own (now hidden) icon
+       row, so click that rather than duplicate UpdateColorPicker. */
+    var MODE_TRIGGER = {
+        color:       '.pickermodergb',
+        white:       '.pickermodewhite',
+        temperature: '.pickermodetemp'
+    };
+
+    function setMode(id) {
+        if (id === _mode) return;
+        var sel = MODE_TRIGGER[id] ||
+            (_hasTemp ? '.pickermodecustomww' : '.pickermodecustomw');
+        var trigger = _host.querySelector(sel);
+        if (!trigger) return;
+        _mode = id;
+        $$()(trigger).trigger('click');
+        render();
+        /* The tab is the user's decision, so make it real — in the timer and
+           scene editors this stages the value, on the device page it commands
+           the light, which is what clicking "White" is asking for. */
+        commit();
+    }
+
+    /* ── Build ────────────────────────────────────────────────────── */
+
+    /* getLEDType does a bare SubType.indexOf, so an absent subtype throws. */
+    function ledTypeOf(subType) {
+        if (typeof window.getLEDType !== 'function') return null;
+        try { return window.getLEDType(String(subType || '')); } catch (e) { return null; }
+    }
+
+    function supportedModes(subType, dimmerType) {
+        var led = ledTypeOf(subType);
+        if (!led) return [{ id: 'color', label: 'Colour', icon: 'fa-circle-half-stroke' }];
+
+        var out = [];
+        /* Mirrors the rules in Domoticz's own UpdateColorPicker. */
+        if (led.bHasRGB) out.push({ id: 'color', label: 'Colour', icon: 'fa-circle-half-stroke' });
+        if (led.bHasWhite && !led.bHasTemperature && dimmerType !== 'rel') {
+            out.push({ id: 'white', label: 'White', icon: 'fa-lightbulb' });
+        }
+        if (led.bHasTemperature && dimmerType !== 'rel') {
+            out.push({ id: 'temperature', label: 'Warmth', icon: 'fa-sun' });
+        }
+        if (led.bHasCustom) out.push({ id: 'custom', label: 'Mix', icon: 'fa-layer-group' });
+        return out.length ? out : [{ id: 'color', label: 'Colour', icon: 'fa-circle-half-stroke' }];
+    }
+
+    function el(tag, cls, html) {
+        var n = document.createElement(tag);
+        if (cls) n.className = cls;
+        if (html != null) n.innerHTML = html;
+        return n;
+    }
+
+    function buildPanel() {
+        var panel = el('div', 'ng-ip-panel');
+
+        /* Tabs — only worth showing when there is a choice to make */
+        if (_modes.length > 1) {
+            var tabs = el('div', 'ng-rgbw-tabs');
+            _modes.forEach(function (m) {
+                var b = el('button', 'ng-rgbw-tab ng-ip-tab',
+                    '<i class="fa-solid ' + m.icon + '"></i> ' + m.label);
+                b.type = 'button';
+                b.setAttribute('data-mode', m.id);
+                b.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    setMode(this.getAttribute('data-mode'));
+                });
+                tabs.appendChild(b);
+            });
+            panel.appendChild(tabs);
+        }
+
+        /* Wheel */
+        _els.wheelBlock = el('div', 'ng-rgbw-pane ng-ip-block');
+        var wrap = el('div', 'ng-rgbw-wheel-wrap');
+        _els.wheel = document.createElement('canvas');
+        _els.wheel.width = WSIZE; _els.wheel.height = WSIZE;
+        _els.wheel.className = 'ng-ip-wheel';
+        wrap.appendChild(_els.wheel);
+        _els.wheelBlock.appendChild(wrap);
+        panel.appendChild(_els.wheelBlock);
+        attachDrag(_els.wheel, pickWheel);
+
+        /* Recently used colours, shared with every other picker */
+        _els.recentSlot = el('div', 'ng-ip-recent-slot');
+        if (window.ngColors) {
+            _els.recentSlot.appendChild(window.ngColors.buildRow({
+                onPick: function (hex) {
+                    var rgb = parseHex(hex);
+                    if (!rgb) return;
+                    var hsv = rgbToHsv(rgb.r, rgb.g, rgb.b);
+                    _h = hsv.h; _s = hsv.s;
+                    render();
+                    commit();
+                }
+            }));
+        }
+        panel.appendChild(_els.recentSlot);
+
+        /* Warmth bar */
+        _els.warmthBlock = el('div', 'ng-rgbw-pane ng-ip-block');
+        var wWrap = el('div', 'ng-rgbw-warmth-wrap');
+        _els.warmth = document.createElement('canvas');
+        _els.warmth.width = 240; _els.warmth.height = 36;
+        _els.warmth.className = 'ng-ip-warmth';
+        wWrap.appendChild(_els.warmth);
+        _els.warmthBlock.appendChild(wWrap);
+        _els.warmthBlock.appendChild(el('div', 'ng-rgbw-warmth-labels',
+            '<span><i class="fa-solid fa-snowflake"></i> Cool</span>' +
+            '<span>Warm <i class="fa-solid fa-fire"></i></span>'));
+        panel.appendChild(_els.warmthBlock);
+        attachDrag(_els.warmth, pickWarmth);
+
+        /* White amount — only the custom (colour + white mix) mode uses it */
+        _els.whiteBlock = el('div', 'ng-rgbw-slider-row ng-ip-block');
+        _els.whiteBlock.appendChild(el('i', 'fa-regular fa-lightbulb ng-rgbw-icon-dim'));
+        _els.whiteRange = document.createElement('input');
+        _els.whiteRange.type = 'range';
+        _els.whiteRange.className = 'ng-rgbw-slider';
+        _els.whiteRange.min = '0'; _els.whiteRange.max = '100';
+        _els.whiteRange.title = 'White mixed into the colour';
+        _els.whiteRange.addEventListener('input', function () {
+            _white = parseInt(this.value, 10) / 100;
+            render(); commit();
+        });
+        _els.whiteBlock.appendChild(_els.whiteRange);
+        _els.whiteBlock.appendChild(el('i', 'fa-solid fa-lightbulb ng-rgbw-icon-bright'));
+        panel.appendChild(_els.whiteBlock);
+
+        /* Plain-white mode has nothing to configure but brightness */
+        _els.whiteNote = el('div', 'ng-ip-note',
+            '<i class="fa-solid fa-circle-info"></i> ' +
+            'This light is set to plain white. Use the brightness below.');
+        panel.appendChild(_els.whiteNote);
+
+        /* Preview + hex */
+        var preview = el('div', 'ng-rgbw-preview');
+        _els.swatch = el('div', 'ng-rgbw-swatch');
+        _els.hex = document.createElement('input');
+        _els.hex.type = 'text';
+        _els.hex.className = 'ng-rgbw-hex';
+        _els.hex.maxLength = 7;
+        _els.hex.spellcheck = false;
+        _els.hex.placeholder = '#rrggbb';
+        _els.hex.addEventListener('input', function () {
+            if (this.readOnly) return;
+            var rgb = parseHex(this.value);
+            if (!rgb) return;
+            var hsv = rgbToHsv(rgb.r, rgb.g, rgb.b);
+            _h = hsv.h; _s = hsv.s;
+            render(); commit();
+        });
+        _els.hex.addEventListener('blur', function () {
+            if (!this.readOnly) this.value = currentHex();
+        });
+        _els.hex.addEventListener('keydown', function (e) {
+            if (e.key === 'Enter') { e.preventDefault(); this.blur(); }
+        });
+        preview.appendChild(_els.swatch);
+        preview.appendChild(_els.hex);
+        panel.appendChild(preview);
+
+        /* Brightness — slider and a typed percentage, the pair Domoticz's
+           own picker gained. Relative dimmers have no absolute level to set. */
+        if (!_isRel) {
+            var row = el('div', 'ng-rgbw-slider-row');
+            row.appendChild(el('i', 'fa-solid fa-moon ng-rgbw-icon-dim'));
+            _els.brightRange = document.createElement('input');
+            _els.brightRange.type = 'range';
+            _els.brightRange.className = 'ng-rgbw-slider';
+            _els.brightRange.min = '1'; _els.brightRange.max = '100';
+            _els.brightRange.addEventListener('input', function () {
+                _bright = parseInt(this.value, 10) || 1;
+                if (_els.brightNum) _els.brightNum.value = _bright;
+                commit();
+            });
+            row.appendChild(_els.brightRange);
+            row.appendChild(el('i', 'fa-solid fa-sun ng-rgbw-icon-bright'));
+
+            var field = el('span', 'ng-rgbw-bright-field');
+            _els.brightNum = document.createElement('input');
+            _els.brightNum.type = 'text';
+            _els.brightNum.className = 'ng-rgbw-bright-input';
+            _els.brightNum.setAttribute('inputmode', 'numeric');
+            _els.brightNum.maxLength = 3;
+            _els.brightNum.title = 'Brightness %';
+            _els.brightNum.addEventListener('input', function () {
+                /* Typing "10" on the way to "100" must not snap anything. */
+                if (this.value === '') return;
+                var n = parseInt(this.value.replace(/\D/g, ''), 10);
+                if (isNaN(n)) return;
+                _bright = Math.max(1, Math.min(100, n));
+                if (_els.brightRange) _els.brightRange.value = _bright;
+                commit();
+            });
+            _els.brightNum.addEventListener('blur', function () { render(); });
+            _els.brightNum.addEventListener('keydown', function (e) {
+                if (e.key === 'Enter') { e.preventDefault(); this.blur(); }
+            });
+            field.appendChild(_els.brightNum);
+            field.appendChild(el('span', 'ng-rgbw-bright-unit', '%'));
+            row.appendChild(field);
+            panel.appendChild(row);
+        }
+
+        return panel;
+    }
+
+    /* ── Pointer interaction ──────────────────────────────────────── */
+
+    /* The panel is rebuilt whenever Angular re-renders the host, so the
+       document-level drag listeners are registered once for the module and
+       aimed at whichever canvas is currently being dragged. Per-canvas
+       listeners would pile up one set per navigation. */
+    var _drag = null;   /* { canvas, pick } while a drag is in progress */
+
+    function pointOf(e) {
+        return e.touches && e.touches[0] ? e.touches[0] : e;
+    }
+
+    function pickWheel(canvas, e) {
+        var rect = canvas.getBoundingClientRect();
+        var scale = WSIZE / (rect.width || WSIZE);
+        var pt = pointOf(e);
+        var dx = (pt.clientX - rect.left) * scale - WR;
+        var dy = (pt.clientY - rect.top)  * scale - WR;
+        _h = ((Math.atan2(dy, dx) / (2*Math.PI)) + 1) % 1;
+        _s = Math.min(Math.sqrt(dx*dx + dy*dy) / WR, 1);
+        render(); commit();
+    }
+
+    function pickWarmth(canvas, e) {
+        var rect = canvas.getBoundingClientRect();
+        var pt = pointOf(e);
+        _warmth = Math.max(0, Math.min(1, (pt.clientX - rect.left) / rect.width));
+        render(); commit();
+    }
+
+    function startDrag(canvas, pick, e) {
+        _drag = { canvas: canvas, pick: pick };
+        pick(canvas, e);
+    }
+
+    function endDrag() {
+        if (!_drag) return;
+        _drag = null;
+        commitNow();          /* the released value must land, throttle or not */
+    }
+
+    document.addEventListener('mousemove', function (e) {
+        if (_drag) _drag.pick(_drag.canvas, e);
+    });
+    document.addEventListener('mouseup', endDrag);
+    document.addEventListener('touchmove', function (e) {
+        if (_drag) { _drag.pick(_drag.canvas, e); e.preventDefault(); }
+    }, { passive: false });
+    document.addEventListener('touchend', endDrag);
+    document.addEventListener('touchcancel', endDrag);
+
+    function attachDrag(canvas, pick) {
+        canvas.addEventListener('mousedown', function (e) { startDrag(canvas, pick, e); });
+        canvas.addEventListener('touchstart', function (e) {
+            e.preventDefault();
+            startDrag(canvas, pick, e);
+        }, { passive: false });
+    }
+
+    /* ── Mount ────────────────────────────────────────────────────── */
+
+    function mount(selector, subType, dimmerType) {
+        var host = document.querySelector(selector);
+        if (!host) return;
+        var engine = host.querySelector('#popup_picker');
+        if (!engine || !$$()) return;
+
+        var led = ledTypeOf(subType);
+        _hasTemp = !!(led && led.bHasTemperature);
+        _isRel = (dimmerType === 'rel');
+
+        var modes = supportedModes(subType, dimmerType);
+        /* Which tabs and controls the panel needs. The scenes page keeps one
+           #popup_picker and re-points it at whichever device you select, so an
+           RGBWW light followed by an RGB one must not keep the Warmth tab. */
+        var sig = modes.map(function (m) { return m.id; }).join(',') + '|' + _isRel;
+
+        /* Re-entry: ShowRGBWPicker runs again on every model change. Same
+           engine, same shape — just re-read it and repaint. */
+        if (engine === _engine && _panel && _panel.parentNode && sig === _sig) {
+            _host = host;
+            _modes = modes;
+            syncFromEngine();
+            render();
+            return;
+        }
+
+        /* The picker markup exists in three shapes: #rgbw-picker is itself the
+           table (device edit, timers), the scenes page wraps a table.colorpicker
+           in a <tr>, and the popup is a plain div. Anchor on the table that
+           actually holds the widget so the panel lands somewhere legal in all
+           of them — a <tr> host cannot take another <tr>. */
+        var table = engine.closest ? engine.closest('table') : null;
+        var anchor = table || engine;
+        if (!anchor.parentNode) return;
+
+        if (_panel && _panel.parentNode) _panel.parentNode.removeChild(_panel);
+
+        _host = host;
+        _engine = engine;
+        _els = {};
+        _modes = modes;
+        _sig = sig;
+
+        /* Park Domoticz's widget off-screen rather than display:none — it
+           stays the engine, and its canvases keep real dimensions. */
+        var cell = engine.parentNode;
+        if (cell && !cell.classList.contains('ng-ip-engine-cell')) {
+            cell.classList.add('ng-ip-engine-cell');
+            var sink = el('div', 'ng-ip-engine');
+            while (cell.firstChild) sink.appendChild(cell.firstChild);
+            cell.appendChild(sink);
+        }
+
+        (table || host).classList.add('ng-ip-host');
+
+        _panel = buildPanel();
+        anchor.parentNode.insertBefore(_panel, anchor);
+
+        syncFromEngine();
+        render();
+    }
+
+    /* ── Hook ─────────────────────────────────────────────────────── */
+
+    function hook() {
+        if (typeof window.ShowRGBWPicker !== 'function') { setTimeout(hook, 300); return; }
+        if (window.ShowRGBWPicker._ngHooked) return;
+
+        var orig = window.ShowRGBWPicker;
+        window.ShowRGBWPicker = function (selector, idx, Protected, MaxDimLevel,
+                                          LevelInt, colorJSON, iSubType, iDimmerType) {
+            orig.apply(this, arguments);
+            /* The device-card popup has its own full rewrite in popups.js. */
+            if (selector === '#rgbw_popup') return;
+            try {
+                mount(selector, iSubType, iDimmerType);
+            } catch (e) {
+                if (window.ngLog) window.ngLog('[ng-picker]', 'mount failed', e);
+            }
+        };
+        window.ShowRGBWPicker._ngHooked = true;
+    }
+
+    hook();
+}());

--- a/src/js/popups.js
+++ b/src/js/popups.js
@@ -568,14 +568,25 @@
                 rgb = hsvToRgb(_h, _s, 1);
                 if (swatch) swatch.style.background =
                     'rgb('+rgb.r+','+rgb.g+','+rgb.b+')';
-                if (hexEl) hexEl.textContent =
-                    '#'+toHex(rgb.r)+toHex(rgb.g)+toHex(rgb.b);
+                if (hexEl) {
+                    hexEl.readOnly = false;
+                    hexEl.title = 'Type or paste a hex colour';
+                    /* Leave the field alone while it is being typed into —
+                       rewriting it would jump the caret mid-edit. */
+                    if (document.activeElement !== hexEl) hexEl.value = currentHex();
+                }
             } else {
                 rgb = warmthToRgb(_warmth);
                 if (swatch) swatch.style.background =
                     'rgb('+rgb.r+','+rgb.g+','+rgb.b+')';
-                if (hexEl) hexEl.textContent =
-                    _warmth < 0.3 ? 'Cool white' : _warmth > 0.7 ? 'Warm white' : 'Natural';
+                /* White mode has no hex to type: the warmth bar is a colour
+                   temperature, not an RGB value. Show what it is instead. */
+                if (hexEl) {
+                    hexEl.readOnly = true;
+                    hexEl.title = 'Colour temperature — use the warmth bar';
+                    hexEl.value =
+                        _warmth < 0.3 ? 'Cool white' : _warmth > 0.7 ? 'Warm white' : 'Natural';
+                }
             }
         }
 
@@ -584,13 +595,41 @@
             return '#' + toHex(rgb.r) + toHex(rgb.g) + toHex(rgb.b);
         }
 
+        /* Local rather than borrowed from ngColors so the popup keeps working
+           if that module ever fails to load. */
+        function parseHex(v) {
+            var hex = String(v == null ? '' : v).trim().replace(/^#/, '');
+            if (hex.length === 3) hex = hex[0]+hex[0]+hex[1]+hex[1]+hex[2]+hex[2];
+            if (!/^[0-9a-f]{6}$/i.test(hex)) return null;
+            var n = parseInt(hex, 16);
+            return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+        }
+
+        /* Load an RGB colour into the wheel without touching the hex field. */
+        function applyRgb(rgb) {
+            var hsv = rgbToHsv(rgb.r, rgb.g, rgb.b);
+            _h = hsv.h; _s = hsv.s;
+            var wc = document.getElementById('ng-rgbw-canvas');
+            if (wc) renderWheel(wc);
+            updatePreview();
+        }
+
+        function setBrightness(pct, skipSlider, skipField) {
+            _bright = Math.max(1, Math.min(100, Math.round(pct) || 1));
+            var slider = document.getElementById('ng-rgbw-bright');
+            var field  = document.getElementById('ng-rgbw-bright-num');
+            if (slider && !skipSlider) slider.value = _bright;
+            if (field && !skipField)   field.value  = _bright;
+        }
+
         /* ── Recently used colours ───────────────────────────────────── */
         /* Shared with the settings panel, the icon-override editor and the
            bar-range dialog, so a colour dialled in on one light is one click
-           away on the next. Hues only — the strip means nothing on the
-           white-temperature side, which is why WW/CW devices don't get it.
-           Picking loads the colour into the wheel; "Set Colour" still sends
-           it, exactly like dragging the wheel does. */
+           away on the next. The strip lives inside the colour pane: these are
+           hues, and they mean nothing on the white-temperature side (which is
+           also why WW/CW-only devices never get one). Picking loads the colour
+           into the wheel; "Set Colour" still sends it, exactly as dragging the
+           wheel does. */
         function mountRecentRow() {
             if (!window.ngColors) return;
             var slot = p.querySelector('.ng-rgbw-recent-slot');
@@ -603,7 +642,6 @@
                                        parseInt(n.slice(3, 5), 16),
                                        parseInt(n.slice(5, 7), 16));
                     _h = hsv.h; _s = hsv.s;
-                    if (_mode !== 'color') window.ngRgbwSetMode('color');
                     var wc = document.getElementById('ng-rgbw-canvas');
                     if (wc) renderWheel(wc);
                     updatePreview();
@@ -623,11 +661,18 @@
                    '</div>';
         }
 
+        /* Brightness reads and writes two ways, matching what Domoticz's own
+           picker gained: drag the slider, or type the percentage. */
         function brightnessRowHTML() {
             return '<div class="ng-rgbw-slider-row">' +
                    '  <i class="fa-solid fa-moon ng-rgbw-icon-dim"></i>' +
                    '  <input type="range" class="ng-rgbw-slider" id="ng-rgbw-bright" min="1" max="100" value="100">' +
                    '  <i class="fa-solid fa-sun ng-rgbw-icon-bright"></i>' +
+                   '  <span class="ng-rgbw-bright-field">' +
+                   '    <input type="text" inputmode="numeric" id="ng-rgbw-bright-num"' +
+                   '           class="ng-rgbw-bright-input" maxlength="3" title="Brightness %">' +
+                   '    <span class="ng-rgbw-bright-unit">%</span>' +
+                   '  </span>' +
                    '</div>';
         }
 
@@ -665,7 +710,7 @@
                     '<div class="ng-rgbw-pane">' + warmthPaneHTML('ng-rgbw-warmth-canvas') + '</div>' +
                     '<div class="ng-rgbw-preview">' +
                     '  <div class="ng-rgbw-swatch"></div>' +
-                    '  <span class="ng-rgbw-hex">Natural</span>' +
+                    '  <input type="text" class="ng-rgbw-hex" maxlength="7" spellcheck="false" readonly>' +
                     '</div>' +
                     brightnessRowHTML() +
                     presetsHTML(false) +
@@ -692,12 +737,15 @@
                     '    <i class="fa-solid fa-sun"></i> White</button>' +
                     '</div>' : '') +
 
-                    // Colour wheel pane
+                    // Colour wheel pane — the recent strip belongs in here, not
+                    // above both panes: offering a green swatch while the White
+                    // tab is showing is a question with no sensible answer.
                     '<div class="ng-rgbw-pane" id="ng-rgbw-pane-color"' + (!colorModeActive ? ' style="display:none"' : '') + '>' +
                     '  <div class="ng-rgbw-wheel-wrap">' +
                     '    <canvas id="ng-rgbw-canvas" width="' + WSIZE + '" height="' + WSIZE + '"' +
                     '      style="border-radius:50%;touch-action:none;cursor:crosshair;display:block"></canvas>' +
                     '  </div>' +
+                    '  <div class="ng-rgbw-recent-slot"></div>' +
                     '</div>' +
 
                     // White temperature pane (only for RGBW/RGBWW)
@@ -708,9 +756,8 @@
 
                     '<div class="ng-rgbw-preview">' +
                     '  <div class="ng-rgbw-swatch"></div>' +
-                    '  <span class="ng-rgbw-hex">#ffffff</span>' +
+                    '  <input type="text" class="ng-rgbw-hex" placeholder="#rrggbb" maxlength="7" spellcheck="false">' +
                     '</div>' +
-                    '<div class="ng-rgbw-recent-slot"></div>' +
                     brightnessRowHTML() +
                     presetsHTML(true) +
                     '<button class="ng-sp-set-btn" onclick="ngRgbwApply()">' +
@@ -729,12 +776,43 @@
                 }
             }
 
-            // Bind brightness slider
+            // Bind brightness slider + the percentage field beside it
             var bright = document.getElementById('ng-rgbw-bright');
             if (bright) {
-                bright.value = _bright;
                 bright.addEventListener('input', function () {
-                    _bright = parseInt(this.value, 10);
+                    setBrightness(parseInt(this.value, 10), true, false);
+                });
+            }
+            var brightNum = document.getElementById('ng-rgbw-bright-num');
+            if (brightNum) {
+                brightNum.addEventListener('input', function () {
+                    /* Typing "10" on the way to "100" must not snap the slider
+                       away, so an empty or half-typed field is left alone. */
+                    if (this.value === '') return;
+                    setBrightness(parseInt(this.value.replace(/\D/g, ''), 10), false, true);
+                });
+                /* Settle the field on the way out: clamp, strip junk, restore
+                   a value if it was emptied. */
+                brightNum.addEventListener('blur', function () { setBrightness(_bright); });
+                brightNum.addEventListener('keydown', function (e) {
+                    if (e.key === 'Enter') { this.blur(); ngRgbwApply(); }
+                });
+            }
+            setBrightness(_bright);
+
+            // Hex field — type or paste a colour instead of hunting the wheel
+            var hexEl = p.querySelector('.ng-rgbw-hex');
+            if (hexEl) {
+                hexEl.addEventListener('input', function () {
+                    if (this.readOnly) return;
+                    var rgb = parseHex(this.value);
+                    if (rgb) applyRgb(rgb);
+                });
+                hexEl.addEventListener('blur', function () {
+                    if (!this.readOnly) this.value = currentHex();
+                });
+                hexEl.addEventListener('keydown', function (e) {
+                    if (e.key === 'Enter') { this.blur(); ngRgbwApply(); }
                 });
             }
 
@@ -870,27 +948,25 @@
                 // Full brightness — white/neutral for WW, near-white for RGB
                 var isWW = (_subType === 'WW' || _subType === 'CW');
                 if (isWW || _isRGBW) {
-                    _mode = 'white'; _warmth = 0.5; _bright = 100;
+                    _mode = 'white'; _warmth = 0.5;
                     if (_isRGBW) window.ngRgbwSetMode('white');
                     var wtc = document.getElementById('ng-rgbw-warmth-canvas');
                     if (wtc) { drawWarmthBar(wtc); }
                 } else {
-                    _h = 0.15; _s = 0.05; _bright = 100;
+                    _h = 0.15; _s = 0.05;
                     var wc2 = document.getElementById('ng-rgbw-canvas');
                     if (wc2) renderWheel(wc2);
                 }
-                var bs = document.getElementById('ng-rgbw-bright');
-                if (bs) bs.value = 100;
+                setBrightness(100);
                 updatePreview();
                 sendRGBW();
                 flashBtn(btn, 'Applied');
             } else if (preset === 'night') {
                 // Warm amber dim
-                _mode = 'color'; _h = 0.08; _s = 0.85; _bright = 15;
+                _mode = 'color'; _h = 0.08; _s = 0.85;
                 var wc3 = document.getElementById('ng-rgbw-canvas');
                 if (wc3) renderWheel(wc3);
-                var bs2 = document.getElementById('ng-rgbw-bright');
-                if (bs2) bs2.value = 15;
+                setBrightness(15);
                 if (_isRGBW) window.ngRgbwSetMode('color');
                 updatePreview();
                 sendRGBW();

--- a/src/js/popups.js
+++ b/src/js/popups.js
@@ -579,6 +579,38 @@
             }
         }
 
+        function currentHex() {
+            var rgb = hsvToRgb(_h, _s, 1);
+            return '#' + toHex(rgb.r) + toHex(rgb.g) + toHex(rgb.b);
+        }
+
+        /* ── Recently used colours ───────────────────────────────────── */
+        /* Shared with the settings panel, the icon-override editor and the
+           bar-range dialog, so a colour dialled in on one light is one click
+           away on the next. Hues only — the strip means nothing on the
+           white-temperature side, which is why WW/CW devices don't get it.
+           Picking loads the colour into the wheel; "Set Colour" still sends
+           it, exactly like dragging the wheel does. */
+        function mountRecentRow() {
+            if (!window.ngColors) return;
+            var slot = p.querySelector('.ng-rgbw-recent-slot');
+            if (!slot) return;
+            slot.appendChild(window.ngColors.buildRow({
+                onPick: function (hex) {
+                    var n = window.ngColors.normalize(hex);
+                    if (!n) return;
+                    var hsv = rgbToHsv(parseInt(n.slice(1, 3), 16),
+                                       parseInt(n.slice(3, 5), 16),
+                                       parseInt(n.slice(5, 7), 16));
+                    _h = hsv.h; _s = hsv.s;
+                    if (_mode !== 'color') window.ngRgbwSetMode('color');
+                    var wc = document.getElementById('ng-rgbw-canvas');
+                    if (wc) renderWheel(wc);
+                    updatePreview();
+                }
+            }));
+        }
+
         /* ── Warmth bar snippet (reused in both WW-only and RGBW white tab) ── */
         function warmthPaneHTML(canvasId) {
             return '<div class="ng-rgbw-warmth-wrap">' +
@@ -678,10 +710,13 @@
                     '  <div class="ng-rgbw-swatch"></div>' +
                     '  <span class="ng-rgbw-hex">#ffffff</span>' +
                     '</div>' +
+                    '<div class="ng-rgbw-recent-slot"></div>' +
                     brightnessRowHTML() +
                     presetsHTML(true) +
                     '<button class="ng-sp-set-btn" onclick="ngRgbwApply()">' +
                     '  <i class="fa-solid fa-check"></i> Set Colour</button>';
+
+                mountRecentRow();
 
                 // Draw colour wheel
                 var wc = document.getElementById('ng-rgbw-canvas');
@@ -807,6 +842,9 @@
                 // m=3: ColorModeRGB — valid fields: r, g, b
                 var rgb = hsvToRgb(_h, _s, 1);
                 colorObj = { m:3, t:0, r:rgb.r, g:rgb.g, b:rgb.b, cw:0, ww:0 };
+                /* A colour the user actually sent to a light is worth offering
+                   again — a colour merely hovered over on the wheel is not. */
+                if (window.ngColors) window.ngColors.remember(currentHex());
             } else {
                 // m=2: ColorModeTemp — valid field: t (0=cool 6500K, 255=warm 2700K)
                 var t = Math.round(_warmth * 255);

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -3225,6 +3225,19 @@
                 popover.appendChild(svCanvas);
                 popover.appendChild(hueCanvas);
                 popover.appendChild(presetsEl);
+
+                /* Recently used colours — the same strip the settings panel,
+                   the device colour popup and the bar-range dialog feed. */
+                if (window.ngColors) {
+                    popover.appendChild(window.ngColors.buildRow({
+                        onPick: function (hex) {
+                            hsv = hexToHsv(hex);
+                            updateFromHsv();
+                            window.ngColors.remember(hex);
+                        }
+                    }));
+                }
+
                 pickerWrap.appendChild(swatch);
                 pickerWrap.appendChild(hexInput);
                 pickerWrap.appendChild(popover);
@@ -3233,6 +3246,10 @@
                 var hsv = hexToHsv(initialColor);
                 drawSV(svCanvas, hsv.h);
                 drawHueBar(hueCanvas);
+
+                function rememberCurrent() {
+                    if (window.ngColors) window.ngColors.remember(hexInput.value);
+                }
 
                 function updateFromHsv() {
                     var hex = hsvToHex(hsv.h, hsv.s, hsv.v);
@@ -3249,7 +3266,7 @@
                 function closeOtherPopovers() {
                     var dialog = wrap.closest('.ng-ov-dialog') || document.body;
                     dialog.querySelectorAll('.ng-color-wrap .ng-cp-popover').forEach(function (p) {
-                        if (p !== popover) p.style.display = 'none';
+                        if (p !== popover) closeAllPopovers(p.parentNode);
                     });
                 }
 
@@ -3257,14 +3274,19 @@
                     e.stopPropagation();
                     var open = popover.style.display === 'block';
                     closeOtherPopovers();
-                    if (!open) {
+                    if (open) {
+                        closeAllPopovers(pickerWrap);
+                    } else {
                         popover.style.display = 'block';
                         var rect = swatch.getBoundingClientRect();
                         var popW = 260;
                         var left = rect.right - popW;
                         var top  = rect.bottom + 8;
+                        /* Measured, not assumed: the recent-colour strip only
+                           appears once something has been picked. */
+                        var popH = popover.offsetHeight || 300;
                         if (left < 8) left = 8;
-                        if (top + 300 > window.innerHeight) top = rect.top - 308;
+                        if (top + popH + 8 > window.innerHeight) top = Math.max(8, rect.top - popH - 8);
                         popover.style.left = left + 'px';
                         popover.style.top  = top  + 'px';
                         drawSV(svCanvas, hsv.h);
@@ -3283,7 +3305,9 @@
                     svDragging = true; svCanvas.setPointerCapture(e.pointerId); handleSV(e);
                 });
                 svCanvas.addEventListener('pointermove', function (e) { if (svDragging) handleSV(e); });
-                svCanvas.addEventListener('pointerup',   function ()  { svDragging = false; });
+                svCanvas.addEventListener('pointerup',   function ()  {
+                    if (svDragging) { svDragging = false; rememberCurrent(); }
+                });
 
                 function handleHue(e) {
                     var rect = hueCanvas.getBoundingClientRect();
@@ -3295,7 +3319,9 @@
                     hueDragging = true; hueCanvas.setPointerCapture(e.pointerId); handleHue(e);
                 });
                 hueCanvas.addEventListener('pointermove', function (e) { if (hueDragging) handleHue(e); });
-                hueCanvas.addEventListener('pointerup',   function ()  { hueDragging = false; });
+                hueCanvas.addEventListener('pointerup',   function ()  {
+                    if (hueDragging) { hueDragging = false; rememberCurrent(); }
+                });
 
                 hexInput.addEventListener('input', function () {
                     var v = this.value.trim();
@@ -3304,6 +3330,8 @@
                 hexInput.addEventListener('blur', function () {
                     if (!/^#[0-9a-fA-F]{6}$/.test(this.value)) {
                         this.value = hsvToHex(hsv.h, hsv.s, hsv.v);
+                    } else {
+                        rememberCurrent();
                     }
                 });
                 hexInput.addEventListener('keydown', function (e) {
@@ -3315,6 +3343,7 @@
                         e.stopPropagation();
                         hsv = hexToHsv(this.getAttribute('data-color'));
                         updateFromHsv();
+                        rememberCurrent();
                     });
                 });
 
@@ -3885,7 +3914,7 @@
             if (e.target === overlay) { close(); return; }
             /* Close any open HSV color-picker popovers when clicking outside them */
             if (!e.target.closest('.ng-color-wrap')) {
-                overlay.querySelectorAll('.ng-cp-popover').forEach(function (p) { p.style.display = 'none'; });
+                closeAllPopovers(overlay);
             }
         });
         overlay.addEventListener('keydown', function (e) {
@@ -4328,6 +4357,23 @@
 
             var hsv = hexToHsv(hexInput.value || '#4e9af1');
 
+            /* Recently used colours, shared with every other picker in the
+               theme. Recorded on commit points only — a drag would otherwise
+               fill the whole strip with one gradient. */
+            if (window.ngColors) {
+                popover.appendChild(window.ngColors.buildRow({
+                    onPick: function (hex) {
+                        hsv = hexToHsv(hex);
+                        updateFromHsv(true);
+                        window.ngColors.remember(hex);
+                    }
+                }));
+            }
+
+            function rememberCurrent() {
+                if (window.ngColors) window.ngColors.remember(hexInput.value);
+            }
+
             function updateFromHsv(commit) {
                 var hex = hsvToHex(hsv.h, hsv.s, hsv.v);
                 swatch.style.background = hex;
@@ -4357,9 +4403,11 @@
                     var popW = 260; // matches CSS width
                     var left = rect.right - popW;
                     var top = rect.bottom + 8;
-                    // Keep within viewport
+                    // Keep within viewport — measure rather than assume a
+                    // height, the recent-colour strip makes it vary
+                    var popH = popover.offsetHeight || 300;
                     if (left < 8) left = 8;
-                    if (top + 300 > window.innerHeight) top = rect.top - 308;
+                    if (top + popH + 8 > window.innerHeight) top = Math.max(8, rect.top - popH - 8);
                     popover.style.left = left + 'px';
                     popover.style.top = top + 'px';
                     drawSV(svCanvas, hsv.h);
@@ -4385,7 +4433,9 @@
             svCanvas.addEventListener('pointermove', function (e) {
                 if (svDragging) handleSV(e);
             });
-            svCanvas.addEventListener('pointerup', function () { svDragging = false; });
+            svCanvas.addEventListener('pointerup', function () {
+                if (svDragging) { svDragging = false; rememberCurrent(); }
+            });
 
             // Hue bar interaction
             function handleHue(e) {
@@ -4402,7 +4452,9 @@
             hueCanvas.addEventListener('pointermove', function (e) {
                 if (hueDragging) handleHue(e);
             });
-            hueCanvas.addEventListener('pointerup', function () { hueDragging = false; });
+            hueCanvas.addEventListener('pointerup', function () {
+                if (hueDragging) { hueDragging = false; rememberCurrent(); }
+            });
 
             // Hex input
             hexInput.addEventListener('input', function () {
@@ -4416,6 +4468,8 @@
                 var v = this.value.trim();
                 if (!/^#[0-9a-fA-F]{6}$/.test(v)) {
                     this.value = hsvToHex(hsv.h, hsv.s, hsv.v);
+                } else {
+                    rememberCurrent();
                 }
             });
             hexInput.addEventListener('keydown', function (e) {
@@ -4429,6 +4483,7 @@
                     var c = this.getAttribute('data-color');
                     hsv = hexToHsv(c);
                     updateFromHsv(true);
+                    rememberCurrent();
                 });
             });
         });
@@ -4443,6 +4498,12 @@
 
     function closeAllPopovers(container) {
         container.querySelectorAll('.ng-cp-popover').forEach(function (p) {
+            /* Whatever a picker was left showing is what the user settled on,
+               so that is the colour worth remembering. */
+            if (p.style.display === 'block' && window.ngColors) {
+                var hexEl = p.parentNode && p.parentNode.querySelector('.ng-cp-hex');
+                if (hexEl) window.ngColors.remember(hexEl.value);
+            }
             p.style.display = 'none';
         });
     }


### PR DESCRIPTION
This pull request introduces a unified "recently used colors" feature to the theme, enhancing the color picking experience across all relevant UI areas. It also improves the styling and usability of color pickers, including both custom and fallback widgets, and refines the layout and accessibility of color-related controls.

**Recently Used Colors Feature:**
- Added a shared, browser-local "recently used colors" list that is accessible from every color picker in the theme (settings panel, per-device icon override, RGB/RGBWW popup, and Domoticz color fields). This allows users to quickly reuse colors without copying hex codes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R131-R135) [[2]](diffhunk://#diff-8a5e94f44ed88aaaf6bdf0cf795df6e090fa78dfd1c4592cd2a241fa33edb31eR1-R152)
- Introduced new module `src/js/colors.js` providing the color kit and swatch row builder, and ensured it is loaded in `custom.js`.

**UI/UX and Styling Improvements:**
- Implemented consistent, theme-aware styling for the "recently used colors" swatch strip, with context-sensitive adjustments for various dialogs and popups. [[1]](diffhunk://#diff-c13048cd243dd079e45c3089a3fba34d812cd58abd436460bb4a8901188ade2aR1855-R1929) [[2]](diffhunk://#diff-c13048cd243dd079e45c3089a3fba34d812cd58abd436460bb4a8901188ade2aR1945-R1947)
- Improved the editable hex field and brightness slider row in color popups for better usability and appearance, including clear distinction between editable and read-only states. [[1]](diffhunk://#diff-3f35feea933997a59c46220b7103a802a6cfed944fdffe34d4a3424e7d5ccffbR1140-R1223) [[2]](diffhunk://#diff-3f35feea933997a59c46220b7103a802a6cfed944fdffe34d4a3424e7d5ccffbL1135-R1243)
- Added a new in-page color picker panel with custom styling and logic, replacing the default widget where possible and hiding the native color input when replaced. [[1]](diffhunk://#diff-3f35feea933997a59c46220b7103a802a6cfed944fdffe34d4a3424e7d5ccffbR1311-R1412) [[2]](diffhunk://#diff-3f35feea933997a59c46220b7103a802a6cfed944fdffe34d4a3424e7d5ccffbL1495-R1708)
- Ensured reduced motion preferences are respected in the swatch animation.

**Fallback and Compatibility Enhancements:**
- Updated fallback styling for the jQuery Wheel Color Picker widget to apply globally and cover all widget instances, fixing previously missed hosts (such as the scenes page). Also fixed layout issues with slider columns and value fields. [[1]](diffhunk://#diff-3f35feea933997a59c46220b7103a802a6cfed944fdffe34d4a3424e7d5ccffbL425-R458) [[2]](diffhunk://#diff-3f35feea933997a59c46220b7103a802a6cfed944fdffe34d4a3424e7d5ccffbL462-R469) [[3]](diffhunk://#diff-3f35feea933997a59c46220b7103a802a6cfed944fdffe34d4a3424e7d5ccffbR478-R529)

These changes collectively provide a more seamless, accessible, and visually consistent color selection experience throughout the application.