### PR TITLE
Add Kelvin field on the RGBWW pickers

### DIFF
--- a/src/css/modals.css
+++ b/src/css/modals.css
@@ -1140,7 +1140,10 @@ body.dz-light .ng-sp-track {
 /* Editable value field: a hex colour on the wheel tabs, a kelvin number on
    the warmth tab. Only plain-white mode has nothing to type and goes
    read-only. */
-.ng-rgbw-hex {
+/* Qualified for the same reason as the brightness field below: a lone
+   .ng-rgbw-hex is (0,0,1,0) and loses every shared property to the
+   generic input[type="text"] rule in controls.css at (0,0,1,1). */
+.ng-rgbw-preview input.ng-rgbw-hex {
     flex: 1;
     min-width: 0;
     font-size: 0.78rem;
@@ -1154,13 +1157,13 @@ body.dz-light .ng-sp-track {
     transition: border-color 0.15s, box-shadow 0.15s;
 }
 
-.ng-rgbw-hex:focus {
+.ng-rgbw-preview input.ng-rgbw-hex:focus {
     border-color: var(--dz-accent) !important;
     outline: none !important;
     box-shadow: 0 0 0 2px rgba(var(--dz-accent-rgb), 0.18) !important;
 }
 
-.ng-rgbw-hex[readonly] {
+.ng-rgbw-preview input.ng-rgbw-hex[readonly] {
     color: var(--dz-text-muted) !important;
     background: transparent !important;
     border-color: transparent !important;
@@ -1218,8 +1221,15 @@ body.dz-light .ng-sp-track {
 /* Every declaration here has to outrank the theme's own generic
    input[type="text"] rule in controls.css, which is entirely !important —
    without that this field inherits a 0.88rem inherited-family font and
-   6px/12px padding, and stops fitting the row it lives in. */
-.ng-rgbw-bright-input {
+   6px/12px padding, and stops fitting the row it lives in.
+
+   !important alone does not do it: input[type="text"] is (0,0,1,1) and a
+   lone .ng-rgbw-bright-input is (0,0,1,0), so controls.css won every
+   property the two share. Its 12px padding then landed inside our 3ch
+   width — border-box, so the content box collapsed to nothing and the
+   field rendered blank and could not even be clicked into. Qualifying by
+   parent and element takes this to (0,0,2,1), which genuinely wins. */
+.ng-rgbw-bright-field input.ng-rgbw-bright-input {
     /* Wide enough for "100" in the monospace face, and no wider — the row
        has an icon, a slider and another icon to fit alongside it. */
     width: 3ch !important;

--- a/src/css/modals.css
+++ b/src/css/modals.css
@@ -1141,9 +1141,11 @@ body.dz-light .ng-sp-track {
    the warmth tab. Only plain-white mode has nothing to type and goes
    read-only. */
 /* Qualified for the same reason as the brightness field below: a lone
-   .ng-rgbw-hex is (0,0,1,0) and loses every shared property to the
-   generic input[type="text"] rule in controls.css at (0,0,1,1). */
-.ng-rgbw-preview input.ng-rgbw-hex {
+   .ng-rgbw-hex is (0,1,0) and loses every shared property to the generic
+   input[type="text"] rule in controls.css at (0,1,1). This lands at
+   (0,3,1), which also clears .modal input[type="text"] at (0,2,1) — the
+   timer editor mounts the picker inside a modal. */
+.ng-rgbw-preview input[type="text"].ng-rgbw-hex {
     flex: 1;
     min-width: 0;
     font-size: 0.78rem;
@@ -1157,13 +1159,13 @@ body.dz-light .ng-sp-track {
     transition: border-color 0.15s, box-shadow 0.15s;
 }
 
-.ng-rgbw-preview input.ng-rgbw-hex:focus {
+.ng-rgbw-preview input[type="text"].ng-rgbw-hex:focus {
     border-color: var(--dz-accent) !important;
     outline: none !important;
     box-shadow: 0 0 0 2px rgba(var(--dz-accent-rgb), 0.18) !important;
 }
 
-.ng-rgbw-preview input.ng-rgbw-hex[readonly] {
+.ng-rgbw-preview input[type="text"].ng-rgbw-hex[readonly] {
     color: var(--dz-text-muted) !important;
     background: transparent !important;
     border-color: transparent !important;
@@ -1223,13 +1225,17 @@ body.dz-light .ng-sp-track {
    without that this field inherits a 0.88rem inherited-family font and
    6px/12px padding, and stops fitting the row it lives in.
 
-   !important alone does not do it: input[type="text"] is (0,0,1,1) and a
-   lone .ng-rgbw-bright-input is (0,0,1,0), so controls.css won every
+   !important alone does not do it: input[type="text"] is (0,1,1) and a
+   lone .ng-rgbw-bright-input is (0,1,0), so controls.css won every
    property the two share. Its 12px padding then landed inside our 3ch
    width — border-box, so the content box collapsed to nothing and the
-   field rendered blank and could not even be clicked into. Qualifying by
-   parent and element takes this to (0,0,2,1), which genuinely wins. */
-.ng-rgbw-bright-field input.ng-rgbw-bright-input {
+   field rendered blank and could not even be clicked into.
+
+   This lands at (0,3,1), clearing both that rule and .modal
+   input[type="text"] at (0,2,1). It cannot outrank an id, so the
+   page-level rules in pages.css that carry #paramstable exclude these
+   two classes by name instead. */
+.ng-rgbw-bright-field input[type="text"].ng-rgbw-bright-input {
     /* Wide enough for "100" in the monospace face, and no wider — the row
        has an icon, a slider and another icon to fit alongside it. */
     width: 3ch !important;

--- a/src/css/modals.css
+++ b/src/css/modals.css
@@ -1137,8 +1137,9 @@ body.dz-light .ng-sp-track {
     transition: background 0.1s;
 }
 
-/* Editable hex field. Goes read-only in white mode, where the value on show
-   is a colour-temperature name rather than something you can type. */
+/* Editable value field: a hex colour on the wheel tabs, a kelvin number on
+   the warmth tab. Only plain-white mode has nothing to type and goes
+   read-only. */
 .ng-rgbw-hex {
     flex: 1;
     min-width: 0;
@@ -1168,6 +1169,17 @@ body.dz-light .ng-sp-track {
     font-family: inherit;
     letter-spacing: normal;
     padding-left: 0 !important;
+}
+
+/* Kelvin unit for the warmth tab. Kept out of the input so the field holds
+   nothing but the number the user types and reads back. */
+.ng-rgbw-hex-unit {
+    flex: 0 0 auto;
+    font-size: 0.72rem;
+    color: var(--dz-text-muted);
+    /* Pulls back most of the row's 10px gap: the unit should read as part
+       of the field, not as the next item along. */
+    margin-left: -6px;
 }
 
 /* Brightness slider row. Tighter gaps than the other rows: it carries two

--- a/src/css/pages.css
+++ b/src/css/pages.css
@@ -1545,9 +1545,16 @@ a[back-button].btnstyle3 {
         white-space: nowrap;
     }
 
-    .container.js-view table.table-details input[type="text"],
+    /* The colour picker is mounted inside this table on the device edit
+       page, and it brings its own field styling. Left unexcluded, this
+       rule reached into it and won — it carries an id, (1,3,2), which no
+       sane class selector in modals.css can outrank. Its 12px padding
+       then landed inside the brightness field's 3ch width; border-box
+       collapsed the content box to nothing, so the percentage read blank
+       and could not be clicked into at all. */
+    .container.js-view table.table-details input[type="text"]:not(.ng-rgbw-hex):not(.ng-rgbw-bright-input),
     .container.js-view table.table-details textarea,
-    .container.js-view table#paramstable input[type="text"],
+    .container.js-view table#paramstable input[type="text"]:not(.ng-rgbw-hex):not(.ng-rgbw-bright-input),
     .container.js-view table#paramstable textarea {
         background: var(--dz-input-bg) !important;
         color: var(--dz-input-text) !important;
@@ -1596,9 +1603,11 @@ a[back-button].btnstyle3 {
 
 /* Mobile: make form fields full width */
 @media (max-width: 767px) {
-    .container.js-view table.table-details input[type="text"],
+    /* Same picker exclusion as above: a 100%-wide brightness percentage
+       would push the slider out of its row. */
+    .container.js-view table.table-details input[type="text"]:not(.ng-rgbw-hex):not(.ng-rgbw-bright-input),
     .container.js-view table.table-details textarea,
-    .container.js-view table#paramstable input[type="text"],
+    .container.js-view table#paramstable input[type="text"]:not(.ng-rgbw-hex):not(.ng-rgbw-bright-input),
     .container.js-view table#paramstable textarea {
         width: 100% !important;
         max-width: 100% !important;

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -306,6 +306,64 @@
         'SO': 'SE', 'OSO': 'ESE', 'SSO': 'SSE'
     };
 
+    /* The letter O is ambiguous across languages and the two readings are
+       exact opposites: Oost/Ost (East) in Dutch and German, Ouest/Oeste/
+       Ovest (West) in the Romance languages.  Treating every feed as
+       Dutch/German sent French easterlies pointing west (issue #257), so
+       the O-based abbreviations get a second table picked by the
+       Domoticz UI language.                                          */
+    var WIND_ALIASES_O_WEST = {
+        'O': 'W',
+        'NO': 'NW',   'SO': 'SW',
+        'NNO': 'NNW', 'ONO': 'WNW', 'OSO': 'WSW', 'SSO': 'SSW'
+    };
+
+    /* Languages where O = West.  fr Ouest, es/pt/gl Oeste, it Ovest,
+       ca Oest, ro Vest but Nord-Ovest style pairs still use O.       */
+    var O_IS_WEST_LANGS = { fr: 1, es: 1, pt: 1, it: 1, ca: 1, gl: 1, ro: 1 };
+
+    /* Domoticz's language, as a plain ISO 639-1 code.  $.i18n is i18next
+       1.8.0, loaded by Domoticz itself; navigator.language covers the
+       window before it has initialised.                              */
+    function dzLang() {
+        try {
+            var lng = window.jQuery && jQuery.i18n &&
+                      typeof jQuery.i18n.lng === 'function' && jQuery.i18n.lng();
+            if (lng && lng !== 'cimode') return String(lng).toLowerCase().slice(0, 2);
+        } catch (e) { /* i18n not ready */ }
+        return String(navigator.language || '').toLowerCase().slice(0, 2);
+    }
+
+    /* Compass abbreviation (any language) → English abbreviation. */
+    function windDirToEnglish(str) {
+        var s = String(str == null ? '' : str).toUpperCase().replace(/[^A-Z]/g, '');
+        if (!s) return null;
+        if (O_IS_WEST_LANGS[dzLang()] && WIND_ALIASES_O_WEST[s]) {
+            return WIND_ALIASES_O_WEST[s];
+        }
+        return WIND_ALIASES[s] || s;
+    }
+
+    /* Rotation in degrees for a compass abbreviation, or null when the
+       letters resolve to nothing we know. */
+    function windRotationFromStr(str) {
+        var eng = windDirToEnglish(str);
+        var rot = eng ? WIND_ROTATION[eng] : undefined;
+        return (rot === undefined) ? null : rot;
+    }
+
+    /* Rotation for an icon.  device.Direction is the true bearing in
+       degrees and carries no language at all, so prefer it and fall back
+       to the letters only for feeds that publish nothing else.        */
+    function windRotationForIcon(el, dirStr) {
+        var d = getDeviceFromIcon(el);
+        if (d) {
+            var deg = parseFloat(d.Direction);
+            if (!isNaN(deg)) return ((deg % 360) + 360) % 360;
+        }
+        return windRotationFromStr(dirStr);
+    }
+
     /* -- Action-button detector ------------------------------------- */
     /* Returns true when the <img> is an action button (not a toggleable
        state icon).  Action buttons live inside popups/dialogs, in
@@ -705,9 +763,10 @@
         /* Wind direction compass icons */
         var windMatch = /images\/Wind([A-Z]{1,3})\.png/.exec(src);
         if (windMatch) {
-            var windDir = windMatch[1];
-            windDir = WIND_ALIASES[windDir] || windDir;
-            return { type: 'wind', dir: windDir, cls: 'fa-solid fa-arrow-up dz-fa-device dz-wind', color: '#29b6f6' };
+            /* Keep the raw letters: they are only meaningful once the UI
+               language is known, and the device's own bearing in degrees
+               beats them anyway — both are handled at rotation time. */
+            return { type: 'wind', dir: windMatch[1], cls: 'fa-solid fa-arrow-up dz-fa-device dz-wind', color: '#29b6f6' };
         }
         /* Wind0 / wind48 (calm / generic wind) */
         if (src.indexOf('Wind0.png') !== -1 || src.indexOf('wind48.png') !== -1) {
@@ -951,14 +1010,19 @@
            before any further processing so both the PNG fallback (which must
            reference a file that actually exists on the Domoticz server) and the
            FA icon resolution work correctly.
-           e.g. Dutch: WindZ.png → WindS.png, WindNO.png → WindNE.png          */
+           e.g. Dutch: WindZ.png → WindS.png, WindNO.png → WindNE.png
+           The translation depends on the UI language: WindO.png is East in
+           Dutch/German but West in French (issue #257).                    */
         var _windSrcMatch = /Wind([A-Z]{1,3})\.png/.exec(src);
-        if (_windSrcMatch && WIND_ALIASES[_windSrcMatch[1]]) {
-            src = src.replace(
-                'Wind' + _windSrcMatch[1] + '.png',
-                'Wind' + WIND_ALIASES[_windSrcMatch[1]] + '.png'
-            );
-            img.setAttribute('src', src);
+        if (_windSrcMatch) {
+            var _windEng = windDirToEnglish(_windSrcMatch[1]);
+            if (_windEng && _windEng !== _windSrcMatch[1]) {
+                src = src.replace(
+                    'Wind' + _windSrcMatch[1] + '.png',
+                    'Wind' + _windEng + '.png'
+                );
+                img.setAttribute('src', src);
+            }
         }
 
         /* Skip unresolved Angular templates */
@@ -1040,7 +1104,7 @@
         } else if (resolved.type === 'wind') {
             icon.className = resolved.cls;
             if (resolved.color) icon.style.color = resolved.color;
-            var rot = WIND_ROTATION[resolved.dir];
+            var rot = windRotationForIcon(img, resolved.dir);
             if (rot !== null) icon.style.transform = 'rotate(' + rot + 'deg)';
             /* Wind icons never went through the override block above, so they
                carry no IDX tag yet — and Drift is the animation they are most
@@ -1236,9 +1300,8 @@
         } else if (resolved.type === 'wind') {
             icon.className = resolved.cls;
             icon.style.color = resolved.color || '';
-            var rot = WIND_ROTATION[resolved.dir];
-            icon.style.transform = (rot !== undefined && rot !== null)
-                ? 'rotate(' + rot + 'deg)' : '';
+            var rot = windRotationForIcon(img, resolved.dir);
+            icon.style.transform = (rot !== null) ? 'rotate(' + rot + 'deg)' : '';
             applyIconAnim(icon, img.getAttribute('data-dz-dev-idx') || '');
         } else if (resolved.type === 'device') {
             icon.className = resolved.cls;
@@ -1340,7 +1403,7 @@
             } else if (newResolved.type === 'wind') {
                 prevIcon.className = newResolved.cls;
                 prevIcon.style.color = newResolved.color || '';
-                var rot = WIND_ROTATION[newResolved.dir];
+                var rot = windRotationForIcon(rImg, newResolved.dir);
                 prevIcon.style.transform = rot !== null ? 'rotate(' + rot + 'deg)' : '';
                 applyIconAnim(prevIcon, rImg.getAttribute('data-dz-dev-idx') || '');
             } else if (newResolved.type === 'device') {
@@ -2024,10 +2087,7 @@
         if (!device) return null;
         var deg = parseFloat(device.Direction);
         if (!isNaN(deg)) return ((deg % 360) + 360) % 360;
-        var str = String(device.DirectionStr || '').toUpperCase();
-        if (!str) return null;
-        var rot = WIND_ROTATION[WIND_ALIASES[str] || str];
-        return (rot === undefined) ? null : rot;
+        return windRotationFromStr(device.DirectionStr);
     }
 
     function applyNativeWind(glyph) {

--- a/src/js/inline-picker.js
+++ b/src/js/inline-picker.js
@@ -58,6 +58,39 @@
         };
     }
 
+    /* ── Colour temperature ───────────────────────────────────────────
+       Domoticz carries warmth as a bare 0…255 axis with no unit attached,
+       which is impossible to reproduce by hand — the reason scenes and
+       groups could pin an exact colour but not an exact white (issue
+       #258). Kelvin is the unit lamps are sold in and scripts speak, so
+       the field takes that and maps it onto the axis. The range is the
+       usual tunable-white span; Domoticz defines no per-lamp calibration,
+       so it is nominal, and what actually reaches the device is still the
+       same 0…255 value the warmth bar produces. */
+    var K_WARM = 2700;   /* warmth = 1, the far right of the bar */
+    var K_COOL = 6500;   /* warmth = 0, the far left            */
+
+    /* Rounded to 10 K: one step of Domoticz's 256-step axis is ~15 K, so
+       finer digits would only show round-trip noise. */
+    function kelvinFromWarmth(w) {
+        return Math.round((K_COOL + (K_WARM - K_COOL) * w) / 10) * 10;
+    }
+
+    function warmthFromKelvin(k) {
+        return Math.max(0, Math.min(1, (K_COOL - k) / (K_COOL - K_WARM)));
+    }
+
+    /* Accepts "3200", "3200K", "3200 k". Out-of-range and half-typed
+       numbers return null so streaming input never snaps the lamp. */
+    function parseKelvin(v) {
+        var m = /^\s*(\d{3,5})\s*k?\s*$/i.exec(String(v == null ? '' : v));
+        if (!m) return null;
+        var k = parseInt(m[1], 10);
+        return (k < K_WARM || k > K_COOL) ? null : k;
+    }
+
+    function kelvinLabel(w) { return kelvinFromWarmth(w) + ' K'; }
+
     function toHex(n) { return ('0' + n.toString(16)).slice(-2); }
 
     function parseHex(v) {
@@ -256,18 +289,27 @@
         if (_els.swatch) _els.swatch.style.background = 'rgb('+rgb.r+','+rgb.g+','+rgb.b+')';
 
         if (_els.hex) {
+            /* Never overwrite what is being typed mid-keystroke. */
+            var typing = document.activeElement === _els.hex;
             if (showsWheel()) {
                 _els.hex.readOnly = false;
                 _els.hex.title = 'Type or paste a hex colour';
-                if (document.activeElement !== _els.hex) _els.hex.value = currentHex();
+                _els.hex.placeholder = '#rrggbb';
+                if (!typing) _els.hex.value = currentHex();
+            } else if (_mode === 'temperature') {
+                /* Warmth is one axis, not a colour, so it takes kelvin
+                   rather than a hex — same job, right unit. */
+                _els.hex.readOnly = false;
+                _els.hex.title = 'Colour temperature in kelvin (' +
+                                 K_WARM + '–' + K_COOL + ')';
+                _els.hex.placeholder = K_WARM + ' K';
+                if (!typing) _els.hex.value = kelvinLabel(_warmth);
             } else {
-                /* Colour temperature and plain white have no hex to type. */
+                /* Plain white has nothing to type. */
                 _els.hex.readOnly = true;
-                _els.hex.title = _mode === 'white'
-                    ? 'This light is in white mode'
-                    : 'Colour temperature — use the warmth bar';
-                _els.hex.value = _mode === 'white' ? 'White'
-                    : (_warmth < 0.3 ? 'Cool white' : _warmth > 0.7 ? 'Warm white' : 'Natural');
+                _els.hex.title = 'This light is in white mode';
+                _els.hex.placeholder = '';
+                _els.hex.value = 'White';
             }
         }
     }
@@ -458,12 +500,21 @@
         _els.hex.placeholder = '#rrggbb';
         _els.hex.addEventListener('input', function () {
             if (this.readOnly) return;
+            if (_mode === 'temperature') {
+                var k = parseKelvin(this.value);
+                if (k === null) return;
+                _warmth = warmthFromKelvin(k);
+                render(); commit();
+                return;
+            }
             var rgb = parseHex(this.value);
             if (rgb) applyRgb(rgb);
         });
         _els.hex.addEventListener('blur', function () {
             if (this.readOnly) return;
-            this.value = currentHex();
+            /* Re-read from state: a half-typed or out-of-range entry never
+               reached it, so this both normalises and reverts. */
+            this.value = _mode === 'temperature' ? kelvinLabel(_warmth) : currentHex();
             commitNow(true);      /* leaving the field settles what was typed */
         });
         _els.hex.addEventListener('keydown', function (e) {

--- a/src/js/inline-picker.js
+++ b/src/js/inline-picker.js
@@ -89,7 +89,8 @@
         return (k < K_WARM || k > K_COOL) ? null : k;
     }
 
-    function kelvinLabel(w) { return kelvinFromWarmth(w) + ' K'; }
+    /* Bare number: the unit rides beside the field, not inside it. */
+    function kelvinValue(w) { return String(kelvinFromWarmth(w)); }
 
     function toHex(n) { return ('0' + n.toString(16)).slice(-2); }
 
@@ -271,15 +272,12 @@
         if (_els.valueRange) _els.valueRange.value = Math.round(_v * 100);
         if (_els.whiteRange) _els.whiteRange.value = Math.round(_white * 100);
 
-        if (_els.brightRange) _els.brightRange.value = _bright;
-        if (_els.brightNum && document.activeElement !== _els.brightNum) {
-            _els.brightNum.value = _bright;
-        }
+        paintBrightness();
 
         /* Assigning .value raises no input event, so the track fill of each
            slider has to be primed by hand. */
         if (window.ngFillRange) {
-            [_els.valueRange, _els.whiteRange, _els.brightRange]
+            [_els.valueRange, _els.whiteRange]
                 .forEach(function (r) { if (r) window.ngFillRange(r); });
         }
 
@@ -291,19 +289,20 @@
         if (_els.hex) {
             /* Never overwrite what is being typed mid-keystroke. */
             var typing = document.activeElement === _els.hex;
+            var kelvinMode = (_mode === 'temperature');
             if (showsWheel()) {
                 _els.hex.readOnly = false;
                 _els.hex.title = 'Type or paste a hex colour';
                 _els.hex.placeholder = '#rrggbb';
                 if (!typing) _els.hex.value = currentHex();
-            } else if (_mode === 'temperature') {
+            } else if (kelvinMode) {
                 /* Warmth is one axis, not a colour, so it takes kelvin
                    rather than a hex — same job, right unit. */
                 _els.hex.readOnly = false;
                 _els.hex.title = 'Colour temperature in kelvin (' +
                                  K_WARM + '–' + K_COOL + ')';
-                _els.hex.placeholder = K_WARM + ' K';
-                if (!typing) _els.hex.value = kelvinLabel(_warmth);
+                _els.hex.placeholder = String(K_WARM);
+                if (!typing) _els.hex.value = kelvinValue(_warmth);
             } else {
                 /* Plain white has nothing to type. */
                 _els.hex.readOnly = true;
@@ -311,10 +310,44 @@
                 _els.hex.placeholder = '';
                 _els.hex.value = 'White';
             }
+            toggle(_els.hexUnit, kelvinMode);
         }
     }
 
     function toggle(el, on) { if (el) el.style.display = on ? '' : 'none'; }
+
+    /* Both brightness controls, looked up live rather than through _els.
+       The panel outlives neither Angular re-rendering the host nor jQWCP's
+       refreshWidget moving nodes around, and a cached input that is no
+       longer the one on screen takes the value silently — which is how the
+       slider could move while the percentage beside it sat still. The
+       popup has always resolved these by id for the same reason. */
+    function brightEls() {
+        return {
+            slider: document.getElementById('ng-ip-bright'),
+            field:  document.getElementById('ng-ip-bright-num')
+        };
+    }
+
+    /* Write _bright to the controls. skipSlider/skipField leave whichever
+       one the user is currently driving alone, so neither fights the input
+       it came from. */
+    function paintBrightness(skipSlider, skipField) {
+        var b = brightEls();
+        if (b.slider && !skipSlider) b.slider.value = _bright;
+        if (b.field && !skipField && document.activeElement !== b.field) {
+            b.field.value = _bright;
+        }
+        /* Assigning .value raises no input event, so the track fill has to
+           be told. Runs even when the slider was skipped: the value still
+           moved, via the percentage field. */
+        if (b.slider && window.ngFillRange) window.ngFillRange(b.slider);
+    }
+
+    function setBrightness(pct, skipSlider, skipField) {
+        _bright = Math.max(1, Math.min(100, Math.round(pct) || 1));
+        paintBrightness(skipSlider, skipField);
+    }
 
     /* Load a concrete RGB colour (typed hex, recent swatch) into our state.
        In Mix the value axis is a real control, so honour it; elsewhere the
@@ -514,7 +547,7 @@
             if (this.readOnly) return;
             /* Re-read from state: a half-typed or out-of-range entry never
                reached it, so this both normalises and reverts. */
-            this.value = _mode === 'temperature' ? kelvinLabel(_warmth) : currentHex();
+            this.value = _mode === 'temperature' ? kelvinValue(_warmth) : currentHex();
             commitNow(true);      /* leaving the field settles what was typed */
         });
         _els.hex.addEventListener('keydown', function (e) {
@@ -522,6 +555,10 @@
         });
         preview.appendChild(_els.swatch);
         preview.appendChild(_els.hex);
+        /* Unit sits beside the field, not in it, so what is typed and what
+           is read back are the same bare number. */
+        _els.hexUnit = el('span', 'ng-rgbw-hex-unit', 'K');
+        preview.appendChild(_els.hexUnit);
         panel.appendChild(preview);
 
         /* Brightness — slider and a typed percentage, the pair Domoticz's
@@ -532,10 +569,11 @@
             _els.brightRange = document.createElement('input');
             _els.brightRange.type = 'range';
             _els.brightRange.className = 'ng-rgbw-slider';
+            _els.brightRange.id = 'ng-ip-bright';
             _els.brightRange.min = '1'; _els.brightRange.max = '100';
             _els.brightRange.addEventListener('input', function () {
-                _bright = parseInt(this.value, 10) || 1;
-                if (_els.brightNum) _els.brightNum.value = _bright;
+                /* skipSlider: this is the control being dragged. */
+                setBrightness(parseInt(this.value, 10), true, false);
                 commit();
             });
             _els.brightRange.addEventListener('change', function () { commitNow(); });
@@ -546,6 +584,7 @@
             _els.brightNum = document.createElement('input');
             _els.brightNum.type = 'text';
             _els.brightNum.className = 'ng-rgbw-bright-input';
+            _els.brightNum.id = 'ng-ip-bright-num';
             _els.brightNum.setAttribute('inputmode', 'numeric');
             /* An input with no size attribute defaults to 20 characters wide.
                If the stylesheet is stale or outbid, that lone default is
@@ -558,11 +597,16 @@
                 if (this.value === '') return;
                 var n = parseInt(this.value.replace(/\D/g, ''), 10);
                 if (isNaN(n)) return;
-                _bright = Math.max(1, Math.min(100, n));
-                if (_els.brightRange) _els.brightRange.value = _bright;
+                /* skipField: this is the control being typed into. */
+                setBrightness(n, false, true);
                 commit();
             });
-            _els.brightNum.addEventListener('blur', function () { render(); commitNow(); });
+            /* Settle the field on the way out: clamp, strip junk, restore a
+               value if it was emptied. */
+            _els.brightNum.addEventListener('blur', function () {
+                setBrightness(_bright);
+                commitNow();
+            });
             _els.brightNum.addEventListener('keydown', function (e) {
                 if (e.key === 'Enter') { e.preventDefault(); this.blur(); }
             });

--- a/src/js/popups.js
+++ b/src/js/popups.js
@@ -536,6 +536,38 @@
 
         function toHex(n) { return ('0'+n.toString(16)).slice(-2); }
 
+        /* ── Colour temperature ──────────────────────────────────────────
+           The warmth axis is a bare 0…255 with no unit, so a white could
+           be dragged to but never typed — the gap issue #258 reports for
+           WW lights and the White tab. Kelvin is the unit lamps carry, so
+           the field takes that; the endpoints are the ones sendRGBW()
+           already documents for t (0 = cool 6500K, 255 = warm 2700K).
+           Nominal, not per-lamp calibrated: Domoticz defines no such
+           calibration, and what reaches the device is unchanged.       */
+        var K_WARM = 2700;   // warmth = 1
+        var K_COOL = 6500;   // warmth = 0
+
+        /* Rounded to 10 K — one step of the 256-step axis is ~15 K, so
+           finer digits would only show round-trip noise. */
+        function kelvinFromWarmth(w) {
+            return Math.round((K_COOL + (K_WARM - K_COOL) * w) / 10) * 10;
+        }
+
+        function warmthFromKelvin(k) {
+            return Math.max(0, Math.min(1, (K_COOL - k) / (K_COOL - K_WARM)));
+        }
+
+        /* Accepts "3200", "3200K", "3200 k". Out-of-range and half-typed
+           numbers return null so streaming input never snaps the lamp. */
+        function parseKelvin(v) {
+            var m = /^\s*(\d{3,5})\s*k?\s*$/i.exec(String(v == null ? '' : v));
+            if (!m) return null;
+            var k = parseInt(m[1], 10);
+            return (k < K_WARM || k > K_COOL) ? null : k;
+        }
+
+        function kelvinLabel(w) { return kelvinFromWarmth(w) + ' K'; }
+
         /* ── Canvas wheel rendering ──────────────────────────────────── */
         function drawWheel(canvas) {
             var ctx = canvas.getContext('2d');
@@ -587,6 +619,7 @@
                 if (hexEl) {
                     hexEl.readOnly = false;
                     hexEl.title = 'Type or paste a hex colour';
+                    hexEl.placeholder = '#rrggbb';
                     /* Leave the field alone while it is being typed into —
                        rewriting it would jump the caret mid-edit. */
                     if (document.activeElement !== hexEl) hexEl.value = currentHex();
@@ -595,13 +628,17 @@
                 rgb = warmthToRgb(_warmth);
                 if (swatch) swatch.style.background =
                     'rgb('+rgb.r+','+rgb.g+','+rgb.b+')';
-                /* White mode has no hex to type: the warmth bar is a colour
-                   temperature, not an RGB value. Show what it is instead. */
+                /* White mode has no hex: the warmth bar is a colour
+                   temperature, not an RGB value. It takes kelvin instead —
+                   same job as the hex field, right unit. Every path that
+                   reaches white mode has a warmth bar (WW/CW popups, and
+                   the White tab, which only exists for hasWhite). */
                 if (hexEl) {
-                    hexEl.readOnly = true;
-                    hexEl.title = 'Colour temperature — use the warmth bar';
-                    hexEl.value =
-                        _warmth < 0.3 ? 'Cool white' : _warmth > 0.7 ? 'Warm white' : 'Natural';
+                    hexEl.readOnly = false;
+                    hexEl.title = 'Colour temperature in kelvin (' +
+                                  K_WARM + '–' + K_COOL + ')';
+                    hexEl.placeholder = K_WARM + ' K';
+                    if (document.activeElement !== hexEl) hexEl.value = kelvinLabel(_warmth);
                 }
             }
         }
@@ -734,7 +771,7 @@
                     '<div class="ng-rgbw-pane">' + warmthPaneHTML('ng-rgbw-warmth-canvas') + '</div>' +
                     '<div class="ng-rgbw-preview">' +
                     '  <div class="ng-rgbw-swatch"></div>' +
-                    '  <input type="text" class="ng-rgbw-hex" maxlength="7" spellcheck="false" readonly>' +
+                    '  <input type="text" class="ng-rgbw-hex" maxlength="7" spellcheck="false">' +
                     '</div>' +
                     brightnessRowHTML() +
                     presetsHTML(false);
@@ -832,16 +869,30 @@
             }
             setBrightness(_bright);
 
-            // Hex field — type or paste a colour instead of hunting the wheel
+            // Hex field — type or paste a colour instead of hunting the
+            // wheel; in white mode the same field takes a kelvin value so
+            // an exact white can be pinned too (#258).
             var hexEl = p.querySelector('.ng-rgbw-hex');
             if (hexEl) {
                 hexEl.addEventListener('input', function () {
                     if (this.readOnly) return;
+                    if (_mode === 'white') {
+                        var k = parseKelvin(this.value);
+                        if (k === null) return;
+                        _warmth = warmthFromKelvin(k);
+                        var wc = document.getElementById('ng-rgbw-warmth-canvas');
+                        if (wc) drawWarmthBar(wc);
+                        updatePreview(); commit();
+                        return;
+                    }
                     var rgb = parseHex(this.value);
                     if (rgb) { applyRgb(rgb); commit(); }
                 });
                 hexEl.addEventListener('blur', function () {
-                    if (!this.readOnly) this.value = currentHex();
+                    if (this.readOnly) return;
+                    /* Re-read from state: a half-typed or out-of-range entry
+                       never reached it, so this normalises and reverts. */
+                    this.value = _mode === 'white' ? kelvinLabel(_warmth) : currentHex();
                 });
                 hexEl.addEventListener('keydown', function (e) {
                     if (e.key === 'Enter') this.blur();

--- a/src/js/popups.js
+++ b/src/js/popups.js
@@ -566,7 +566,8 @@
             return (k < K_WARM || k > K_COOL) ? null : k;
         }
 
-        function kelvinLabel(w) { return kelvinFromWarmth(w) + ' K'; }
+        /* Bare number: the unit rides beside the field, not inside it. */
+        function kelvinValue(w) { return String(kelvinFromWarmth(w)); }
 
         /* ── Canvas wheel rendering ──────────────────────────────────── */
         function drawWheel(canvas) {
@@ -611,7 +612,11 @@
         function updatePreview() {
             var swatch = p.querySelector('.ng-rgbw-swatch');
             var hexEl  = p.querySelector('.ng-rgbw-hex');
+            var unitEl = p.querySelector('.ng-rgbw-hex-unit');
             var rgb;
+            /* The unit belongs beside the field, not inside it, so what is
+               typed and what is read back are the same bare number. */
+            if (unitEl) unitEl.style.display = _mode === 'white' ? '' : 'none';
             if (_mode === 'color') {
                 rgb = hsvToRgb(_h, _s, 1);
                 if (swatch) swatch.style.background =
@@ -637,8 +642,8 @@
                     hexEl.readOnly = false;
                     hexEl.title = 'Colour temperature in kelvin (' +
                                   K_WARM + '–' + K_COOL + ')';
-                    hexEl.placeholder = K_WARM + ' K';
-                    if (document.activeElement !== hexEl) hexEl.value = kelvinLabel(_warmth);
+                    hexEl.placeholder = String(K_WARM);
+                    if (document.activeElement !== hexEl) hexEl.value = kelvinValue(_warmth);
                 }
             }
         }
@@ -772,6 +777,7 @@
                     '<div class="ng-rgbw-preview">' +
                     '  <div class="ng-rgbw-swatch"></div>' +
                     '  <input type="text" class="ng-rgbw-hex" maxlength="7" spellcheck="false">' +
+                    '  <span class="ng-rgbw-hex-unit">K</span>' +
                     '</div>' +
                     brightnessRowHTML() +
                     presetsHTML(false);
@@ -816,6 +822,7 @@
                     '<div class="ng-rgbw-preview">' +
                     '  <div class="ng-rgbw-swatch"></div>' +
                     '  <input type="text" class="ng-rgbw-hex" placeholder="#rrggbb" maxlength="7" spellcheck="false">' +
+                    '  <span class="ng-rgbw-hex-unit" style="display:none">K</span>' +
                     '</div>' +
                     /* No "Set Colour" button: every control applies as you use
                        it, the way Domoticz's own picker and the Switches-tab
@@ -892,7 +899,7 @@
                     if (this.readOnly) return;
                     /* Re-read from state: a half-typed or out-of-range entry
                        never reached it, so this normalises and reverts. */
-                    this.value = _mode === 'white' ? kelvinLabel(_warmth) : currentHex();
+                    this.value = _mode === 'white' ? kelvinValue(_warmth) : currentHex();
                 });
                 hexEl.addEventListener('keydown', function (e) {
                     if (e.key === 'Enter') this.blur();


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the color picker modal and wind direction icon handling, focusing on UI correctness, internationalization, and user experience. The most significant changes include: enhanced wind direction abbreviation handling for multiple languages, improved Kelvin color temperature input in the color picker, and CSS selector adjustments to ensure correct field styling and interaction.

**Wind direction internationalization and icon handling:**

* Added language-aware mapping for compass abbreviations where "O" means "West" in Romance languages (e.g., French, Spanish, Italian) but "East" in Dutch/German, ensuring correct icon rotation and labeling across UI languages. [[1]](diffhunk://#diff-1964037d423ee82a30f222c2a928458bbc898d8ef3037cf31ed14d5867126517R309-R366) [[2]](diffhunk://#diff-1964037d423ee82a30f222c2a928458bbc898d8ef3037cf31ed14d5867126517L708-R769) [[3]](diffhunk://#diff-1964037d423ee82a30f222c2a928458bbc898d8ef3037cf31ed14d5867126517L954-R1026)
* Refactored wind direction icon rotation logic to use the new language-aware mapping and device bearing when available, fixing incorrect arrow orientation for some languages. [[1]](diffhunk://#diff-1964037d423ee82a30f222c2a928458bbc898d8ef3037cf31ed14d5867126517L1043-R1107) [[2]](diffhunk://#diff-1964037d423ee82a30f222c2a928458bbc898d8ef3037cf31ed14d5867126517L1239-R1304) [[3]](diffhunk://#diff-1964037d423ee82a30f222c2a928458bbc898d8ef3037cf31ed14d5867126517L1343-R1406) [[4]](diffhunk://#diff-1964037d423ee82a30f222c2a928458bbc898d8ef3037cf31ed14d5867126517L2027-R2090)

**Color picker modal improvements:**

* Added support for Kelvin (color temperature) input on the warmth tab, allowing users to type a temperature in Kelvin, which is mapped to the internal 0–255 axis. The unit is displayed beside the field, not inside it, for clarity and ease of use. [[1]](diffhunk://#diff-b07697369386d1d604f0d43faa01827e5479caa7fb737a87b60f520a8df9fb2aR61-R94) [[2]](diffhunk://#diff-b07697369386d1d604f0d43faa01827e5479caa7fb737a87b60f520a8df9fb2aR290-R351) [[3]](diffhunk://#diff-b07697369386d1d604f0d43faa01827e5479caa7fb737a87b60f520a8df9fb2aR536-R561)
* Improved brightness input handling to ensure the slider and percentage field always stay in sync, regardless of UI re-renders or user input focus. [[1]](diffhunk://#diff-b07697369386d1d604f0d43faa01827e5479caa7fb737a87b60f520a8df9fb2aL241-R280) [[2]](diffhunk://#diff-b07697369386d1d604f0d43faa01827e5479caa7fb737a87b60f520a8df9fb2aR290-R351)

**CSS selector and style fixes:**

* Updated CSS selectors for the color picker’s hex and brightness fields to ensure their styles always override generic input rules, preventing layout and usability issues when embedded in modals or tables. [[1]](diffhunk://#diff-3f35feea933997a59c46220b7103a802a6cfed944fdffe34d4a3424e7d5ccffbL1140-R1148) [[2]](diffhunk://#diff-3f35feea933997a59c46220b7103a802a6cfed944fdffe34d4a3424e7d5ccffbL1156-R1168) [[3]](diffhunk://#diff-3f35feea933997a59c46220b7103a802a6cfed944fdffe34d4a3424e7d5ccffbL1209-R1238) [[4]](diffhunk://#diff-3f8163a967e2cafa22c44385d166c00484337961f852e18ab4c33cdb9ffcc7edL1548-R1557) [[5]](diffhunk://#diff-3f8163a967e2cafa22c44385d166c00484337961f852e18ab4c33cdb9ffcc7edL1599-R1610)
* Added a dedicated `.ng-rgbw-hex-unit` class for the Kelvin unit display, visually associating it with the input field.

These changes collectively improve internationalization, input usability, and visual consistency in the color picker and device icon rendering.